### PR TITLE
fix(ci): replace fetch with axios and fix CI/CD pipelines

### DIFF
--- a/.github/workflows/publish-electron.yml
+++ b/.github/workflows/publish-electron.yml
@@ -147,7 +147,6 @@ jobs:
 
       # Python 3.12+ removed distutils; setuptools restores it for node-gyp native builds
       - name: Fix Python distutils (native module builds)
-        if: runner.os == 'Windows'
         run: pip install setuptools
 
       - name: Build Electron app
@@ -161,7 +160,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # tree-sitter 0.21.x binding.gyp forces C++17, but Electron 35 V8 headers require C++20
+          # _CL_ is for MSVC (Windows), CXXFLAGS is for GCC/Clang (Linux/macOS)
           _CL_: ${{ runner.os == 'Windows' && '/std:c++20' || '' }}
+          CXXFLAGS: ${{ runner.os != 'Windows' && '-std=c++20' || '' }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -142,12 +142,17 @@ jobs:
       - name: Publish to VS Code Marketplace
         run: |
           cd dist/apps/ptah-extension-vscode
-          DIST_VERSION=$(node -p "require('./package.json').version")
-          echo "Publishing version: $DIST_VERSION"
+          VSIX_FILE=$(ls *.vsix 2>/dev/null | head -1)
+          if [ -z "$VSIX_FILE" ]; then
+            echo "::error::No .vsix file found in dist"
+            exit 1
+          fi
+          VSIX_SIZE=$(du -h "$VSIX_FILE" | cut -f1)
+          echo "Publishing $VSIX_FILE ($VSIX_SIZE)"
           if [ "${{ github.event.inputs.pre-release }}" = "true" ]; then
-            npx @vscode/vsce publish --pre-release --pat ${{ secrets.VSCE_PAT }}
+            npx @vscode/vsce publish --packagePath "$VSIX_FILE" --pre-release --pat ${{ secrets.VSCE_PAT }}
           else
-            npx @vscode/vsce publish --pat ${{ secrets.VSCE_PAT }}
+            npx @vscode/vsce publish --packagePath "$VSIX_FILE" --pat ${{ secrets.VSCE_PAT }}
           fi
 
       - name: Commit version bump and tag

--- a/apps/ptah-electron/scripts/launch.js
+++ b/apps/ptah-electron/scripts/launch.js
@@ -17,11 +17,16 @@ const mainPath = path.resolve(
   '../../../dist/apps/ptah-electron/main.mjs',
 );
 
+// Support --production flag to test against live API (api.ptah.live)
+const useProd = process.argv.includes('--production');
+const nodeEnv = useProd ? 'production' : 'development';
+
 // Forward any extra args (e.g., workspace path) to the Electron app
-const extraArgs = process.argv.slice(2);
+const extraArgs = process.argv.slice(2).filter((a) => a !== '--production');
 
 console.log('[launch] Starting Electron app...');
 console.log(`[launch] Main: ${mainPath}`);
+console.log(`[launch] NODE_ENV: ${nodeEnv}`);
 if (extraArgs.length) {
   console.log(`[launch] Args: ${extraArgs.join(' ')}`);
 }
@@ -31,7 +36,7 @@ try {
     stdio: 'inherit',
     env: {
       ...process.env,
-      NODE_ENV: 'development',
+      NODE_ENV: nodeEnv,
     },
   });
 } catch (error) {

--- a/apps/ptah-extension-vscode/.vscodeignore
+++ b/apps/ptah-extension-vscode/.vscodeignore
@@ -1,7 +1,5 @@
 # Source files (not in dist)
 src/**
-**/*.ts
-!**/*.js
 **/*.map
 tsconfig*.json
 project.json
@@ -83,11 +81,8 @@ Thumbs.db
 **/node_modules/@anthropic-ai/claude-agent-sdk/vendor/**
 **/node_modules/@anthropic-ai/claude-agent-sdk/cli.js
 **/node_modules/@anthropic-ai/claude-agent-sdk/resvg.wasm
-# @github/copilot: CLI binary + bundled tools (237 MB)
-**/node_modules/@github/copilot/ripgrep/**
-**/node_modules/@github/copilot/prebuilds/**
-**/node_modules/@github/copilot/sharp/**
-**/node_modules/@github/copilot/clipboard/**
+# @github/copilot: entire CLI package (128+ MB) — only copilot-sdk is needed
+**/node_modules/@github/copilot/**
 **/node_modules/@github/copilot-win32-x64/**
 **/node_modules/@github/copilot-linux-x64/**
 **/node_modules/@github/copilot-darwin-arm64/**
@@ -100,3 +95,6 @@ Thumbs.db
 **/node_modules/@openai/codex/**
 # @img/sharp: not needed at runtime
 **/node_modules/@img/**
+# Native module C source files — prebuilt binaries are used at runtime
+**/node_modules/tree-sitter*/src/**
+**/node_modules/tree-sitter/vendor/**

--- a/apps/ptah-extension-vscode/package.json
+++ b/apps/ptah-extension-vscode/package.json
@@ -565,9 +565,6 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.81",
     "@github/copilot-sdk": "^0.1.25",
     "@openai/codex-sdk": "^0.104.0",
-    "axios": "^1.6.0",
-    "reflect-metadata": "^0.2.2",
-    "tsyringe": "^4.10.0",
     "tree-sitter": "^0.21.1",
     "tree-sitter-javascript": "^0.23.1",
     "tree-sitter-typescript": "^0.23.2"

--- a/apps/ptah-extension-vscode/project.json
+++ b/apps/ptah-extension-vscode/project.json
@@ -23,7 +23,7 @@
         "platform": "node",
         "target": "node20",
         "bundle": true,
-        "thirdParty": false,
+        "thirdParty": true,
         "esbuildOptions": {
           "outExtension": {
             ".js": ".mjs"
@@ -37,12 +37,9 @@
           "@anthropic-ai/claude-agent-sdk",
           "@github/copilot-sdk",
           "@openai/codex-sdk",
-          "reflect-metadata",
-          "tsyringe",
           "tree-sitter",
           "tree-sitter-javascript",
-          "tree-sitter-typescript",
-          "axios"
+          "tree-sitter-typescript"
         ],
         "assets": [
           {

--- a/apps/ptah-extension-vscode/src/main.ts
+++ b/apps/ptah-extension-vscode/src/main.ts
@@ -14,6 +14,7 @@ import {
   PluginLoaderService,
   PtahCliRegistry,
   SkillJunctionService,
+  setPtahMcpPort,
   type SettingsExportService,
   type SettingsImportService,
 } from '@ptah-extension/agent-sdk';
@@ -908,16 +909,30 @@ export async function activate(
 
     if (licenseStatus.tier === 'pro' || licenseStatus.tier === 'trial_pro') {
       // PRO USER: Register MCP Server (Pro-only feature)
-      logger.info('Registering premium MCP server (Pro tier user)');
-      const codeExecutionMCP = DIContainer.resolve(TOKENS.CODE_EXECUTION_MCP);
-      const mcpPort = await (
-        codeExecutionMCP as { start: () => Promise<number> }
-      ).start();
-      context.subscriptions.push(codeExecutionMCP as vscode.Disposable);
-      logger.info(`Code Execution MCP Server started on port ${mcpPort}`);
-      console.log(
-        `[Activate] Step 12: Pro MCP Server started (port ${mcpPort})`,
-      );
+      // Non-blocking: MCP server failure should NOT crash the extension
+      try {
+        logger.info('Registering premium MCP server (Pro tier user)');
+        const codeExecutionMCP = DIContainer.resolve(TOKENS.CODE_EXECUTION_MCP);
+        const mcpPort = await (
+          codeExecutionMCP as { start: () => Promise<number> }
+        ).start();
+        context.subscriptions.push(codeExecutionMCP as vscode.Disposable);
+        // Update the runtime port so SDK query builders use the actual port
+        // (may differ from default 51820 if fallback to OS-assigned port)
+        setPtahMcpPort(mcpPort);
+        logger.info(`Code Execution MCP Server started on port ${mcpPort}`);
+        console.log(
+          `[Activate] Step 12: Pro MCP Server started (port ${mcpPort})`,
+        );
+      } catch (mcpError) {
+        logger.warn('MCP server failed to start (non-blocking)', {
+          error:
+            mcpError instanceof Error ? mcpError.message : String(mcpError),
+        });
+        console.log(
+          `[Activate] Step 12: MCP Server failed to start: ${mcpError instanceof Error ? mcpError.message : String(mcpError)}`,
+        );
+      }
     } else {
       // COMMUNITY USER: Skip MCP Server (Pro-only feature)
       logger.info('Skipping MCP server (Community tier - Pro feature only)', {

--- a/libs/backend/agent-sdk/src/index.ts
+++ b/libs/backend/agent-sdk/src/index.ts
@@ -270,5 +270,10 @@ export type {
   StreamProcessorResult,
 } from './lib/stream-processing';
 
+// ============================================================
+// MCP Port Management
+// ============================================================
+export { setPtahMcpPort } from './lib/constants';
+
 // Library version
 export const AGENT_SDK_VERSION = '0.0.1';

--- a/libs/backend/agent-sdk/src/lib/constants.ts
+++ b/libs/backend/agent-sdk/src/lib/constants.ts
@@ -8,6 +8,27 @@
 /**
  * Default port for Ptah HTTP MCP server.
  * Used by SdkQueryOptionsBuilder, PtahCliAdapter, and InternalQueryService.
- * Matches the port configured in vscode-lm-tools/CodeExecutionMCP.
+ * Matches the default port configured in vscode-lm-tools/CodeExecutionMCP.
  */
-export const PTAH_MCP_PORT = 51820;
+export const PTAH_MCP_DEFAULT_PORT = 51820;
+
+/**
+ * Actual runtime port for the Ptah HTTP MCP server.
+ *
+ * Starts as the default (51820). Updated by main.ts after the MCP server
+ * starts — it may differ from the default when the configured port is
+ * unavailable (EACCES on Windows Hyper-V, EADDRINUSE) and the server
+ * falls back to an OS-assigned port.
+ *
+ * All consumers (SdkQueryOptionsBuilder, PtahCliAdapter, InternalQueryService)
+ * read this at query time, so they always get the actual running port.
+ */
+export let PTAH_MCP_PORT = PTAH_MCP_DEFAULT_PORT;
+
+/**
+ * Update the runtime MCP port. Called once from main.ts after the MCP
+ * server successfully starts.
+ */
+export function setPtahMcpPort(port: number): void {
+  PTAH_MCP_PORT = port;
+}

--- a/libs/backend/vscode-core/src/services/license.service.ts
+++ b/libs/backend/vscode-core/src/services/license.service.ts
@@ -545,6 +545,8 @@ export class LicenseService extends EventEmitter<LicenseEvents> {
     } catch (error) {
       this.logger.error('[LicenseService.verifyLicense] Verification failed', {
         error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+        url: this.licenseServerUrl,
       });
 
       // TASK_2025_121: Check offline grace period cache

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-handlers/http-server.handler.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-handlers/http-server.handler.ts
@@ -5,9 +5,7 @@
  * Handles CORS, request parsing, and response formatting.
  *
  * APPROVED EXCEPTION: This file retains `import * as vscode from 'vscode'`
- * because it uses vscode.workspace.getConfiguration() for MCP port config
- * and vscode.window.showErrorMessage() for user-facing error notifications.
- * These are VS Code-specific APIs with no platform-core equivalent.
+ * because it uses vscode.workspace.getConfiguration() for MCP port config.
  * The public interface uses IStateStorage (platform-core) for state persistence.
  */
 
@@ -46,42 +44,69 @@ export function getConfiguredPort(): number {
 }
 
 /**
- * Start the HTTP MCP server
+ * Try to listen on a specific port. Returns a promise that resolves with
+ * the server+port on success, or rejects on error.
  */
-export async function startHttpServer(
-  config: HttpServerConfig
+function tryListen(
+  server: http.Server,
+  port: number,
+  logger: Logger,
+  workspaceState: IStateStorage,
 ): Promise<HttpServerResult> {
-  const { port: configuredPort, logger, workspaceState, onMCPRequest } = config;
-
   return new Promise((resolve, reject) => {
-    const server = http.createServer((req, res) => {
-      handleHttpRequest(req, res, onMCPRequest);
-    });
+    const onError = (error: NodeJS.ErrnoException) => {
+      server.removeListener('error', onError);
+      reject(error);
+    };
+    server.on('error', onError);
 
-    server.listen(configuredPort, 'localhost', () => {
+    server.listen(port, 'localhost', () => {
+      server.removeListener('error', onError);
       const address = server.address();
       if (!address || typeof address === 'string') {
         reject(new Error('Failed to get server address'));
         return;
       }
 
-      const port = address.port;
-
-      // Store port in workspace state for Claude CLI discovery
-      workspaceState.update('ptah.mcp.port', port);
-
+      const actualPort = address.port;
+      workspaceState.update('ptah.mcp.port', actualPort);
       logger.info(
-        `CodeExecutionMCP server started on http://localhost:${port}`,
-        'CodeExecutionMCP'
+        `CodeExecutionMCP server started on http://localhost:${actualPort}`,
+        'CodeExecutionMCP',
       );
-
-      resolve({ server, port });
-    });
-
-    server.on('error', (error: NodeJS.ErrnoException) => {
-      handleServerError(error, configuredPort, logger, reject);
+      resolve({ server, port: actualPort });
     });
   });
+}
+
+/**
+ * Start the HTTP MCP server.
+ *
+ * Tries the configured port first. If it fails (EACCES on Windows due to
+ * Hyper-V port exclusions, or EADDRINUSE), retries with port 0 which lets
+ * the OS assign a random available port.
+ */
+export async function startHttpServer(
+  config: HttpServerConfig,
+): Promise<HttpServerResult> {
+  const { port: configuredPort, logger, workspaceState, onMCPRequest } = config;
+
+  const server = http.createServer((req, res) => {
+    handleHttpRequest(req, res, onMCPRequest);
+  });
+
+  try {
+    return await tryListen(server, configuredPort, logger, workspaceState);
+  } catch (error) {
+    const errCode = (error as NodeJS.ErrnoException).code;
+    if (errCode === 'EACCES' || errCode === 'EADDRINUSE') {
+      logger.warn(
+        `MCP port ${configuredPort} unavailable (${errCode}), retrying with OS-assigned port`,
+      );
+      return await tryListen(server, 0, logger, workspaceState);
+    }
+    throw error;
+  }
 }
 
 /**
@@ -90,7 +115,7 @@ export async function startHttpServer(
 export async function stopHttpServer(
   server: http.Server | null,
   workspaceState: IStateStorage,
-  logger: Logger
+  logger: Logger,
 ): Promise<void> {
   if (!server) {
     return;
@@ -114,7 +139,7 @@ const MAX_BODY_SIZE = 1024 * 1024;
 async function handleHttpRequest(
   req: http.IncomingMessage,
   res: http.ServerResponse,
-  onMCPRequest: (request: MCPRequest) => Promise<MCPResponse>
+  onMCPRequest: (request: MCPRequest) => Promise<MCPResponse>,
 ): Promise<void> {
   // CORS headers for localhost
   res.setHeader('Access-Control-Allow-Origin', 'http://localhost');
@@ -191,27 +216,4 @@ async function handleHttpRequest(
       res.end(JSON.stringify(errorResponse));
     }
   });
-}
-
-/**
- * Handle server startup errors with user-friendly messages
- */
-function handleServerError(
-  error: NodeJS.ErrnoException,
-  configuredPort: number,
-  logger: Logger,
-  reject: (error: Error) => void
-): void {
-  if (error.code === 'EADDRINUSE') {
-    const errorMsg = `Failed to start MCP server on port ${configuredPort}. Port is already in use. Please change 'ptah.mcpPort' setting to use a different port.`;
-    logger.error(errorMsg, error);
-
-    // Show user-friendly notification
-    vscode.window.showErrorMessage(errorMsg);
-
-    reject(new Error(errorMsg));
-  } else {
-    logger.error('CodeExecutionMCP server error', error);
-    reject(error);
-  }
 }


### PR DESCRIPTION
## Summary
- **Replace raw `fetch()` with `axios`** across all backend libraries (vscode-core, agent-sdk, llm-abstraction) for consistent HTTP handling in both VS Code and Electron
- **Reduce VSIX from 124 MB to 8.9 MB** by bundling pure-JS deps (axios, tsyringe, eventemitter3) and fixing `.vscodeignore` patterns that leaked 55 MB of `@github/copilot` CLI files
- **Fix Linux/macOS Electron builds** failing with `#error "C++20 or later required"` by adding `CXXFLAGS=-std=c++20`
- **MCP server resilience**: retry with OS-assigned port on EACCES/EADDRINUSE, wrap startup in try/catch so failures don't crash the extension

## Test plan
- [x] VS Code extension packages to 8.9 MB VSIX (clean build from scratch)
- [x] Electron app launches and verifies license against live API (`--production` flag)
- [x] Typecheck passes for VS Code extension
- [x] esbuild production build succeeds with `thirdParty: true`
- [ ] CI: Electron Linux/macOS builds pass with CXXFLAGS
- [ ] CI: VS Code extension publishes without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)