### PR TITLE
fix(deps): align license public key with production server

### DIFF
--- a/apps/ptah-extension-vscode/package.json
+++ b/apps/ptah-extension-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ptah-extension-vscode",
   "displayName": "Ptah - Coding Orchestra",
   "description": "The AI coding orchestra for VS Code. Provider-agnostic AI orchestration with intelligent workspace analysis, Code Execution MCP server, and project-adaptive multi-agent workflows.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "publisher": "ptah-extensions",
   "repository": {
     "type": "git",

--- a/libs/shared/src/lib/constants/environment.constants.ts
+++ b/libs/shared/src/lib/constants/environment.constants.ts
@@ -60,7 +60,7 @@ export const PtahDevDefaults = {
  * Replace this placeholder with the generated public key before production.
  */
 export const LICENSE_PUBLIC_KEY_BASE64 =
-  'MCowBQYDK2VwAyEAy8PRu7wT/Fv2yGMPd/5kNyKfs0i42C7oAvsk63pV/MA=';
+  'MCowBQYDK2VwAyEAKCYdta2d6ePQAQirldcF90FXv00yuXQgaLJ0aW3/wWQ=';
 
 /**
  * Resolve the correct URL set and defaults for the current environment.


### PR DESCRIPTION
Update LICENSE_PUBLIC_KEY_BASE64 to match the production server's LICENSE_SIGNING_PRIVATE_KEY. The previous key was from a different key pair, causing Ed25519 signature verification to reject all valid license responses.