### PR TITLE
feat(vscode-lm-tools): make headless mode and viewport agent-controlled

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
   "ptah.authMethod": "oauth",
-  "ptah.model.selected": "opus"
+  "ptah.model.selected": "opus",
+  "ptah.reasoningEffort": "high",
+  "ptah.autopilot.enabled": false,
+  "ptah.autopilot.permissionLevel": "yolo"
 }

--- a/apps/ptah-electron/src/di/container.ts
+++ b/apps/ptah-electron/src/di/container.ts
@@ -701,21 +701,14 @@ export class ElectronDIContainer {
     // Phase 4.0.1: Browser capabilities (TASK_2025_244)
     // ElectronBrowserCapabilities uses Electron's native BrowserWindow + webContents.debugger
     // for CDP browser automation. Zero external dependencies.
-    // TASK_2025_254: Pass config accessors for headless mode and recording directory.
+    // Headless/viewport are agent-controlled via ptah_browser_navigate params.
     {
       const workspaceProvider = container.resolve<IWorkspaceProvider>(
         PLATFORM_TOKENS.WORKSPACE_PROVIDER,
       );
       container.register(BROWSER_CAPABILITIES_TOKEN, {
         useValue: new ElectronBrowserCapabilities(
-          // getHeadless (TASK_2025_254)
-          () =>
-            workspaceProvider.getConfiguration<boolean>(
-              'ptah.browser',
-              'headless',
-              true,
-            ) ?? true,
-          // getRecordingDir (TASK_2025_254)
+          // getRecordingDir
           () =>
             workspaceProvider.getConfiguration<string>(
               'ptah.browser',

--- a/apps/ptah-electron/src/ipc/webview-manager-adapter.ts
+++ b/apps/ptah-electron/src/ipc/webview-manager-adapter.ts
@@ -46,9 +46,10 @@ export class ElectronWebviewManagerAdapter {
   async sendMessage(
     _viewType: string,
     type: string,
-    payload: unknown
-  ): Promise<void> {
+    payload: unknown,
+  ): Promise<boolean> {
     this.ipcBridge.sendToRenderer({ type, payload });
+    return true;
   }
 
   /**

--- a/apps/ptah-electron/src/ipc/webview-manager-adapter.ts
+++ b/apps/ptah-electron/src/ipc/webview-manager-adapter.ts
@@ -14,8 +14,8 @@
  * webContents.send('to-renderer', message).
  *
  * The interface contract expected by consumers (from the VS Code app):
- *   sendMessage(viewType: string, type: string, payload: unknown): Promise<void>
- *   broadcastMessage(type: string, payload: unknown): Promise<void>
+ *   sendMessage(viewType: string, type: string, payload: unknown): Promise<boolean>
+ *   broadcastMessage(type: string, payload: unknown): Promise<boolean>
  */
 
 import type { IpcBridge } from './ipc-bridge';

--- a/apps/ptah-electron/src/services/electron-browser-capabilities.ts
+++ b/apps/ptah-electron/src/services/electron-browser-capabilities.ts
@@ -420,6 +420,14 @@ export class ElectronBrowserCapabilities implements IBrowserCapabilities {
     await this.sendCDP('Network.enable', {});
     await this.sendCDP('Runtime.enable', {});
 
+    // Set viewport via CDP Emulation (matches ChromeLauncherBrowserCapabilities behavior)
+    await this.sendCDP('Emulation.setDeviceMetricsOverride', {
+      width: this._viewport.width,
+      height: this._viewport.height,
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
+
     // Set up network monitoring
     this.networkEntries = [];
     this.pendingResponses.clear();
@@ -603,6 +611,7 @@ export class ElectronBrowserCapabilities implements IBrowserCapabilities {
     this.startedAt = null;
     this.networkEntries = [];
     this.pendingResponses.clear();
+    this._pendingOptions = {};
   }
 
   // Recording methods (TASK_2025_254)

--- a/apps/ptah-electron/src/services/electron-browser-capabilities.ts
+++ b/apps/ptah-electron/src/services/electron-browser-capabilities.ts
@@ -11,7 +11,10 @@
  */
 
 import { BrowserWindow } from 'electron';
-import type { IBrowserCapabilities } from '@ptah-extension/vscode-lm-tools';
+import type {
+  IBrowserCapabilities,
+  BrowserSessionOptions,
+} from '@ptah-extension/vscode-lm-tools';
 import { ScreenRecorderService } from '@ptah-extension/vscode-lm-tools';
 
 /** Network request entry stored in ring buffer */
@@ -27,6 +30,9 @@ const INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes (headless)
 const VISIBLE_INACTIVITY_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes (visible, TASK_2025_254)
 const MAX_LIFETIME_MS = 30 * 60 * 1000; // 30 minutes
 const MAX_NETWORK_ENTRIES = 500;
+
+/** Default viewport dimensions (desktop) */
+const DEFAULT_VIEWPORT = { width: 1920, height: 1080 };
 
 export class ElectronBrowserCapabilities implements IBrowserCapabilities {
   private window: BrowserWindow | null = null;
@@ -44,15 +50,20 @@ export class ElectronBrowserCapabilities implements IBrowserCapabilities {
 
   /** Recording service (TASK_2025_254) */
   private recorder: ScreenRecorderService | null = null;
-  /** Whether current session is headless (TASK_2025_254) */
-  private _headless = true;
+  /** Whether current session is headless — agent-controlled, default false (visible) */
+  private _headless = false;
+  /** Current viewport dimensions — agent-controlled, default 1920x1080 (desktop) */
+  private _viewport = { ...DEFAULT_VIEWPORT };
+  /** Pending session options set by configureSession(), consumed by createSession() */
+  private _pendingOptions: BrowserSessionOptions = {};
   /** Inactivity timer paused flag (TASK_2025_254) */
   private _inactivityPaused = false;
 
-  constructor(
-    private readonly getHeadless: () => boolean = () => true,
-    private readonly getRecordingDir: () => string = () => '',
-  ) {}
+  constructor(private readonly getRecordingDir: () => string = () => '') {}
+
+  configureSession(options: BrowserSessionOptions): void {
+    this._pendingOptions = { ...this._pendingOptions, ...options };
+  }
 
   async navigate(
     url: string,
@@ -312,6 +323,7 @@ export class ElectronBrowserCapabilities implements IBrowserCapabilities {
     autoCloseInMs?: number;
     headless?: boolean;
     recording?: boolean;
+    viewport?: { width: number; height: number };
   }> {
     if (!this.connected || !this.window || this.window.isDestroyed()) {
       return { connected: false };
@@ -330,6 +342,7 @@ export class ElectronBrowserCapabilities implements IBrowserCapabilities {
       autoCloseInMs,
       headless: this._headless,
       recording: this.recorder?.isRecording() ?? false,
+      viewport: { ...this._viewport },
     };
   }
 
@@ -371,14 +384,18 @@ export class ElectronBrowserCapabilities implements IBrowserCapabilities {
     // Clean up any stale state from a crashed session (auto-reconnect)
     await this.cleanup();
 
-    // Read headless setting at session creation time (TASK_2025_254)
-    this._headless = this.getHeadless();
+    // Consume pending session options (agent-controlled headless + viewport)
+    this._headless = this._pendingOptions.headless ?? false;
+    this._viewport = this._pendingOptions.viewport
+      ? { ...this._pendingOptions.viewport }
+      : { ...DEFAULT_VIEWPORT };
+    this._pendingOptions = {};
 
-    // Create BrowserWindow — visible when not headless (TASK_2025_254)
+    // Create BrowserWindow — visible when not headless
     this.window = new BrowserWindow({
       show: !this._headless,
-      width: 1280,
-      height: 720,
+      width: this._viewport.width,
+      height: this._viewport.height,
       webPreferences: {
         contextIsolation: true,
         nodeIntegration: false,

--- a/apps/ptah-electron/src/services/rpc/handlers/electron-agent-rpc.handlers.ts
+++ b/apps/ptah-electron/src/services/rpc/handlers/electron-agent-rpc.handlers.ts
@@ -14,7 +14,7 @@
  * (IStateStorage, IWorkspaceProvider) instead of VS Code APIs.
  */
 
-import { injectable, inject } from 'tsyringe';
+import { injectable, inject, container } from 'tsyringe';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -44,6 +44,8 @@ import type {
   CliDetectionResult,
   CliType,
   SpawnAgentResult,
+  ISdkPermissionHandler,
+  PermissionResponse,
 } from '@ptah-extension/shared';
 
 @injectable()
@@ -338,6 +340,17 @@ export class ElectronAgentRpcHandlers {
     );
   }
 
+  /**
+   * agent:permissionResponse - Route user's permission decision to handlers
+   *
+   * Tries both:
+   * 1. SdkPermissionHandler (Ptah CLI agent permissions) - via lazy container resolution
+   * 2. CopilotPermissionBridge (Copilot SDK permissions) - via CLI adapter
+   *
+   * Both handlers silently ignore unknown requestIds, so trying both is safe.
+   *
+   * TASK_2025_255: Extended to also route to SdkPermissionHandler for Ptah CLI agents
+   */
   private registerPermissionResponse(): void {
     this.rpcHandler.registerMethod<
       AgentPermissionDecision,
@@ -349,16 +362,41 @@ export class ElectronAgentRpcHandlers {
           decision: params.decision,
         });
 
+        let handled = false;
+
+        // Try SdkPermissionHandler first (handles Ptah CLI agent permissions)
+        // Uses lazy container resolution (same pattern as webview-message-handler.service.ts:464)
+        if (container.isRegistered(SDK_TOKENS.SDK_PERMISSION_HANDLER)) {
+          const permissionHandler = container.resolve<ISdkPermissionHandler>(
+            SDK_TOKENS.SDK_PERMISSION_HANDLER,
+          );
+          const response: PermissionResponse = {
+            id: params.requestId,
+            decision: params.decision,
+            reason: params.reason,
+          };
+          permissionHandler.handleResponse(params.requestId, response);
+          handled = true;
+        }
+
+        // Also try Copilot bridge (existing flow, idempotent for unknown requestIds)
         const copilotAdapter = this.cliDetection.getAdapter('copilot');
         if (copilotAdapter && 'permissionBridge' in copilotAdapter) {
           const bridge = (
             copilotAdapter as { permissionBridge: CopilotPermissionBridge }
           ).permissionBridge;
           bridge.resolvePermission(params.requestId, params);
+          handled = true;
+        }
+
+        if (handled) {
           return { success: true };
         }
 
-        return { success: false, error: 'Copilot SDK adapter not active' };
+        return {
+          success: false,
+          error: 'No permission handler available (neither SDK nor Copilot)',
+        };
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
@@ -547,16 +585,24 @@ export class ElectronAgentRpcHandlers {
       });
     }
 
-    return this.agentProcessManager.spawnFromSdkHandle(spawnResult.handle, {
-      task: params.task,
-      cli: 'ptah-cli',
-      workingDirectory: workspaceRoot,
-      parentSessionId: params.parentSessionId,
-      ptahCliName: spawnResult.agentName,
-      ptahCliId: params.ptahCliId,
-      resumedFromAgentId: params.previousAgentId,
-      resumeSessionId: sessionFileExists ? params.cliSessionId : undefined,
-    });
+    const result = await this.agentProcessManager.spawnFromSdkHandle(
+      spawnResult.handle,
+      {
+        task: params.task,
+        cli: 'ptah-cli',
+        workingDirectory: workspaceRoot,
+        parentSessionId: params.parentSessionId,
+        ptahCliName: spawnResult.agentName,
+        ptahCliId: params.ptahCliId,
+        resumedFromAgentId: params.previousAgentId,
+        resumeSessionId: sessionFileExists ? params.cliSessionId : undefined,
+      },
+    );
+
+    // TASK_2025_255: Wire agentId so CLI permission requests route to agent monitor panel
+    spawnResult.setAgentId(result.agentId);
+
+    return result;
   }
 
   private async resolveDefaultPtahCliId(): Promise<string | undefined> {

--- a/apps/ptah-electron/src/services/rpc/rpc-method-registration.service.ts
+++ b/apps/ptah-electron/src/services/rpc/rpc-method-registration.service.ts
@@ -77,6 +77,8 @@ import {
   ElectronGitRpcHandlers,
   ElectronTerminalRpcHandlers,
 } from './handlers';
+import { ELECTRON_TOKENS } from '../../di/electron-tokens';
+import type { GitInfoService } from '../git-info.service';
 
 /**
  * Orchestrates RPC method registration across all domain handlers.
@@ -378,13 +380,36 @@ export class ElectronRpcMethodRegistrationService {
       });
 
       // 4. WORKTREE callbacks — git worktree create/remove notifications
-      sdkAdapter.setWorktreeCreatedCallback((data) => {
+      // Resolve GitInfoService lazily to query git for the actual worktree path
+      // (the SDK hook only provides branch name + session cwd, not the worktree path)
+      sdkAdapter.setWorktreeCreatedCallback(async (data) => {
         this.logger.info(`[Electron RPC] Worktree created: name=${data.name}`);
+
+        // Find the actual worktree path by listing worktrees and matching by branch name
+        let worktreePath: string | undefined;
+        try {
+          if (container.isRegistered(ELECTRON_TOKENS.GIT_INFO_SERVICE)) {
+            const gitInfo = container.resolve<GitInfoService>(
+              ELECTRON_TOKENS.GIT_INFO_SERVICE,
+            );
+            const worktrees = await gitInfo.getWorktrees(data.cwd);
+            // parseWorktreeList() already strips refs/heads/ prefix,
+            // so exact match on branch name is sufficient
+            const match = worktrees.find((w) => w.branch === data.name);
+            worktreePath = match?.path;
+          }
+        } catch (err) {
+          this.logger.warn(
+            '[Electron RPC] Failed to resolve worktree path, falling back to name-based path',
+            { error: err instanceof Error ? err.message : String(err) },
+          );
+        }
+
         webviewManager
           .broadcastMessage('git:worktreeChanged', {
             action: 'created',
             name: data.name,
-            path: data.cwd,
+            path: worktreePath,
           })
           .catch((error) => {
             this.logger.error(

--- a/apps/ptah-extension-vscode/package.json
+++ b/apps/ptah-extension-vscode/package.json
@@ -278,11 +278,6 @@
           "default": false,
           "description": "Allow AI agent browser automation to access localhost URLs (127.0.0.1, 0.0.0.0, [::1]). Enable for local dev server testing."
         },
-        "ptah.browser.headless": {
-          "type": "boolean",
-          "default": true,
-          "description": "When true (default), the browser runs in headless mode. Set to false to show the browser window for interactive workflows (login, 2FA, CAPTCHAs)."
-        },
         "ptah.browser.recordingDir": {
           "type": "string",
           "default": "",

--- a/apps/ptah-extension-vscode/src/di/container.ts
+++ b/apps/ptah-extension-vscode/src/di/container.ts
@@ -428,16 +428,11 @@ export class DIContainer {
 
     // TASK_2025_244: Register browser capabilities for PtahAPIBuilder.
     // ChromeLauncherBrowserCapabilities uses chrome-launcher + chrome-remote-interface
-    // to launch and control a headless Chrome for browser automation tools.
-    // TASK_2025_254: Pass config accessors for headless mode and recording directory.
+    // to launch and control Chrome for browser automation tools.
+    // Headless/viewport are agent-controlled via ptah_browser_navigate params.
     container.register(BROWSER_CAPABILITIES_TOKEN, {
       useValue: new ChromeLauncherBrowserCapabilities(
-        // getHeadless (TASK_2025_254)
-        () =>
-          vscode.workspace
-            .getConfiguration('ptah.browser')
-            .get<boolean>('headless', true) ?? true,
-        // getRecordingDir (TASK_2025_254)
+        // getRecordingDir
         () =>
           vscode.workspace
             .getConfiguration('ptah.browser')

--- a/apps/ptah-extension-vscode/src/services/rpc/handlers/agent-rpc.handlers.ts
+++ b/apps/ptah-extension-vscode/src/services/rpc/handlers/agent-rpc.handlers.ts
@@ -9,7 +9,7 @@
  * TASK_2025_157: Agent Orchestration Settings UI
  */
 
-import { injectable, inject } from 'tsyringe';
+import { injectable, inject, container } from 'tsyringe';
 import { Logger, RpcHandler, TOKENS } from '@ptah-extension/vscode-core';
 import {
   CliDetectionService,
@@ -29,6 +29,8 @@ import type {
   AgentListCliModelsResult,
   CliModelOption,
   AgentPermissionDecision,
+  ISdkPermissionHandler,
+  PermissionResponse,
 } from '@ptah-extension/shared';
 import type { CliDetectionResult, CliType } from '@ptah-extension/shared';
 import * as vscode from 'vscode';
@@ -547,13 +549,17 @@ export class AgentRpcHandlers {
   }
 
   /**
-   * agent:permissionResponse - Route user's permission decision to Copilot SDK bridge
+   * agent:permissionResponse - Route user's permission decision to handlers
    *
-   * Called by the webview when the user clicks Allow/Deny on a permission dialog.
-   * Resolves the pending permission Promise in the CopilotPermissionBridge, which
-   * unblocks the SDK's onPreToolUse hook.
+   * Called by the webview when the user clicks Allow/Deny on a permission dialog
+   * in the agent monitor panel. Tries both:
+   * 1. SdkPermissionHandler (Ptah CLI agent permissions) - via lazy container resolution
+   * 2. CopilotPermissionBridge (Copilot SDK permissions) - via CLI adapter
+   *
+   * Both handlers silently ignore unknown requestIds, so trying both is safe.
    *
    * TASK_2025_162: Copilot SDK Integration
+   * TASK_2025_255: Extended to also route to SdkPermissionHandler for Ptah CLI agents
    */
   private registerPermissionResponse(): void {
     this.rpcHandler.registerMethod<
@@ -566,16 +572,41 @@ export class AgentRpcHandlers {
           decision: params.decision,
         });
 
+        let handled = false;
+
+        // Try SdkPermissionHandler first (handles Ptah CLI agent permissions)
+        // Uses lazy container resolution (same pattern as webview-message-handler.service.ts:464)
+        if (container.isRegistered(SDK_TOKENS.SDK_PERMISSION_HANDLER)) {
+          const permissionHandler = container.resolve<ISdkPermissionHandler>(
+            SDK_TOKENS.SDK_PERMISSION_HANDLER,
+          );
+          const response: PermissionResponse = {
+            id: params.requestId,
+            decision: params.decision,
+            reason: params.reason,
+          };
+          permissionHandler.handleResponse(params.requestId, response);
+          handled = true;
+        }
+
+        // Also try Copilot bridge (existing flow, idempotent for unknown requestIds)
         const copilotAdapter = this.cliDetection.getAdapter('copilot');
         if (copilotAdapter && 'permissionBridge' in copilotAdapter) {
           const bridge = (
             copilotAdapter as { permissionBridge: CopilotPermissionBridge }
           ).permissionBridge;
           bridge.resolvePermission(params.requestId, params);
+          handled = true;
+        }
+
+        if (handled) {
           return { success: true };
         }
 
-        return { success: false, error: 'Copilot SDK adapter not active' };
+        return {
+          success: false,
+          error: 'No permission handler available (neither SDK nor Copilot)',
+        };
       } catch (error) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
@@ -776,16 +807,24 @@ export class AgentRpcHandlers {
       });
     }
 
-    return this.agentProcessManager.spawnFromSdkHandle(spawnResult.handle, {
-      task: params.task,
-      cli: 'ptah-cli',
-      workingDirectory: workspaceRoot,
-      parentSessionId: params.parentSessionId,
-      ptahCliName: spawnResult.agentName,
-      ptahCliId: params.ptahCliId,
-      resumedFromAgentId: params.previousAgentId,
-      resumeSessionId: sessionFileExists ? params.cliSessionId : undefined,
-    });
+    const result = await this.agentProcessManager.spawnFromSdkHandle(
+      spawnResult.handle,
+      {
+        task: params.task,
+        cli: 'ptah-cli',
+        workingDirectory: workspaceRoot,
+        parentSessionId: params.parentSessionId,
+        ptahCliName: spawnResult.agentName,
+        ptahCliId: params.ptahCliId,
+        resumedFromAgentId: params.previousAgentId,
+        resumeSessionId: sessionFileExists ? params.cliSessionId : undefined,
+      },
+    );
+
+    // TASK_2025_255: Wire agentId so CLI permission requests route to agent monitor panel
+    spawnResult.setAgentId(result.agentId);
+
+    return result;
   }
 
   /**

--- a/apps/ptah-extension-vscode/src/services/rpc/rpc-method-registration.service.ts
+++ b/apps/ptah-extension-vscode/src/services/rpc/rpc-method-registration.service.ts
@@ -37,6 +37,7 @@ import {
   AgentProcessInfo,
   AgentOutputDelta,
   CliSessionReference,
+  parseWorktreeList,
 } from '@ptah-extension/shared';
 import type { AgentPermissionRequest } from '@ptah-extension/shared';
 import { AGENT_GENERATION_TOKENS } from '@ptah-extension/agent-generation';
@@ -604,16 +605,45 @@ export class RpcMethodRegistrationService {
    * WorktreeService can refresh its worktree list and register new workspace folders.
    */
   private setupWorktreeCallbacks(): void {
-    this.sdkAdapter.setWorktreeCreatedCallback((data) => {
+    this.sdkAdapter.setWorktreeCreatedCallback(async (data) => {
       this.logger.info(
         `[RPC] Worktree created: name=${data.name}, sessionId=${data.sessionId}`,
       );
+
+      // Resolve the actual worktree path by listing worktrees and matching by branch name.
+      // The SDK hook only provides branch name + session cwd, not the worktree path.
+      let worktreePath: string | undefined;
+      try {
+        const crossSpawn = await import('cross-spawn');
+        const child = crossSpawn.default(
+          'git',
+          ['worktree', 'list', '--porcelain'],
+          {
+            cwd: data.cwd,
+            stdio: ['pipe', 'pipe', 'pipe'],
+          },
+        );
+        const chunks: Buffer[] = [];
+        child.stdout?.on('data', (chunk: Buffer) => chunks.push(chunk));
+        await new Promise<void>((resolve) =>
+          child.on('close', () => resolve()),
+        );
+        const output = Buffer.concat(chunks).toString();
+        const worktrees = parseWorktreeList(output);
+        const match = worktrees.find((w) => w.branch === data.name);
+        worktreePath = match?.path;
+      } catch (err) {
+        this.logger.warn(
+          '[RPC] Failed to resolve worktree path for notification',
+          err instanceof Error ? err : new Error(String(err)),
+        );
+      }
 
       this.webviewManager
         .broadcastMessage('git:worktreeChanged', {
           action: 'created',
           name: data.name,
-          path: data.cwd,
+          path: worktreePath,
         })
         .catch((error) => {
           this.logger.error(

--- a/apps/ptah-landing-page/src/app/pages/pricing/components/pricing-grid.component.ts
+++ b/apps/ptah-landing-page/src/app/pages/pricing/components/pricing-grid.component.ts
@@ -8,7 +8,6 @@ import {
   effect,
   OnDestroy,
   DestroyRef,
-  HostListener,
 } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -197,6 +196,7 @@ import {
       }
     `,
   ],
+  host: { '(window:focus)': 'onWindowFocus()' },
 })
 export class PricingGridComponent implements OnInit, OnDestroy {
   /** Lucide icon references */
@@ -317,7 +317,6 @@ export class PricingGridComponent implements OnInit, OnDestroy {
    * Handle window focus to refresh subscription state after portal return.
    * Only refreshes if portal was opened previously.
    */
-  @HostListener('window:focus')
   public onWindowFocus(): void {
     if (this.portalWasOpened) {
       this.portalWasOpened = false;

--- a/libs/backend/agent-sdk/src/lib/helpers/session-lifecycle-manager.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/session-lifecycle-manager.ts
@@ -310,6 +310,79 @@ export class SessionLifecycleManager {
   }
 
   /**
+   * Interrupt the current assistant turn without ending the session.
+   *
+   * Unlike endSession(), this does NOT abort the session or clean up resources.
+   * The session remains active for continued use — the user's follow-up message
+   * will start a new turn.
+   *
+   * Used when the user sends a message during autopilot (yolo/auto-edit) execution.
+   * In these modes, tool calls are auto-approved, so the user has no checkpoint to
+   * stop the agent. Calling interrupt() forces the SDK to stop the current turn,
+   * ensuring the user's message is processed in a new turn.
+   *
+   * @param sessionId - Session whose current turn should be interrupted
+   * @returns true if interrupt was called, false if session/query not found
+   */
+  async interruptCurrentTurn(sessionId: SessionId): Promise<boolean> {
+    let session = this.activeSessions.get(sessionId as string);
+
+    // Reverse lookup: frontend may send real SDK UUID but activeSessions is keyed by tab ID.
+    // Same pattern as endSession() and setSessionModel().
+    if (!session) {
+      for (const [tabId, realId] of this.tabIdToRealId.entries()) {
+        if (realId === (sessionId as string)) {
+          session = this.activeSessions.get(tabId);
+          if (session) {
+            sessionId = tabId as SessionId;
+            break;
+          }
+        }
+      }
+    }
+
+    if (!session?.query) {
+      this.logger.warn(
+        `[SessionLifecycle] Cannot interrupt turn - session or query not found: ${sessionId}`,
+      );
+      return false;
+    }
+
+    this.logger.info(
+      `[SessionLifecycle] Interrupting current turn for session: ${sessionId}`,
+    );
+
+    try {
+      let timedOut = false;
+      await Promise.race([
+        session.query.interrupt(),
+        new Promise<void>((resolve) =>
+          setTimeout(() => {
+            timedOut = true;
+            resolve();
+          }, 3000),
+        ),
+      ]);
+      if (timedOut) {
+        this.logger.warn(
+          `[SessionLifecycle] Turn interrupt timed out (3s) for session: ${sessionId}`,
+        );
+      } else {
+        this.logger.info(
+          `[SessionLifecycle] Turn interrupt completed for session: ${sessionId}`,
+        );
+      }
+      return !timedOut;
+    } catch (err) {
+      this.logger.warn(
+        `[SessionLifecycle] Turn interrupt failed for session ${sessionId}`,
+        err instanceof Error ? err : new Error(String(err)),
+      );
+      return false;
+    }
+  }
+
+  /**
    * End session and cleanup
    * TASK_2025_102: Now calls cleanupPendingPermissions to prevent unhandled promise rejections
    * TASK_2025_103: Now marks all running subagents as interrupted before session removal

--- a/libs/backend/agent-sdk/src/lib/ptah-cli/ptah-cli-adapter.ts
+++ b/libs/backend/agent-sdk/src/lib/ptah-cli/ptah-cli-adapter.ts
@@ -767,7 +767,15 @@ export class PtahCliAdapter implements IAIProvider {
   }): {
     prompt: AsyncIterable<SDKUserMessage>;
     options: SdkQueryOptions;
+    /** TASK_2025_255: Populate after spawn to route CLI agent permissions to agent monitor panel */
+    setAgentId: (id: string) => void;
   } {
+    // TASK_2025_255: Create mutable holder for agentId.
+    // For interactive sessions the agentId is not typically available (no
+    // AgentProcessManager spawn), so the resolver returns undefined and
+    // permissions fall back to the existing main agent flow.
+    const agentIdHolder: { value?: string } = {};
+
     const {
       userMessageStream,
       abortController,
@@ -800,7 +808,21 @@ export class PtahCliAdapter implements IAIProvider {
     const useBypass = sdkPermMode === 'bypassPermissions';
     const canUseTool = useBypass
       ? undefined
-      : this.permissionHandler.createCallback(sessionId);
+      : this.permissionHandler.createCallback(
+          sessionId,
+          () => agentIdHolder.value,
+        );
+
+    this.logger.info(
+      '[PtahCliAdapter] Permission config for interactive session',
+      {
+        permLevel,
+        sdkPermMode,
+        useBypass,
+        hasCanUseTool: !!canUseTool,
+        sessionId,
+      },
+    );
 
     // Build system prompt with full premium capabilities
     const activeProviderId = getActiveProviderId(this.authEnv);
@@ -920,6 +942,12 @@ export class PtahCliAdapter implements IAIProvider {
         // Without this, the subprocess resolves to the build-time path
         // causing "process exited with code 1" in production.
         pathToClaudeCodeExecutable: this.resolvedCliJsPath ?? undefined,
+      },
+      // TASK_2025_255: Expose setAgentId for callers to populate after spawn.
+      // For interactive sessions this is typically never called (no spawn step),
+      // so the resolver returns undefined and permissions use the main agent flow.
+      setAgentId: (agentId: string) => {
+        agentIdHolder.value = agentId;
       },
     };
   }

--- a/libs/backend/agent-sdk/src/lib/ptah-cli/ptah-cli-registry.ts
+++ b/libs/backend/agent-sdk/src/lib/ptah-cli/ptah-cli-registry.ts
@@ -489,7 +489,10 @@ export class PtahCliRegistry {
        *  will be scoped to this session for cleanup purposes. */
       parentSessionId?: string;
     },
-  ): Promise<{ handle: SdkHandle; agentName: string } | SpawnAgentFailure> {
+  ): Promise<
+    | { handle: SdkHandle; agentName: string; setAgentId: (id: string) => void }
+    | SpawnAgentFailure
+  > {
     // Find config
     const configs = this.configPersistence.loadConfigs();
     const agentConfig = configs.find((c) => c.id === id);
@@ -534,6 +537,13 @@ export class PtahCliRegistry {
         message: `Unknown provider "${agentConfig.providerId}" for Ptah CLI agent "${id}"`,
       };
     }
+
+    // TASK_2025_255: Create mutable holder for agentId.
+    // The agentId is not available until after spawnFromSdkHandle() returns,
+    // but the permission callback (canUseTool) is created before that.
+    // The resolver closure captures this holder; the caller populates it
+    // via setAgentId() after spawn completes.
+    const agentIdHolder: { value?: string } = {};
 
     // Build isolated AuthEnv
     const authEnv = this.buildAuthEnv(agentConfig, provider, apiKey);
@@ -611,6 +621,7 @@ export class PtahCliRegistry {
           options?.resumeSessionId ??
             options?.parentSessionId ??
             `ptah-cli:${id}`,
+          () => agentIdHolder.value,
         ),
         settingSources: ['user', 'project', 'local'] as const,
         includePartialMessages: true,
@@ -676,7 +687,16 @@ export class PtahCliRegistry {
       `[PtahCliRegistry] Spawned headless agent "${agentConfig.name}" (${id}) with model ${providerModel} (SDK model: ${model})`,
     );
 
-    return { handle, agentName: agentConfig.name };
+    return {
+      handle,
+      agentName: agentConfig.name,
+      /** Call this AFTER spawnFromSdkHandle() returns with the agentId.
+       *  Populates the lazy resolver used by SdkPermissionHandler to route
+       *  CLI agent permissions to the agent monitor panel. */
+      setAgentId: (agentId: string) => {
+        agentIdHolder.value = agentId;
+      },
+    };
   }
 
   /**
@@ -711,7 +731,10 @@ export class PtahCliRegistry {
    * For other modes ('ask', 'auto-edit'), we keep `default` and provide
    * the canUseTool callback so the user sees permission prompts.
    */
-  private resolvePermissionOptions(sessionId?: string): {
+  private resolvePermissionOptions(
+    sessionId?: string,
+    cliAgentResolver?: () => string | undefined,
+  ): {
     permissionMode: string;
     canUseTool?: ReturnType<SdkPermissionHandler['createCallback']>;
     allowDangerouslySkipPermissions?: boolean;
@@ -741,10 +764,14 @@ export class PtahCliRegistry {
 
     this.logger.info(
       `[PtahCliRegistry] Permission mode for subagent: ${sdkMode} (level: ${level})`,
+      { sessionId, hasCanUseTool: true },
     );
     return {
       permissionMode: sdkMode,
-      canUseTool: this.permissionHandler.createCallback(sessionId),
+      canUseTool: this.permissionHandler.createCallback(
+        sessionId,
+        cliAgentResolver,
+      ),
     };
   }
 

--- a/libs/backend/agent-sdk/src/lib/sdk-agent-adapter.ts
+++ b/libs/backend/agent-sdk/src/lib/sdk-agent-adapter.ts
@@ -804,6 +804,18 @@ export class SdkAgentAdapter implements IAIProvider {
   }
 
   /**
+   * Interrupt the current assistant turn without ending the session.
+   * The session remains active for continued use.
+   * Used when the user sends a message during autopilot execution.
+   */
+  async interruptCurrentTurn(sessionId: SessionId): Promise<boolean> {
+    this.logger.info(
+      `[SdkAgentAdapter] Interrupting current turn: ${sessionId}`,
+    );
+    return this.sessionLifecycle.interruptCurrentTurn(sessionId);
+  }
+
+  /**
    * Interrupt active session
    * Delegates to SessionLifecycleManager.endSession() which handles abort and cleanup
    */

--- a/libs/backend/agent-sdk/src/lib/sdk-permission-handler.ts
+++ b/libs/backend/agent-sdk/src/lib/sdk-permission-handler.ts
@@ -427,12 +427,19 @@ export class SdkPermissionHandler implements ISdkPermissionHandler {
     }
 
     // Convert PermissionRequest -> AgentPermissionRequest
+    let toolArgs: string;
+    try {
+      toolArgs = JSON.stringify(payload.toolInput);
+    } catch {
+      toolArgs = '[unable to serialize tool input]';
+    }
+
     const agentPermissionRequest: AgentPermissionRequest = {
       requestId: payload.id,
       agentId,
       kind: 'tool',
       toolName: payload.toolName,
-      toolArgs: JSON.stringify(payload.toolInput),
+      toolArgs,
       description: payload.description,
       timestamp: payload.timestamp,
       timeoutAt: payload.timeoutAt,

--- a/libs/backend/agent-sdk/src/lib/sdk-permission-handler.ts
+++ b/libs/backend/agent-sdk/src/lib/sdk-permission-handler.ts
@@ -38,6 +38,7 @@ import {
   isExitPlanModeToolInput,
   MESSAGE_TYPES,
   UNKNOWN_AGENT_TOOL_CALL_ID,
+  type AgentPermissionRequest,
   type QuestionItem,
   type PermissionRequest,
   type PermissionResponse,
@@ -159,7 +160,7 @@ interface WebviewManager {
     viewType: string,
     type: string,
     payload: T,
-  ): Promise<void>;
+  ): Promise<boolean>;
 }
 
 /**
@@ -296,8 +297,21 @@ export class SdkPermissionHandler implements ISdkPermissionHandler {
   /**
    * Send permission request to webview
    * TASK_2025_092: Replaced external emitter pattern with direct webview messaging
+   * TASK_2025_255: When cliAgentResolver returns an agentId, routes to agent monitor panel
    */
-  private sendPermissionRequest(payload: PermissionRequest): void {
+  private sendPermissionRequest(
+    payload: PermissionRequest,
+    cliAgentResolver?: () => string | undefined,
+  ): void {
+    // TASK_2025_255: Check if this is a CLI agent permission request.
+    // When the resolver returns an agentId, route to the agent monitor panel
+    // (same path as Copilot SDK permissions) instead of the chat UI badge.
+    const cliAgentId = cliAgentResolver?.();
+    if (cliAgentId) {
+      this.sendCliAgentPermissionRequest(payload, cliAgentId);
+      return;
+    }
+
     this.logger.info(`[SdkPermissionHandler] Permission event emitter called`, {
       payloadId: payload.id,
       payloadToolName: payload.toolName,
@@ -327,11 +341,37 @@ export class SdkPermissionHandler implements ISdkPermissionHandler {
 
     this.webviewManager
       .sendMessage('ptah.main', MESSAGE_TYPES.PERMISSION_REQUEST, payload)
-      .then(() => {
-        this.logger.info(
-          `[SdkPermissionHandler] Permission event sent to webview`,
-          { requestId: payload.id },
-        );
+      .then((delivered) => {
+        if (delivered) {
+          this.logger.info(
+            `[SdkPermissionHandler] Permission event sent to webview`,
+            { requestId: payload.id, sessionId: payload.sessionId },
+          );
+        } else {
+          // CRITICAL: sendMessage returns false when the webview isn't found.
+          // Without this check, the pending request hangs forever — the agent
+          // blocks indefinitely waiting for a response that will never come.
+          this.logger.warn(
+            `[SdkPermissionHandler] Permission event NOT delivered — webview "ptah.main" not found. ` +
+              `Denying to prevent permanent hang.`,
+            {
+              requestId: payload.id,
+              toolName: payload.toolName,
+              sessionId: payload.sessionId,
+            },
+          );
+          const pending = this.pendingRequests.get(payload.id);
+          if (pending) {
+            this.pendingRequests.delete(payload.id);
+            this.pendingRequestContext.delete(payload.id);
+            pending.resolve({
+              id: payload.id,
+              decision: 'deny',
+              reason:
+                'Permission request could not be delivered to UI (webview not available)',
+            });
+          }
+        }
       })
       .catch((error) => {
         this.logger.error(
@@ -354,6 +394,100 @@ export class SdkPermissionHandler implements ISdkPermissionHandler {
   }
 
   /**
+   * Send CLI agent permission request to agent monitor panel.
+   *
+   * Converts PermissionRequest to AgentPermissionRequest and broadcasts via
+   * AGENT_MONITOR_PERMISSION_REQUEST (same message type as Copilot permissions).
+   * This routes CLI agent permissions through the agent monitor panel instead
+   * of the broken chat UI badge.
+   *
+   * TASK_2025_255: Unified CLI agent permission channel
+   */
+  private sendCliAgentPermissionRequest(
+    payload: PermissionRequest,
+    agentId: string,
+  ): void {
+    if (!this.webviewManager) {
+      // Electron fallback: auto-approve (same as main agent path)
+      this.logger.warn(
+        `[SdkPermissionHandler] No WebviewManager available (Electron) — auto-resolving CLI agent permission`,
+        { requestId: payload.id, toolName: payload.toolName, agentId },
+      );
+      const pending = this.pendingRequests.get(payload.id);
+      if (pending) {
+        this.pendingRequests.delete(payload.id);
+        this.pendingRequestContext.delete(payload.id);
+        pending.resolve({
+          id: payload.id,
+          decision: 'allow',
+          reason: 'Auto-approved: no webview UI available (Electron)',
+        });
+      }
+      return;
+    }
+
+    // Convert PermissionRequest -> AgentPermissionRequest
+    const agentPermissionRequest: AgentPermissionRequest = {
+      requestId: payload.id,
+      agentId,
+      kind: 'tool',
+      toolName: payload.toolName,
+      toolArgs: JSON.stringify(payload.toolInput),
+      description: payload.description,
+      timestamp: payload.timestamp,
+      timeoutAt: payload.timeoutAt,
+    };
+
+    this.webviewManager
+      .sendMessage(
+        'ptah.main',
+        MESSAGE_TYPES.AGENT_MONITOR_PERMISSION_REQUEST,
+        agentPermissionRequest,
+      )
+      .then((delivered) => {
+        if (delivered) {
+          this.logger.info(
+            `[SdkPermissionHandler] CLI agent permission sent to agent monitor panel`,
+            { requestId: payload.id, agentId, toolName: payload.toolName },
+          );
+        } else {
+          // Deny on delivery failure (same safety as main agent path)
+          this.logger.warn(
+            `[SdkPermissionHandler] CLI agent permission NOT delivered — denying to prevent permanent hang`,
+            { requestId: payload.id, agentId, toolName: payload.toolName },
+          );
+          const pending = this.pendingRequests.get(payload.id);
+          if (pending) {
+            this.pendingRequests.delete(payload.id);
+            this.pendingRequestContext.delete(payload.id);
+            pending.resolve({
+              id: payload.id,
+              decision: 'deny',
+              reason:
+                'Permission request could not be delivered to UI (webview not available)',
+            });
+          }
+        }
+      })
+      .catch((error) => {
+        this.logger.error(
+          '[SdkPermissionHandler] Failed to send CLI agent permission',
+          { error, requestId: payload.id, agentId },
+        );
+        const pending = this.pendingRequests.get(payload.id);
+        if (pending) {
+          this.pendingRequests.delete(payload.id);
+          this.pendingRequestContext.delete(payload.id);
+          pending.resolve({
+            id: payload.id,
+            decision: 'deny',
+            reason: 'Failed to send permission request to UI',
+          });
+        }
+      });
+  }
+
+  /**
    * Create canUseTool callback for SDK query
    *
    * Returns a function matching SDK's CanUseTool signature that:
@@ -362,7 +496,10 @@ export class SdkPermissionHandler implements ISdkPermissionHandler {
    * 3. Requests user approval for MCP tools (can execute arbitrary code)
    * 4. Denies unknown tools (fail-safe)
    */
-  createCallback(sessionId?: string): CanUseTool {
+  createCallback(
+    sessionId?: string,
+    cliAgentResolver?: () => string | undefined,
+  ): CanUseTool {
     return async (
       toolName: string,
       input: Record<string, unknown>,
@@ -530,6 +667,7 @@ export class SdkPermissionHandler implements ISdkPermissionHandler {
           sessionId,
           options.agentID,
           options.signal,
+          cliAgentResolver,
         );
       }
 
@@ -545,6 +683,7 @@ export class SdkPermissionHandler implements ISdkPermissionHandler {
           sessionId,
           options.agentID,
           options.signal,
+          cliAgentResolver,
         );
       }
 
@@ -571,6 +710,7 @@ export class SdkPermissionHandler implements ISdkPermissionHandler {
           sessionId,
           options.agentID,
           options.signal,
+          cliAgentResolver,
         );
       }
 
@@ -586,6 +726,7 @@ export class SdkPermissionHandler implements ISdkPermissionHandler {
         sessionId,
         options.agentID,
         options.signal,
+        cliAgentResolver,
       );
     };
   }
@@ -602,6 +743,7 @@ export class SdkPermissionHandler implements ISdkPermissionHandler {
    * @param sessionId - Session ID for routing to correct tab
    * @param agentID - Sub-agent's short hex ID from SDK (if tool runs inside a subagent)
    * @param signal - AbortSignal from SDK for cancellation on session abort
+   * @param cliAgentResolver - Optional resolver for CLI agent ID; routes to agent monitor panel when defined
    */
   private async requestUserPermission(
     toolName: string,
@@ -610,6 +752,7 @@ export class SdkPermissionHandler implements ISdkPermissionHandler {
     sessionId?: string,
     agentID?: string,
     signal?: AbortSignal,
+    cliAgentResolver?: () => string | undefined,
   ): Promise<PermissionResult> {
     // TASK_2025_097: Timing diagnostics - capture start time for latency measurement
     const startTime = Date.now();
@@ -677,7 +820,7 @@ export class SdkPermissionHandler implements ISdkPermissionHandler {
       },
     );
 
-    this.sendPermissionRequest(request);
+    this.sendPermissionRequest(request, cliAgentResolver);
 
     // TASK_2025_097: Log emit latency for timing diagnostics
     this.logger.info(`[SdkPermissionHandler] Permission request emitted`, {

--- a/libs/backend/agent-sdk/src/lib/session-metadata-store.ts
+++ b/libs/backend/agent-sdk/src/lib/session-metadata-store.ts
@@ -401,19 +401,22 @@ export class SessionMetadataStore {
   }
 
   /**
-   * Rename session
+   * Rename session.
+   * Serialized through writeQueue to prevent lost updates from concurrent writes.
    */
   async rename(sessionId: string, newName: string): Promise<void> {
-    const metadata = await this.get(sessionId);
-    if (metadata) {
-      await this.save({
-        ...metadata,
-        name: newName,
-      });
-      this.logger.info(
-        `[SessionMetadataStore] Renamed session ${sessionId} to "${newName}"`,
-      );
-    }
+    return this.enqueueWrite(async () => {
+      const metadata = await this.get(sessionId);
+      if (metadata) {
+        await this._saveInternal({
+          ...metadata,
+          name: newName,
+        });
+        this.logger.info(
+          `[SessionMetadataStore] Renamed session ${sessionId} to "${newName}"`,
+        );
+      }
+    });
   }
 
   /**

--- a/libs/backend/rpc-handlers/src/lib/handlers/chat-rpc.handlers.ts
+++ b/libs/backend/rpc-handlers/src/lib/handlers/chat-rpc.handlers.ts
@@ -97,7 +97,7 @@ export class ChatRpcHandlers {
     @inject(SDK_TOKENS.SDK_SESSION_METADATA_STORE)
     private readonly sessionMetadataStore: SessionMetadataStore,
     @inject(PLATFORM_TOKENS.WORKSPACE_PROVIDER)
-    private readonly workspaceProvider: IWorkspaceProvider
+    private readonly workspaceProvider: IWorkspaceProvider,
   ) {}
 
   /**
@@ -111,6 +111,51 @@ export class ChatRpcHandlers {
   }
 
   /**
+   * Detect clear stop/cancel intent in a user message.
+   *
+   * Used in autopilot mode to decide whether to interrupt the current turn.
+   * Conservative matching — only triggers on unambiguous stop phrases to avoid
+   * false positives on steering messages like "stop using semicolons" or
+   * "cancel the old approach and try X instead".
+   *
+   * Patterns matched:
+   * - Standalone commands: "stop", "cancel", "abort", "halt", "quit"
+   * - Polite variants: "please stop", "stop please", "stop now"
+   * - Targeted: "stop it", "stop this", "stop that", "stop execution"
+   * - Descriptive: "stop what you're doing", "don't continue"
+   */
+  static hasStopIntent(message: string): boolean {
+    const trimmed = message.trim().toLowerCase();
+
+    // Standalone stop words (entire message is just a stop command)
+    // [.!]* allows multiple punctuation: "stop!!!", "cancel!!", "abort."
+    if (
+      /^(stop|cancel|abort|halt|quit|enough|nevermind|nvm)[.!]*$/.test(trimmed)
+    ) {
+      return true;
+    }
+
+    // Short messages (≤60 chars) with clear stop phrases.
+    // Length gate avoids false positives in longer steering messages like
+    // "stop using semicolons and switch to the new API pattern".
+    if (trimmed.length <= 60) {
+      const stopPhrases = [
+        // "stop", "please stop", "stop now", "stop it", etc. — must be at end of message
+        /\b(please\s+)?(stop|cancel|abort|halt)\s*(please|now|it|this|that|execution|running|everything|immediately)?[.!]*$/,
+        // "stop what you're doing"
+        /\bstop\s+what\s+you'?re?\s+(doing|running)/,
+        // "don't continue" — must be at end to avoid "don't continue with X, do Y instead"
+        /\bdon'?t\s+continue[.!]*$/,
+        // "stop the execution/agent/process"
+        /\bstop\s+the\s+(execution|agent|process|task)/,
+      ];
+      return stopPhrases.some((pattern) => pattern.test(trimmed));
+    }
+
+    return false;
+  }
+
+  /**
    * Check if a subagent's transcript file exists on disk.
    * Without a transcript, the SDK cannot resume the subagent.
    *
@@ -119,7 +164,7 @@ export class ChatRpcHandlers {
   private async hasSubagentTranscript(
     workspacePath: string,
     parentSessionId: string,
-    agentId: string
+    agentId: string,
   ): Promise<boolean> {
     try {
       const homeDir = os.homedir();
@@ -144,7 +189,7 @@ export class ChatRpcHandlers {
         projectDir,
         parentSessionId,
         'subagents',
-        `agent-${agentId}.jsonl`
+        `agent-${agentId}.jsonl`,
       );
 
       await fs.access(transcriptPath);
@@ -166,7 +211,7 @@ export class ChatRpcHandlers {
    */
   private async resolveEnhancedPromptsContent(
     workspacePath: string | undefined,
-    isPremium: boolean
+    isPremium: boolean,
   ): Promise<string | undefined> {
     if (!isPremium || !workspacePath) {
       return undefined;
@@ -175,7 +220,7 @@ export class ChatRpcHandlers {
     try {
       const content =
         await this.enhancedPromptsService.getEnhancedPromptContent(
-          workspacePath
+          workspacePath,
         );
       return content ?? undefined;
     } catch (error) {
@@ -183,7 +228,7 @@ export class ChatRpcHandlers {
         'Failed to resolve enhanced prompts content, using fallback',
         {
           error: error instanceof Error ? error.message : String(error),
-        }
+        },
       );
       return undefined;
     }
@@ -209,7 +254,7 @@ export class ChatRpcHandlers {
         return undefined;
       }
       const paths = this.pluginLoader.resolvePluginPaths(
-        config.enabledPluginIds
+        config.enabledPluginIds,
       );
       if (paths.length === 0) {
         return undefined;
@@ -254,7 +299,7 @@ export class ChatRpcHandlers {
    * as the main SdkAgentAdapter.
    */
   private async handlePtahCliStart(
-    params: ChatStartParams
+    params: ChatStartParams,
   ): Promise<ChatStartResult> {
     const { prompt, tabId, workspacePath, options, name } = params;
     const agentId = params.ptahCliId as string; // Guaranteed non-null by caller
@@ -295,7 +340,7 @@ export class ChatRpcHandlers {
     // Resolve enhanced prompts and plugins for premium users
     const enhancedPromptsContent = await this.resolveEnhancedPromptsContent(
       workspacePath,
-      isPremium
+      isPremium,
     );
     const pluginPaths = this.resolvePluginPaths(isPremium);
 
@@ -343,7 +388,7 @@ export class ChatRpcHandlers {
    * message sending to the correct adapter.
    */
   private async handlePtahCliContinue(
-    params: ChatContinueParams
+    params: ChatContinueParams,
   ): Promise<ChatContinueResult> {
     const { prompt, sessionId, tabId } = params;
     const ptahCliAgentId =
@@ -364,7 +409,7 @@ export class ChatRpcHandlers {
     const adapter = await this.ptahCliRegistry.getAdapter(ptahCliAgentId);
     if (!adapter) {
       this.logger.error(
-        `[RPC] Ptah CLI adapter not found for continue: ${ptahCliAgentId}`
+        `[RPC] Ptah CLI adapter not found for continue: ${ptahCliAgentId}`,
       );
       return {
         success: false,
@@ -385,7 +430,7 @@ export class ChatRpcHandlers {
     if (health.status !== 'available') {
       this.logger.warn(
         `[RPC] Ptah CLI adapter not available for continue: ${ptahCliAgentId}`,
-        { status: health.status }
+        { status: health.status },
       );
       return {
         success: false,
@@ -406,7 +451,7 @@ export class ChatRpcHandlers {
    * Handle chat:abort for Ptah CLI sessions.
    */
   private async handlePtahCliAbort(
-    params: ChatAbortParams
+    params: ChatAbortParams,
   ): Promise<ChatAbortResult> {
     const { sessionId } = params;
     const ptahCliAgentId = this.ptahCliSessions.get(sessionId as string);
@@ -528,7 +573,7 @@ export class ChatRpcHandlers {
                   tabId,
                   command: 'clear',
                   message: 'Starting fresh conversation.',
-                }
+                },
               );
               return { success: true };
             }
@@ -540,7 +585,7 @@ export class ChatRpcHandlers {
                 tabId,
                 command: interceptResult.commandName,
                 message: `No session data available yet for /${interceptResult.commandName}.`,
-              }
+              },
             );
             return { success: true };
           }
@@ -628,14 +673,14 @@ export class ChatRpcHandlers {
         } catch (error) {
           this.logger.error(
             'RPC: chat:start failed',
-            error instanceof Error ? error : new Error(String(error))
+            error instanceof Error ? error : new Error(String(error)),
           );
           return {
             success: false,
             error: error instanceof Error ? error.message : String(error),
           };
         }
-      }
+      },
     );
   }
 
@@ -670,10 +715,13 @@ export class ChatRpcHandlers {
             }
           }
 
+          // Track whether we just resumed — if so, there's no active turn to interrupt
+          let justResumed = false;
+
           // Check if session is active in memory
           if (!this.sdkAdapter.isSessionActive(sessionId)) {
             this.logger.info(
-              `[RPC] Session ${sessionId} not active, attempting resume...`
+              `[RPC] Session ${sessionId} not active, attempting resume...`,
             );
 
             // TASK_2025_108: Get license status for premium feature gating in resumed sessions
@@ -689,14 +737,14 @@ export class ChatRpcHandlers {
                 mcpServerRunning,
                 mcpPort: this.codeExecutionMcp.getPort(),
                 sessionId,
-              }
+              },
             );
 
             // TASK_2025_151: Resolve enhanced prompt content for premium users
             const enhancedPromptsContent =
               await this.resolveEnhancedPromptsContent(
                 workspacePath,
-                isPremium
+                isPremium,
               );
 
             // TASK_2025_153: Resolve plugin paths for premium users
@@ -708,7 +756,7 @@ export class ChatRpcHandlers {
                 hasEnhancedPrompts: !!enhancedPromptsContent,
                 enhancedPromptsLength: enhancedPromptsContent?.length ?? 0,
                 pluginCount: pluginPaths?.length ?? 0,
-              }
+              },
             );
 
             // Get current model: prefer frontend-provided model, then config, then hardcoded fallback
@@ -716,7 +764,7 @@ export class ChatRpcHandlers {
               params.model ||
               this.configManager.getWithDefault<string>(
                 'model.selected',
-                'sonnet'
+                'sonnet',
               );
 
             // Resume the session to reconnect to Claude's conversation context
@@ -740,6 +788,7 @@ export class ChatRpcHandlers {
             this.streamExecutionNodesToWebview(sessionId, stream, tabId);
 
             this.logger.info(`[RPC] Session ${sessionId} resumed successfully`);
+            justResumed = true;
           }
 
           // Extract files from params for debugging (Phase 2)
@@ -765,7 +814,7 @@ export class ChatRpcHandlers {
             sessionId,
             tabId,
             workspacePath,
-            params
+            params,
           );
           if (slashResult) {
             return slashResult;
@@ -795,7 +844,7 @@ export class ChatRpcHandlers {
                 parentSessionId: s.parentSessionId,
               })),
               workspacePath,
-            }
+            },
           );
 
           // Filter to only agents whose transcript files exist on disk.
@@ -806,7 +855,7 @@ export class ChatRpcHandlers {
               ? await this.hasSubagentTranscript(
                   workspacePath,
                   sessionId,
-                  s.agentId
+                  s.agentId,
                 )
               : false;
             if (hasTranscript) {
@@ -814,7 +863,7 @@ export class ChatRpcHandlers {
             } else {
               this.logger.warn(
                 'RPC: chat:continue - skipping agent without transcript on disk',
-                { agentId: s.agentId, agentType: s.agentType, sessionId }
+                { agentId: s.agentId, agentType: s.agentType, sessionId },
               );
               // Remove from registry — can't resume without transcript
               this.subagentRegistry.remove(s.toolCallId);
@@ -833,7 +882,7 @@ export class ChatRpcHandlers {
                   sessionId,
                   workspacePath,
                   subagent.agentType,
-                  subagent.toolCallId
+                  subagent.toolCallId,
                 );
               } catch (err) {
                 this.logger.warn(
@@ -841,7 +890,7 @@ export class ChatRpcHandlers {
                   {
                     agentId: subagent.agentId,
                     error: err instanceof Error ? err.message : String(err),
-                  }
+                  },
                 );
               }
             }
@@ -900,7 +949,39 @@ IMPORTANT INSTRUCTIONS:
             }
           }
 
-          // Default: passthrough — send as regular message (existing flow)
+          // AUTOPILOT STOP-INTENT INTERRUPT: In yolo/auto-edit mode, tool calls are
+          // auto-approved so the user has no checkpoint to stop the agent via tool denial.
+          // When the user sends a message with clear stop intent (e.g., "stop", "cancel"),
+          // interrupt the current turn so the SDK actually stops.
+          // Regular steering messages ("also update tests") pass through normally via
+          // streamInput() without interrupting — preserving the steering workflow.
+          // Skip if we just resumed — there's no active turn to interrupt.
+          if (!justResumed && ChatRpcHandlers.hasStopIntent(prompt)) {
+            const autopilotEnabled = this.configManager.getWithDefault<boolean>(
+              'autopilot.enabled',
+              false,
+            );
+            const permissionLevel = this.configManager.getWithDefault<string>(
+              'autopilot.permissionLevel',
+              'ask',
+            );
+            if (
+              autopilotEnabled &&
+              (permissionLevel === 'yolo' || permissionLevel === 'auto-edit')
+            ) {
+              this.logger.info(
+                'RPC: chat:continue - stop intent detected, interrupting current turn',
+                { sessionId, permissionLevel, prompt: prompt.substring(0, 80) },
+              );
+              await this.sdkAdapter.interruptCurrentTurn(sessionId);
+            }
+          }
+
+          // Send the message to the session (existing flow).
+          // Even after an interrupt, we still send the message: the interrupt stops the
+          // current assistant turn, and this message starts a new turn. The agent sees
+          // the user's "stop" message and can respond acknowledging it, rather than
+          // leaving the session in an ambiguous state with no user context.
           const images = params.images ?? [];
           await this.sdkAdapter.sendMessageToSession(
             sessionId,
@@ -908,21 +989,21 @@ IMPORTANT INSTRUCTIONS:
             {
               files,
               images,
-            }
+            },
           );
 
           return { success: true, sessionId };
         } catch (error) {
           this.logger.error(
             'RPC: chat:continue failed',
-            error instanceof Error ? error : new Error(String(error))
+            error instanceof Error ? error : new Error(String(error)),
           );
           return {
             success: false,
             error: error instanceof Error ? error.message : String(error),
           };
         }
-      }
+      },
     );
   }
 
@@ -939,7 +1020,7 @@ IMPORTANT INSTRUCTIONS:
     sessionId: SessionId,
     tabId: string,
     workspacePath: string | undefined,
-    params: ChatContinueParams
+    params: ChatContinueParams,
   ): Promise<ChatContinueResult | null> {
     const interceptResult = this.slashCommandInterceptor.intercept(prompt);
 
@@ -967,7 +1048,7 @@ IMPORTANT INSTRUCTIONS:
             command: 'clear',
             message:
               'Conversation cleared. Start a new message to begin fresh.',
-          }
+          },
         );
         return { success: true, sessionId };
       }
@@ -988,7 +1069,7 @@ IMPORTANT INSTRUCTIONS:
         {
           command: interceptResult.rawCommand,
           sessionId,
-        }
+        },
       );
 
       // Resolve premium config for the new query
@@ -997,7 +1078,7 @@ IMPORTANT INSTRUCTIONS:
       const mcpServerRunning = this.isMcpServerRunning();
       const enhancedPromptsContent = await this.resolveEnhancedPromptsContent(
         workspacePath,
-        isPremium
+        isPremium,
       );
       const pluginPaths = this.resolvePluginPaths(isPremium);
 
@@ -1015,7 +1096,7 @@ IMPORTANT INSTRUCTIONS:
               params.model ||
               this.configManager.getWithDefault<string>(
                 'model.selected',
-                'sonnet'
+                'sonnet',
               ),
             projectPath: workspacePath,
           } as AISessionConfig,
@@ -1024,7 +1105,7 @@ IMPORTANT INSTRUCTIONS:
           enhancedPromptsContent,
           pluginPaths,
           tabId,
-        }
+        },
       );
 
       // Reconnect streaming to the frontend
@@ -1076,13 +1157,13 @@ IMPORTANT INSTRUCTIONS:
           // Also includes aggregated usage stats from JSONL
           const { events, stats } = await this.historyReader.readSessionHistory(
             sessionId,
-            resolvedWorkspacePath
+            resolvedWorkspacePath,
           );
 
           // Also read simple messages for backward compatibility
           const messages = await this.historyReader.readHistoryAsMessages(
             sessionId,
-            resolvedWorkspacePath
+            resolvedWorkspacePath,
           );
 
           // TASK_2025_109: Register interrupted agents from history into SubagentRegistryService
@@ -1098,7 +1179,7 @@ IMPORTANT INSTRUCTIONS:
               {
                 sessionId,
                 registeredCount: registeredFromHistory,
-              }
+              },
             );
           }
 
@@ -1148,14 +1229,14 @@ IMPORTANT INSTRUCTIONS:
         } catch (error) {
           this.logger.error(
             'RPC: chat:resume failed',
-            error instanceof Error ? error : new Error(String(error))
+            error instanceof Error ? error : new Error(String(error)),
           );
           return {
             success: false,
             error: error instanceof Error ? error.message : String(error),
           };
         }
-      }
+      },
     );
   }
 
@@ -1187,14 +1268,14 @@ IMPORTANT INSTRUCTIONS:
         } catch (error) {
           this.logger.error(
             'RPC: chat:abort failed',
-            error instanceof Error ? error : new Error(String(error))
+            error instanceof Error ? error : new Error(String(error)),
           );
           return {
             success: false,
             error: error instanceof Error ? error.message : String(error),
           };
         }
-      }
+      },
     );
   }
 
@@ -1214,7 +1295,7 @@ IMPORTANT INSTRUCTIONS:
         this.logger.debug('RPC: chat:running-agents called', { sessionId });
 
         const running = this.subagentRegistry.getRunningBySession(
-          sessionId as string
+          sessionId as string,
         );
 
         return {
@@ -1226,7 +1307,7 @@ IMPORTANT INSTRUCTIONS:
       } catch (error) {
         this.logger.error(
           'RPC: chat:running-agents failed',
-          error instanceof Error ? error : new Error(String(error))
+          error instanceof Error ? error : new Error(String(error)),
         );
         return { agents: [] };
       }
@@ -1283,10 +1364,10 @@ IMPORTANT INSTRUCTIONS:
           .catch((err) => {
             this.logger.error(
               '[RPC] Failed to broadcast background agent completed event',
-              err instanceof Error ? err : new Error(String(err))
+              err instanceof Error ? err : new Error(String(err)),
             );
           });
-      }
+      },
     );
   }
 
@@ -1323,7 +1404,7 @@ IMPORTANT INSTRUCTIONS:
       } catch (error) {
         this.logger.error(
           'RPC: agent:backgroundList failed',
-          error instanceof Error ? error : new Error(String(error))
+          error instanceof Error ? error : new Error(String(error)),
         );
         return { agents: [] };
       }
@@ -1349,10 +1430,10 @@ IMPORTANT INSTRUCTIONS:
   private async streamExecutionNodesToWebview(
     sessionId: SessionId,
     stream: AsyncIterable<FlatStreamEventUnion>,
-    tabId: string
+    tabId: string,
   ): Promise<void> {
     this.logger.info(
-      `[RPC] streamExecutionNodesToWebview STARTED for session ${sessionId}, tabId ${tabId}`
+      `[RPC] streamExecutionNodesToWebview STARTED for session ${sessionId}, tabId ${tabId}`,
     );
     let eventCount = 0;
 
@@ -1377,7 +1458,7 @@ IMPORTANT INSTRUCTIONS:
             tabId,
             eventType: event.eventType,
             messageId: event.messageId,
-          }
+          },
         );
 
         // Save child session metadata for Ptah CLI sessions once the real
@@ -1401,7 +1482,7 @@ IMPORTANT INSTRUCTIONS:
             await this.sessionMetadataStore.createChild(
               event.sessionId,
               workspacePath,
-              sessionName
+              sessionName,
             );
             // Track SDK UUID for cross-referencing in CliSessionReference.
             // Store by both tabId and agentId so persistCliSessionReference
@@ -1412,12 +1493,12 @@ IMPORTANT INSTRUCTIONS:
             }
             this.logger.info(
               '[RPC] Child session metadata saved for Ptah CLI session',
-              { sessionId: event.sessionId, tabId, agentId: ptahCliAgentId }
+              { sessionId: event.sessionId, tabId, agentId: ptahCliAgentId },
             );
           } catch (err: unknown) {
             this.logger.warn(
               '[RPC] Failed to save child session metadata — session may appear in sidebar',
-              { error: err instanceof Error ? err.message : String(err) }
+              { error: err instanceof Error ? err.message : String(err) },
             );
           }
         }
@@ -1455,7 +1536,7 @@ IMPORTANT INSTRUCTIONS:
               {
                 toolCallId: bgEvent.toolCallId,
                 agentId: bgEvent.agentId,
-              }
+              },
             );
           }
         }
@@ -1464,7 +1545,7 @@ IMPORTANT INSTRUCTIONS:
           turnCompleteSent = true;
           this.logger.info(
             `[RPC] Turn complete - sending chat:complete for session ${sessionId}, tabId ${tabId}`,
-            { eventCount }
+            { eventCount },
           );
           await this.webviewManager.broadcastMessage(
             MESSAGE_TYPES.CHAT_COMPLETE,
@@ -1472,7 +1553,7 @@ IMPORTANT INSTRUCTIONS:
               tabId,
               sessionId,
               code: 0,
-            }
+            },
           );
         }
       }
@@ -1484,7 +1565,7 @@ IMPORTANT INSTRUCTIONS:
             tabId,
             sessionId,
             code: 0,
-          }
+          },
         );
       }
     } catch (error) {
@@ -1502,13 +1583,13 @@ IMPORTANT INSTRUCTIONS:
       if (isUserAbort) {
         // User aborts are expected behavior, log at INFO level
         this.logger.info(
-          `[RPC] Session ${sessionId} aborted by user after ${eventCount} events`
+          `[RPC] Session ${sessionId} aborted by user after ${eventCount} events`,
         );
       } else {
         // Real errors should be logged at ERROR level
         this.logger.error(
           `[RPC] Error streaming flat events for session ${sessionId}, tabId ${tabId} after ${eventCount} events`,
-          error instanceof Error ? error : new Error(String(error))
+          error instanceof Error ? error : new Error(String(error)),
         );
       }
 
@@ -1518,7 +1599,7 @@ IMPORTANT INSTRUCTIONS:
       const isCorruptedResume = eventCount === 0 && !isUserAbort;
       if (isCorruptedResume) {
         this.logger.warn(
-          `[RPC] Session ${sessionId} failed during resume (0 events), cleaning up dead session. Original error: ${errorMessage}`
+          `[RPC] Session ${sessionId} failed during resume (0 events), cleaning up dead session. Original error: ${errorMessage}`,
         );
         try {
           await this.sdkAdapter.endSession(sessionId);
@@ -1527,7 +1608,7 @@ IMPORTANT INSTRUCTIONS:
             `[RPC] Failed to clean up corrupted session ${sessionId}`,
             cleanupErr instanceof Error
               ? cleanupErr
-              : new Error(String(cleanupErr))
+              : new Error(String(cleanupErr)),
           );
         }
       }

--- a/libs/backend/rpc-handlers/src/lib/handlers/session-rpc.handlers.ts
+++ b/libs/backend/rpc-handlers/src/lib/handlers/session-rpc.handlers.ts
@@ -1,7 +1,8 @@
 /**
  * Session RPC Handlers
  *
- * Handles session-related RPC methods: session:list, session:load, session:delete, session:validate
+ * Handles session-related RPC methods: session:list, session:load, session:delete, session:rename,
+ * session:validate, session:cli-sessions, session:stats-batch
  * Uses SessionMetadataStore for lightweight UI metadata.
  * SDK handles message persistence natively to ~/.claude/projects/{sessionId}.jsonl
  *
@@ -23,6 +24,8 @@ import {
   SessionLoadParams,
   SessionLoadResult,
   CliSessionReference,
+  SessionRenameParams,
+  SessionRenameResult,
   SessionStatsBatchParams,
   SessionStatsBatchResult,
   SessionStatsEntry,
@@ -47,7 +50,7 @@ export class SessionRpcHandlers {
     @inject(SDK_TOKENS.SDK_SESSION_METADATA_STORE)
     private readonly metadataStore: SessionMetadataStore,
     @inject(SDK_TOKENS.SDK_SESSION_HISTORY_READER)
-    private readonly historyReader: SessionHistoryReaderService
+    private readonly historyReader: SessionHistoryReaderService,
   ) {}
 
   /**
@@ -57,6 +60,7 @@ export class SessionRpcHandlers {
     this.registerSessionList();
     this.registerSessionLoad();
     this.registerSessionDelete();
+    this.registerSessionRename();
     this.registerSessionValidate();
     this.registerSessionCliSessions();
     this.registerSessionStatsBatch();
@@ -66,6 +70,7 @@ export class SessionRpcHandlers {
         'session:list',
         'session:load',
         'session:delete',
+        'session:rename',
         'session:validate',
         'session:cli-sessions',
         'session:stats-batch',
@@ -90,9 +95,8 @@ export class SessionRpcHandlers {
           });
 
           // Get session metadata for workspace
-          const allSessions = await this.metadataStore.getForWorkspace(
-            workspacePath
-          );
+          const allSessions =
+            await this.metadataStore.getForWorkspace(workspacePath);
 
           // Already sorted by lastActiveAt in metadataStore
           const total = allSessions.length;
@@ -123,15 +127,15 @@ export class SessionRpcHandlers {
         } catch (error) {
           this.logger.error(
             'RPC: session:list failed',
-            error instanceof Error ? error : new Error(String(error))
+            error instanceof Error ? error : new Error(String(error)),
           );
           throw new Error(
             `Failed to list sessions: ${
               error instanceof Error ? error.message : String(error)
-            }`
+            }`,
           );
         }
-      }
+      },
     );
   }
 
@@ -167,7 +171,7 @@ export class SessionRpcHandlers {
             'RPC: session:load validated - call chat:resume next',
             {
               sessionId,
-            }
+            },
           );
 
           // Return empty arrays - actual messages loaded via chat:resume
@@ -179,15 +183,15 @@ export class SessionRpcHandlers {
         } catch (error) {
           this.logger.error(
             'RPC: session:load failed',
-            error instanceof Error ? error : new Error(String(error))
+            error instanceof Error ? error : new Error(String(error)),
           );
           throw new Error(
             `Failed to load session: ${
               error instanceof Error ? error.message : String(error)
-            }`
+            }`,
           );
         }
-      }
+      },
     );
   }
 
@@ -218,7 +222,7 @@ export class SessionRpcHandlers {
         } else {
           this.logger.warn(
             'RPC: session:delete - no workspace path in metadata, skipping file deletion',
-            { sessionId }
+            { sessionId },
           );
         }
 
@@ -228,7 +232,7 @@ export class SessionRpcHandlers {
       } catch (error) {
         this.logger.error(
           'RPC: session:delete failed',
-          error instanceof Error ? error : new Error(String(error))
+          error instanceof Error ? error : new Error(String(error)),
         );
         return {
           success: false,
@@ -236,6 +240,54 @@ export class SessionRpcHandlers {
         };
       }
     });
+  }
+
+  /**
+   * session:rename - Rename session metadata
+   */
+  private registerSessionRename(): void {
+    this.rpcHandler.registerMethod<SessionRenameParams, SessionRenameResult>(
+      'session:rename',
+      async (params: SessionRenameParams) => {
+        try {
+          const { sessionId, name } = params;
+          const trimmedName = name.trim();
+
+          if (!trimmedName || trimmedName.length > 200) {
+            return {
+              success: false,
+              error: 'Session name must be between 1 and 200 characters',
+            };
+          }
+
+          this.logger.info('RPC: session:rename called', {
+            sessionId,
+            name: trimmedName,
+          });
+
+          // Verify session exists before renaming
+          const metadata = await this.metadataStore.get(sessionId as string);
+          if (!metadata) {
+            return { success: false, error: 'Session not found' };
+          }
+
+          await this.metadataStore.rename(sessionId as string, trimmedName);
+
+          this.logger.info('RPC: session:rename succeeded', { sessionId });
+
+          return { success: true };
+        } catch (error) {
+          this.logger.error(
+            'RPC: session:rename failed',
+            error instanceof Error ? error : new Error(String(error)),
+          );
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+      },
+    );
   }
 
   /**
@@ -249,17 +301,17 @@ export class SessionRpcHandlers {
    */
   private async deleteSessionFiles(
     sessionId: string,
-    workspacePath: string
+    workspacePath: string,
   ): Promise<void> {
     const sessionFilePath = await this.findSessionFile(
       sessionId,
-      workspacePath
+      workspacePath,
     );
 
     if (!sessionFilePath) {
       this.logger.debug(
         'RPC: session:delete - JSONL file not found on disk (already deleted or never created)',
-        { sessionId }
+        { sessionId },
       );
       return;
     }
@@ -320,7 +372,7 @@ export class SessionRpcHandlers {
       try {
         const allFiles = await fs.readdir(sessionsDir);
         const agentFiles = allFiles.filter(
-          (f) => f.startsWith('agent-') && f.endsWith('.jsonl')
+          (f) => f.startsWith('agent-') && f.endsWith('.jsonl'),
         );
         for (const file of agentFiles) {
           const filePath = path.join(sessionsDir, file);
@@ -380,7 +432,7 @@ export class SessionRpcHandlers {
 
           const filePath = await this.findSessionFile(
             sessionId as string,
-            workspacePath
+            workspacePath,
           );
 
           if (filePath) {
@@ -398,11 +450,11 @@ export class SessionRpcHandlers {
         } catch (error) {
           this.logger.error(
             'RPC: session:validate failed',
-            error instanceof Error ? error : new Error(String(error))
+            error instanceof Error ? error : new Error(String(error)),
           );
           return { exists: false };
         }
-      }
+      },
     );
   }
 
@@ -429,14 +481,14 @@ export class SessionRpcHandlers {
         // CLI sessions. Real ptah-cli CLI sessions persisted by
         // persistCliSessionReference() always have a ptahCliId set.
         const cliSessions = raw.filter(
-          (ref) => ref.cli !== 'ptah-cli' || ref.ptahCliId
+          (ref) => ref.cli !== 'ptah-cli' || ref.ptahCliId,
         );
 
         return { cliSessions };
       } catch (error) {
         this.logger.error(
           'RPC: session:cli-sessions failed',
-          error instanceof Error ? error : new Error(String(error))
+          error instanceof Error ? error : new Error(String(error)),
         );
         return { cliSessions: [] };
       }
@@ -475,7 +527,7 @@ export class SessionRpcHandlers {
             try {
               const { stats } = await this.historyReader.readSessionHistory(
                 sessionId,
-                workspacePath
+                workspacePath,
               );
 
               // Get CLI agent types from metadata (gemini, codex, copilot, ptah-cli)
@@ -531,7 +583,7 @@ export class SessionRpcHandlers {
                 status: 'error' as const,
               };
             }
-          })
+          }),
         );
 
         for (let j = 0; j < results.length; j++) {
@@ -551,7 +603,7 @@ export class SessionRpcHandlers {
                   },
                   messageCount: 0,
                   status: 'error' as const,
-                }
+                },
           );
         }
       }
@@ -575,7 +627,7 @@ export class SessionRpcHandlers {
    */
   private async findSessionFile(
     sessionId: string,
-    workspacePath: string
+    workspacePath: string,
   ): Promise<string | null> {
     const homeDir = os.homedir();
     const projectsDir = path.join(homeDir, '.claude', 'projects');
@@ -612,7 +664,7 @@ export class SessionRpcHandlers {
         sessionDir = dirs.find(
           (d) =>
             d.toLowerCase().includes(workspaceName.toLowerCase()) ||
-            normalize(d).includes(normalize(workspaceName))
+            normalize(d).includes(normalize(workspaceName)),
         );
       }
     }
@@ -624,7 +676,7 @@ export class SessionRpcHandlers {
     const sessionFilePath = path.join(
       projectsDir,
       sessionDir,
-      `${sessionId}.jsonl`
+      `${sessionId}.jsonl`,
     );
 
     try {

--- a/libs/backend/vscode-lm-tools/package.json
+++ b/libs/backend/vscode-lm-tools/package.json
@@ -19,6 +19,7 @@
     "chrome-launcher": "^1.2.1",
     "chrome-remote-interface": "^0.34.0",
     "jpeg-js": "^0.4.4",
-    "gifenc": "^1.0.3"
+    "gifenc": "^1.0.3",
+    "cross-spawn": "^7.0.6"
   }
 }

--- a/libs/backend/vscode-lm-tools/src/index.ts
+++ b/libs/backend/vscode-lm-tools/src/index.ts
@@ -46,7 +46,10 @@ export type {
 } from './lib/code-execution/services/web-search-provider.interface';
 
 // Browser capabilities exports (TASK_2025_244)
-export type { IBrowserCapabilities } from './lib/code-execution/namespace-builders/browser-namespace.builder';
+export type {
+  IBrowserCapabilities,
+  BrowserSessionOptions,
+} from './lib/code-execution/namespace-builders/browser-namespace.builder';
 export { ChromeLauncherBrowserCapabilities } from './lib/code-execution/services/chrome-launcher-browser-capabilities';
 
 // Screen Recorder Service export (TASK_2025_254)

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-handlers/mcp-response-formatter.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-handlers/mcp-response-formatter.ts
@@ -1124,6 +1124,9 @@ export function formatBrowserStatus(result: BrowserStatusResult): string {
     if (result.headless !== undefined) {
       statusText += `  \n**Mode:** ${result.headless ? 'Headless' : 'Visible'}`;
     }
+    if (result.viewport) {
+      statusText += `  \n**Viewport:** ${result.viewport.width}x${result.viewport.height}`;
+    }
     if (result.recording !== undefined) {
       statusText += `  \n**Recording:** ${result.recording ? 'Active' : 'Inactive'}`;
     }

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-handlers/protocol-handlers.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-handlers/protocol-handlers.ts
@@ -734,9 +734,11 @@ async function handleIndividualTool(
 
       // Browser automation tools (TASK_2025_244)
       case 'ptah_browser_navigate': {
-        const { url, waitForLoad } = args as {
+        const { url, waitForLoad, headless, viewport } = args as {
           url: string;
           waitForLoad?: boolean;
+          headless?: boolean;
+          viewport?: { width: number; height: number };
         };
 
         if (!url || typeof url !== 'string' || !url.trim()) {
@@ -758,6 +760,8 @@ async function handleIndividualTool(
         const navResult = await ptahAPI.browser.navigate({
           url: url.trim(),
           waitForLoad,
+          headless,
+          viewport,
         });
         return createToolSuccessResponse(
           request,

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-handlers/protocol-handlers.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-handlers/protocol-handlers.ts
@@ -738,7 +738,7 @@ async function handleIndividualTool(
           url: string;
           waitForLoad?: boolean;
           headless?: boolean;
-          viewport?: { width: number; height: number };
+          viewport?: { width: number; height: number }; // MCP JSON input; validated in namespace builder
         };
 
         if (!url || typeof url !== 'string' || !url.trim()) {

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-handlers/tool-description.builder.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-handlers/tool-description.builder.ts
@@ -656,10 +656,17 @@ export function buildBrowserNavigateTool(): MCPToolDefinition {
             'Browser viewport dimensions (default: 1920x1080 desktop). ' +
             'Common presets: desktop 1920x1080, tablet 768x1024, mobile 375x812.',
           properties: {
-            width: { type: 'number', description: 'Viewport width in pixels' },
+            width: {
+              type: 'integer',
+              description: 'Viewport width in pixels',
+              minimum: 1,
+              maximum: 7680,
+            },
             height: {
-              type: 'number',
+              type: 'integer',
               description: 'Viewport height in pixels',
+              minimum: 1,
+              maximum: 7680,
             },
           },
           required: ['width', 'height'],

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-handlers/tool-description.builder.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-handlers/tool-description.builder.ts
@@ -629,7 +629,8 @@ export function buildBrowserNavigateTool(): MCPToolDefinition {
     description:
       'Navigate the browser to a URL. Lazily starts a browser session if none exists. ' +
       'Returns the final URL and page title after load. Only http/https URLs are allowed. ' +
-      'Localhost is blocked by default (enable via ptah.browser.allowLocalhost setting).',
+      'Localhost is blocked by default (enable via ptah.browser.allowLocalhost setting). ' +
+      'You can control headless mode and viewport size — these take effect when creating a new session.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -641,6 +642,27 @@ export function buildBrowserNavigateTool(): MCPToolDefinition {
           type: 'boolean',
           description:
             'Wait for the page load event before returning (default: true)',
+        },
+        headless: {
+          type: 'boolean',
+          description:
+            'Run browser in headless mode — no visible window (default: false). ' +
+            'Set to true for background scraping/testing. Set to false (default) for visual verification ' +
+            'or when the user needs to interact (login, 2FA, CAPTCHA).',
+        },
+        viewport: {
+          type: 'object',
+          description:
+            'Browser viewport dimensions (default: 1920x1080 desktop). ' +
+            'Common presets: desktop 1920x1080, tablet 768x1024, mobile 375x812.',
+          properties: {
+            width: { type: 'number', description: 'Viewport width in pixels' },
+            height: {
+              type: 'number',
+              description: 'Viewport height in pixels',
+            },
+          },
+          required: ['width', 'height'],
         },
       },
       required: ['url'],
@@ -834,7 +856,8 @@ export function buildBrowserStatusTool(): MCPToolDefinition {
     name: 'ptah_browser_status',
     description:
       'Get the current browser session status. Returns whether a session is active, the current URL, ' +
-      'page title, uptime, and time until auto-close. Use to check if a browser session exists before starting one.',
+      'page title, uptime, time until auto-close, headless mode, and viewport dimensions. ' +
+      'Use to check if a browser session exists before starting one.',
     inputSchema: {
       type: 'object',
       properties: {},
@@ -903,7 +926,7 @@ export function buildBrowserWaitForUserTool(): MCPToolDefinition {
     description:
       'Pause the agent and prompt the user to perform manual actions in the visible browser window ' +
       '(e.g., login, 2FA, CAPTCHA). The agent resumes when the user clicks Ready. ' +
-      'Requires visible browser mode (ptah.browser.headless = false). ' +
+      'Requires visible browser mode (headless must be false when starting the session via ptah_browser_navigate). ' +
       'The browser session inactivity timer is paused during the wait.',
     inputSchema: {
       type: 'object',

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/agent-namespace.builder.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/agent-namespace.builder.ts
@@ -68,8 +68,12 @@ interface PtahCliRegistryLike {
       projectGuidance?: string;
       workingDirectory?: string;
       resumeSessionId?: string;
+      parentSessionId?: string;
     },
-  ): Promise<{ handle: SdkHandle; agentName: string } | SpawnAgentFailure>;
+  ): Promise<
+    | { handle: SdkHandle; agentName: string; setAgentId: (id: string) => void }
+    | SpawnAgentFailure
+  >;
 }
 
 /**
@@ -142,6 +146,7 @@ export function buildAgentNamespace(
             projectGuidance,
             workingDirectory,
             resumeSessionId: request.resumeSessionId,
+            parentSessionId: activeSessionId,
           },
         );
         if ('status' in result) {
@@ -151,17 +156,25 @@ export function buildAgentNamespace(
           );
         }
 
-        return agentProcessManager.spawnFromSdkHandle(result.handle, {
-          task: request.task,
-          cli: 'ptah-cli',
-          workingDirectory,
-          taskFolder: request.taskFolder,
-          parentSessionId: activeSessionId,
-          ptahCliName: result.agentName,
-          ptahCliId: request.ptahCliId,
-          timeout: request.timeout,
-          resumeSessionId: request.resumeSessionId,
-        });
+        const spawnResult = await agentProcessManager.spawnFromSdkHandle(
+          result.handle,
+          {
+            task: request.task,
+            cli: 'ptah-cli',
+            workingDirectory,
+            taskFolder: request.taskFolder,
+            parentSessionId: activeSessionId,
+            ptahCliName: result.agentName,
+            ptahCliId: request.ptahCliId,
+            timeout: request.timeout,
+            resumeSessionId: request.resumeSessionId,
+          },
+        );
+
+        // TASK_2025_255: Wire agentId so CLI permission requests route to agent monitor panel
+        result.setAgentId(spawnResult.agentId);
+
+        return spawnResult;
       }
 
       // Check if the requested CLI type is disabled by the user

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/browser-namespace.builder.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/browser-namespace.builder.ts
@@ -25,6 +25,7 @@ import type {
   BrowserRecordStartResult,
   BrowserRecordStopResult,
   BrowserWaitForUserResult,
+  ViewportDimensions,
 } from '../types';
 
 // ========================================
@@ -53,7 +54,7 @@ export interface BrowserSessionOptions {
   /** Whether to run in headless mode (default: false — visible browser) */
   headless?: boolean;
   /** Viewport dimensions (default: 1920x1080 — desktop) */
-  viewport?: { width: number; height: number };
+  viewport?: ViewportDimensions;
 }
 
 export interface IBrowserCapabilities {
@@ -115,7 +116,7 @@ export interface IBrowserCapabilities {
     autoCloseInMs?: number;
     headless?: boolean;
     recording?: boolean;
-    viewport?: { width: number; height: number };
+    viewport?: ViewportDimensions;
   }>;
 
   isConnected(): boolean;
@@ -290,18 +291,35 @@ function buildCapabilityBackedBrowserNamespace(
         };
       }
 
+      // Validate viewport dimensions if provided
+      if (params.viewport) {
+        const { width, height } = params.viewport;
+        if (
+          !Number.isInteger(width) ||
+          !Number.isInteger(height) ||
+          width < 1 ||
+          height < 1 ||
+          width > 7680 ||
+          height > 7680
+        ) {
+          return {
+            success: false,
+            url: params.url,
+            title: '',
+            error:
+              'Invalid viewport dimensions. Width and height must be positive integers between 1 and 7680.',
+          };
+        }
+      }
+
       try {
         // Pass agent-controlled session options (headless, viewport) to capabilities.
         // These only take effect when creating a NEW session.
-        const sessionOptions: BrowserSessionOptions = {};
-        if (params.headless !== undefined) {
-          sessionOptions.headless = params.headless;
-        }
-        if (params.viewport) {
-          sessionOptions.viewport = params.viewport;
-        }
-        if (Object.keys(sessionOptions).length > 0) {
-          capabilities.configureSession(sessionOptions);
+        if (params.headless !== undefined || params.viewport) {
+          capabilities.configureSession({
+            ...(params.headless !== undefined && { headless: params.headless }),
+            ...(params.viewport && { viewport: params.viewport }),
+          });
         }
 
         return await capabilities.navigate(

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/browser-namespace.builder.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/browser-namespace.builder.ts
@@ -44,7 +44,29 @@ import type {
  * In standalone/fallback mode, this interface is NOT provided, and
  * buildBrowserNamespace() returns graceful degradation stubs instead.
  */
+/**
+ * Session options that the agent can configure before a browser session is created.
+ * These only take effect when creating a NEW session — if a session already exists,
+ * they are stored for the next session creation.
+ */
+export interface BrowserSessionOptions {
+  /** Whether to run in headless mode (default: false — visible browser) */
+  headless?: boolean;
+  /** Viewport dimensions (default: 1920x1080 — desktop) */
+  viewport?: { width: number; height: number };
+}
+
 export interface IBrowserCapabilities {
+  /**
+   * Configure session options for the next browser session creation.
+   * These options are consumed by ensureSession()/createSession() when
+   * a new session is lazily started (e.g., on first navigate call).
+   *
+   * If a session already exists, the options are stored and will apply
+   * when the current session is closed and a new one is created.
+   */
+  configureSession(options: BrowserSessionOptions): void;
+
   navigate(
     url: string,
     waitForLoad?: boolean,
@@ -93,6 +115,7 @@ export interface IBrowserCapabilities {
     autoCloseInMs?: number;
     headless?: boolean;
     recording?: boolean;
+    viewport?: { width: number; height: number };
   }>;
 
   isConnected(): boolean;
@@ -195,9 +218,8 @@ const BROWSER_NOT_AVAILABLE_MSG =
 export interface BrowserNamespaceDependencies {
   capabilities?: IBrowserCapabilities;
   getAllowLocalhost?: () => boolean;
-  /** Returns whether the browser should run in headless mode (TASK_2025_254) */
-  getHeadless?: () => boolean;
   // Note: recordingDir is configured via the capabilities constructor, not here.
+  // Note: headless and viewport are agent-controlled via navigate params, not settings.
   /**
    * Wait-for-user implementation (TASK_2025_254).
    * In VS Code: uses WebviewManager + PermissionPromptService.
@@ -229,7 +251,7 @@ export interface BrowserNamespaceDependencies {
 export function buildBrowserNamespace(
   deps: BrowserNamespaceDependencies,
 ): BrowserNamespace {
-  const { capabilities, getAllowLocalhost, getHeadless, waitForUser } = deps;
+  const { capabilities, getAllowLocalhost, waitForUser } = deps;
 
   if (!capabilities) {
     return buildGracefulBrowserNamespace();
@@ -238,7 +260,6 @@ export function buildBrowserNamespace(
   return buildCapabilityBackedBrowserNamespace(
     capabilities,
     getAllowLocalhost,
-    getHeadless,
     waitForUser,
   );
 }
@@ -250,7 +271,6 @@ export function buildBrowserNamespace(
 function buildCapabilityBackedBrowserNamespace(
   capabilities: IBrowserCapabilities,
   getAllowLocalhost?: () => boolean,
-  getHeadless?: () => boolean,
   waitForUser?: (params: {
     message: string;
     timeout?: number;
@@ -271,6 +291,19 @@ function buildCapabilityBackedBrowserNamespace(
       }
 
       try {
+        // Pass agent-controlled session options (headless, viewport) to capabilities.
+        // These only take effect when creating a NEW session.
+        const sessionOptions: BrowserSessionOptions = {};
+        if (params.headless !== undefined) {
+          sessionOptions.headless = params.headless;
+        }
+        if (params.viewport) {
+          sessionOptions.viewport = params.viewport;
+        }
+        if (Object.keys(sessionOptions).length > 0) {
+          capabilities.configureSession(sessionOptions);
+        }
+
         return await capabilities.navigate(
           params.url,
           params.waitForLoad ?? true,
@@ -434,16 +467,14 @@ function buildCapabilityBackedBrowserNamespace(
         };
       }
 
-      // Check the session's actual headless state (not the live config setting,
-      // which may have changed after session creation)
+      // Check the session's actual headless state
       const statusResult = await capabilities.status();
-      const isHeadless = statusResult.headless ?? getHeadless?.() ?? true;
-      if (isHeadless) {
+      if (statusResult.headless) {
         return {
           ready: false,
           waitDurationMs: 0,
           error:
-            'Wait-for-user requires visible browser mode. Set ptah.browser.headless to false in settings and restart the browser session.',
+            'Wait-for-user requires visible browser mode. Close the current session and start a new one with headless=false in ptah_browser_navigate.',
         };
       }
 

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.ts
@@ -3,14 +3,13 @@
  * TASK_2025_236: Git worktree MCP tools for AI agent access
  *
  * Provides worktreeList, worktreeAdd, worktreeRemove methods for managing
- * git worktrees via the CLI. Uses child_process.execFile WITHOUT shell: true
- * to prevent command injection. On Windows, uses 'git.cmd' as the executable
- * since git is distributed as a .cmd wrapper.
+ * git worktrees via the CLI. Uses cross-spawn for cross-platform compatibility
+ * (handles Windows .cmd wrappers automatically without shell: true).
  *
  * Pattern: namespace-builders/agent-namespace.builder.ts
  */
 
-import { execFile } from 'child_process';
+import crossSpawn from 'cross-spawn';
 import * as path from 'path';
 import type { GitNamespace } from '../types';
 import {
@@ -21,18 +20,32 @@ import {
 const GIT_TIMEOUT_MS = 10_000;
 
 /**
+ * Callback for worktree change notifications.
+ * Fired after a worktree is successfully added or removed via the MCP tool,
+ * so the frontend can refresh its worktree list and file explorer.
+ */
+export type WorktreeChangeCallback = (event: {
+  action: 'created' | 'removed';
+  worktreePath?: string;
+  branch?: string;
+}) => void;
+
+/**
  * Dependencies required to build the git namespace.
  * workspaceRoot is the absolute path to the current workspace directory.
  */
 export interface GitNamespaceDependencies {
   workspaceRoot: string;
+  /** Optional callback fired after worktree add/remove to notify frontend */
+  onWorktreeChanged?: WorktreeChangeCallback;
 }
 
 /**
  * Build the git namespace with worktree operations.
  *
- * All git commands are executed via child_process.execFile with a 10-second timeout.
- * On Windows, 'git.cmd' is used as the executable (shell: false to prevent injection).
+ * All git commands are executed via cross-spawn with a 10-second timeout.
+ * cross-spawn handles Windows .cmd wrappers automatically, preventing
+ * EINVAL/ENOENT errors without needing shell: true.
  *
  * @param deps - Dependencies containing the workspace root path
  * @returns GitNamespace with worktreeList, worktreeAdd, worktreeRemove methods
@@ -40,56 +53,62 @@ export interface GitNamespaceDependencies {
 export function buildGitNamespace(
   deps: GitNamespaceDependencies,
 ): GitNamespace {
-  const { workspaceRoot } = deps;
-
-  /**
-   * Platform-specific git executable.
-   * On Windows, git is distributed as a .cmd wrapper, so we must use 'git.cmd'
-   * when NOT using shell: true. This avoids ENOENT errors on Windows while
-   * keeping shell: false to prevent command injection.
-   *
-   * @see apps/ptah-electron/src/services/git-info.service.ts for the cross-spawn pattern
-   */
-  const gitExecutable = process.platform === 'win32' ? 'git.cmd' : 'git';
+  const { workspaceRoot, onWorktreeChanged } = deps;
 
   /**
    * Execute a git command and return stdout/stderr/exitCode.
-   * Uses execFile WITHOUT shell: true to prevent command injection from
-   * AI-provided branch names and paths. On Windows, 'git.cmd' is used
-   * as the executable to handle the .cmd wrapper.
+   * Uses cross-spawn which handles Windows .cmd wrappers automatically,
+   * preventing EINVAL errors while keeping command injection safety
+   * (no shell: true needed).
+   *
+   * @see apps/ptah-electron/src/services/git-info.service.ts for the same pattern
    */
   function execGit(
     args: string[],
   ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
     return new Promise((resolve, reject) => {
-      execFile(
-        gitExecutable,
-        args,
-        {
-          cwd: workspaceRoot,
-          timeout: GIT_TIMEOUT_MS,
-          maxBuffer: 1024 * 1024, // 1MB buffer for large worktree lists
-        },
-        (error, stdout, stderr) => {
-          if (error && 'killed' in error && error.killed) {
-            reject(
-              new Error(`git ${args[0]} timed out after ${GIT_TIMEOUT_MS}ms`),
-            );
-            return;
-          }
+      const child = crossSpawn('git', args, {
+        cwd: workspaceRoot,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
 
-          // execFile treats non-zero exit codes as errors,
-          // but we want to handle them gracefully.
-          // Node.js ExecFileException uses string codes (e.g. 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'),
-          // so we simply use exit code 1 as fallback when error is truthy.
-          const exitCode = error ? 1 : 0;
-          resolve({
-            stdout: typeof stdout === 'string' ? stdout : '',
-            stderr: typeof stderr === 'string' ? stderr : '',
-            exitCode,
-          });
-        },
-      );
+      let stdout = '';
+      let stderr = '';
+      let settled = false;
+
+      const timeout = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          child.kill('SIGTERM');
+          reject(
+            new Error(`git ${args[0]} timed out after ${GIT_TIMEOUT_MS}ms`),
+          );
+        }
+      }, GIT_TIMEOUT_MS);
+
+      child.stdout?.on('data', (data: Buffer) => {
+        stdout += data.toString();
+      });
+
+      child.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      child.on('close', (code: number | null) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeout);
+          resolve({ stdout, stderr, exitCode: code ?? 1 });
+        }
+      });
+
+      child.on('error', (error: Error) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeout);
+          reject(error);
+        }
+      });
     });
   }
 
@@ -143,6 +162,19 @@ export function buildGitNamespace(
           };
         }
 
+        // Notify frontend about the new worktree so it can refresh UI
+        if (onWorktreeChanged) {
+          try {
+            onWorktreeChanged({
+              action: 'created',
+              worktreePath,
+              branch: params.branch,
+            });
+          } catch {
+            // Notification failure should never break worktree creation
+          }
+        }
+
         return { success: true, worktreePath };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -168,6 +200,18 @@ export function buildGitNamespace(
             success: false,
             error: stderr.trim() || 'Failed to remove worktree',
           };
+        }
+
+        // Notify frontend about the removal so it can refresh UI
+        if (onWorktreeChanged) {
+          try {
+            onWorktreeChanged({
+              action: 'removed',
+              worktreePath: params.path,
+            });
+          } catch {
+            // Notification failure should never break worktree removal
+          }
         }
 
         return { success: true };

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/index.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/index.ts
@@ -71,6 +71,7 @@ export {
 export {
   buildBrowserNamespace,
   type IBrowserCapabilities,
+  type BrowserSessionOptions,
   type BrowserNamespaceDependencies,
   validateBrowserUrl,
 } from './browser-namespace.builder';

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/ptah-api-builder.service.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/ptah-api-builder.service.ts
@@ -443,6 +443,7 @@ export class PtahAPIBuilder {
                         onOutput: (cb: (data: string) => void) => void;
                       };
                       agentName: string;
+                      setAgentId: (id: string) => void;
                     }
                   | {
                       status:
@@ -480,8 +481,13 @@ export class PtahAPIBuilder {
       ),
 
       // Git worktree namespace (TASK_2025_236)
+      // Wires onWorktreeChanged callback to broadcast git:worktreeChanged
+      // to the frontend when MCP tools create/remove worktrees.
       git: this.buildNamespaceSafe('git', () =>
-        buildGitNamespace({ workspaceRoot }),
+        buildGitNamespace({
+          workspaceRoot,
+          onWorktreeChanged: this.buildWorktreeChangeHandler(),
+        }),
       ),
 
       // JSON validation namespace (TASK_2025_240)
@@ -495,6 +501,7 @@ export class PtahAPIBuilder {
       // Browser automation namespace (TASK_2025_244)
       // Resolved lazily: if BROWSER_CAPABILITIES_TOKEN is not registered,
       // buildBrowserNamespace receives undefined capabilities and returns graceful degradation stubs.
+      // Headless/viewport are agent-controlled via ptah_browser_navigate params (not settings).
       browser: this.buildNamespaceSafe('browser', () =>
         buildBrowserNamespace({
           capabilities: this.resolveBrowserCapabilities(),
@@ -504,15 +511,8 @@ export class PtahAPIBuilder {
               'allowLocalhost',
               false,
             ) ?? false,
-          // TASK_2025_254: Headless mode config accessor
-          getHeadless: () =>
-            this.workspaceProvider.getConfiguration<boolean>(
-              'ptah.browser',
-              'headless',
-              true,
-            ) ?? true,
           // Note: recordingDir is configured via capabilities constructor, not namespace deps
-          // TASK_2025_254: Wait-for-user handler (VS Code only, undefined in Electron)
+          // Wait-for-user handler (VS Code only, undefined in Electron)
           waitForUser: this.buildWaitForUserHandler(),
         }),
       ),
@@ -588,6 +588,56 @@ export class PtahAPIBuilder {
     }
     // Fallback to current working directory
     return process.cwd();
+  }
+
+  /**
+   * Build a worktree change handler that broadcasts git:worktreeChanged
+   * to the frontend via WebviewManager when MCP tools create/remove worktrees.
+   *
+   * WebviewManager is resolved lazily on each invocation (not at build time)
+   * to handle cases where the manager is registered after PtahAPIBuilder.build().
+   */
+  private buildWorktreeChangeHandler(): (event: {
+    action: 'created' | 'removed';
+    worktreePath?: string;
+    branch?: string;
+  }) => void {
+    const logger = this.logger;
+
+    return (event) => {
+      // Lazy resolution: check and resolve on each invocation
+      if (!container.isRegistered(TOKENS.WEBVIEW_MANAGER)) {
+        logger.debug(
+          '[PtahAPIBuilder] WebviewManager not registered, skipping worktree notification',
+        );
+        return;
+      }
+
+      let webviewManager: WebviewManager;
+      try {
+        webviewManager = container.resolve<WebviewManager>(
+          TOKENS.WEBVIEW_MANAGER,
+        );
+      } catch {
+        return;
+      }
+
+      logger.info(
+        `[PtahAPIBuilder] MCP worktree ${event.action}: ${event.worktreePath ?? event.branch}`,
+      );
+      webviewManager
+        .broadcastMessage('git:worktreeChanged', {
+          action: event.action,
+          name: event.branch,
+          path: event.worktreePath,
+        })
+        .catch((error) => {
+          logger.error(
+            '[PtahAPIBuilder] Failed to send git:worktreeChanged',
+            error instanceof Error ? error : new Error(String(error)),
+          );
+        });
+    };
   }
 
   /**

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/ptah-system-prompt.constant.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/ptah-system-prompt.constant.ts
@@ -40,8 +40,16 @@ Validate and repair a JSON file. Extracts JSON from agent output (strips markdow
 
 You have browser automation tools that let you navigate web pages, take screenshots, execute JavaScript, interact with elements, and monitor network requests. A browser session starts lazily on first use and auto-closes after 5 minutes of inactivity or 30 minutes total.
 
-### ptah_browser_navigate { url, waitForLoad? }
+You control the browser mode and viewport at session creation time via ptah_browser_navigate parameters:
+- **headless** (default: false) — set to true for background scraping/testing, false for visible browser
+- **viewport** (default: 1920x1080 desktop) — set dimensions for responsive testing (e.g., 768x1024 tablet, 375x812 mobile)
+
+These settings apply when creating a NEW session. To change them, close the current session first.
+
+### ptah_browser_navigate { url, waitForLoad?, headless?, viewport? }
 Navigate to a URL (http/https only). Starts browser session if none exists. Returns final URL and page title.
+- headless: false (default) = visible browser, true = no window
+- viewport: { width, height } — default 1920x1080
 
 ### ptah_browser_screenshot { format?, quality?, fullPage? }
 Capture a screenshot. Returns base64-encoded image data. Use for visual verification.
@@ -65,16 +73,25 @@ Read captured network requests (URL, method, status, type, size).
 Close the browser session and release resources.
 
 ### ptah_browser_status (no parameters)
-Check if a browser session is active, current URL, uptime, auto-close countdown.
+Check if a browser session is active, current URL, uptime, auto-close countdown, headless mode, viewport.
 
 ### Browser Workflow Example
 
-1. **Navigate**: \`ptah_browser_navigate { url: "https://example.com" }\`
+1. **Navigate**: \`ptah_browser_navigate { url: "https://example.com" }\` — visible desktop browser
 2. **Read page**: \`ptah_browser_content {}\` — understand the page structure
 3. **Interact**: \`ptah_browser_click { selector: "#login-btn" }\` or \`ptah_browser_type { selector: "#email", text: "user@example.com" }\`
 4. **Verify**: \`ptah_browser_screenshot {}\` — visual confirmation
 5. **Check API calls**: \`ptah_browser_network {}\` — inspect requests made
 6. **Done**: \`ptah_browser_close {}\` — release resources (or let it auto-close)
+
+### Responsive Testing Example
+\`\`\`
+ptah_browser_navigate { url: "https://example.com", viewport: { width: 375, height: 812 } }
+ptah_browser_screenshot {} — mobile layout verification
+ptah_browser_close {}
+ptah_browser_navigate { url: "https://example.com", viewport: { width: 768, height: 1024 } }
+ptah_browser_screenshot {} — tablet layout verification
+\`\`\`
 
 ### ptah_browser_record_start { maxFrames?, frameDelay? }
 Start recording the browser session as a GIF. Frames captured via CDP. Stop with ptah_browser_record_stop.
@@ -83,7 +100,7 @@ Start recording the browser session as a GIF. Frames captured via CDP. Stop with
 Stop recording. Assembles frames into GIF file. Returns file path, frame count, duration, file size.
 
 ### ptah_browser_wait_for_user { message, timeout? }
-Pause and prompt the user to perform manual actions in the visible browser (login, 2FA, CAPTCHA). Requires headless=false. Resumes when user clicks Ready.
+Pause and prompt the user to perform manual actions in the visible browser (login, 2FA, CAPTCHA). Requires headless=false (the default). Resumes when user clicks Ready.
 
 ### Browser Recording
 Use recording for audit trails, debugging, and demonstrating steps to users:
@@ -119,7 +136,7 @@ For tasks requiring human authentication (login, 2FA, CAPTCHA, OAuth consent), u
 5. \`ptah_browser_wait_for_user { message: "Please review and confirm the token generation, then click Ready" }\`
 6. \`ptah_browser_content { selector: ".token" }\` — extract the generated token
 
-**Important**: Always set ptah.browser.headless to false before using wait-for-user workflows. The browser must be visible for the user to interact with it.
+**Important**: The browser defaults to visible mode (headless=false). For wait-for-user workflows, ensure you did NOT set headless=true when starting the session.
 
 ## IDE Access via execute_code
 

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/services/chrome-launcher-browser-capabilities.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/services/chrome-launcher-browser-capabilities.ts
@@ -9,7 +9,10 @@
  * 30-min max lifetime, auto-cleanup.
  */
 
-import type { IBrowserCapabilities } from '../namespace-builders/browser-namespace.builder';
+import type {
+  IBrowserCapabilities,
+  BrowserSessionOptions,
+} from '../namespace-builders/browser-namespace.builder';
 import { ScreenRecorderService } from './screen-recorder.service';
 
 // Dynamic imports to avoid bundling issues when this module isn't used (e.g., Electron)
@@ -42,6 +45,9 @@ const VISIBLE_INACTIVITY_TIMEOUT_MS = 15 * 60 * 1000; // 15 minutes (visible, TA
 const MAX_LIFETIME_MS = 30 * 60 * 1000; // 30 minutes
 const MAX_NETWORK_ENTRIES = 500;
 
+/** Default viewport dimensions (desktop) */
+const DEFAULT_VIEWPORT = { width: 1920, height: 1080 };
+
 export class ChromeLauncherBrowserCapabilities implements IBrowserCapabilities {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private chrome: any = null; // chrome-launcher instance
@@ -63,15 +69,20 @@ export class ChromeLauncherBrowserCapabilities implements IBrowserCapabilities {
   private recorder: ScreenRecorderService | null = null;
   /** Whether the screencast frame listener has been registered on the current CDP client */
   private screencastListenerRegistered = false;
-  /** Whether current session is headless (TASK_2025_254) */
-  private _headless = true;
+  /** Whether current session is headless — agent-controlled, default false (visible) */
+  private _headless = false;
+  /** Current viewport dimensions — agent-controlled, default 1920x1080 (desktop) */
+  private _viewport = { ...DEFAULT_VIEWPORT };
+  /** Pending session options set by configureSession(), consumed by createSession() */
+  private _pendingOptions: BrowserSessionOptions = {};
   /** Inactivity timer paused flag (TASK_2025_254) */
   private _inactivityPaused = false;
 
-  constructor(
-    private readonly getHeadless: () => boolean = () => true,
-    private readonly getRecordingDir: () => string = () => '',
-  ) {}
+  constructor(private readonly getRecordingDir: () => string = () => '') {}
+
+  configureSession(options: BrowserSessionOptions): void {
+    this._pendingOptions = { ...this._pendingOptions, ...options };
+  }
 
   async navigate(
     url: string,
@@ -324,6 +335,7 @@ export class ChromeLauncherBrowserCapabilities implements IBrowserCapabilities {
     autoCloseInMs?: number;
     headless?: boolean;
     recording?: boolean;
+    viewport?: { width: number; height: number };
   }> {
     if (!this._connected || !this.client) {
       return { connected: false };
@@ -355,6 +367,7 @@ export class ChromeLauncherBrowserCapabilities implements IBrowserCapabilities {
         autoCloseInMs,
         headless: this._headless,
         recording: this.recorder?.isRecording() ?? false,
+        viewport: { ...this._viewport },
       };
     } catch {
       return { connected: false };
@@ -407,8 +420,12 @@ export class ChromeLauncherBrowserCapabilities implements IBrowserCapabilities {
       );
     }
 
-    // Read headless setting at session creation time (TASK_2025_254)
-    this._headless = this.getHeadless();
+    // Consume pending session options (agent-controlled headless + viewport)
+    this._headless = this._pendingOptions.headless ?? false;
+    this._viewport = this._pendingOptions.viewport
+      ? { ...this._pendingOptions.viewport }
+      : { ...DEFAULT_VIEWPORT };
+    this._pendingOptions = {};
 
     // Launch Chrome with remote debugging
     try {
@@ -419,9 +436,10 @@ export class ChromeLauncherBrowserCapabilities implements IBrowserCapabilities {
         '--disable-extensions',
         '--disable-translate',
         '--disable-background-networking',
+        `--window-size=${this._viewport.width},${this._viewport.height}`,
       ];
 
-      // Conditionally include --headless (TASK_2025_254)
+      // Conditionally include --headless
       if (this._headless) {
         chromeFlags.unshift('--headless');
       }
@@ -450,10 +468,18 @@ export class ChromeLauncherBrowserCapabilities implements IBrowserCapabilities {
     }
 
     // Enable CDP domains
-    const { Page, Network, Runtime } = this.client;
+    const { Page, Network, Runtime, Emulation } = this.client;
     await Page.enable();
     await Network.enable();
     await Runtime.enable();
+
+    // Set viewport via CDP Emulation (works in both headless and visible modes)
+    await Emulation.setDeviceMetricsOverride({
+      width: this._viewport.width,
+      height: this._viewport.height,
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
 
     // Set up network monitoring
     this.networkEntries = [];

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/services/chrome-launcher-browser-capabilities.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/services/chrome-launcher-browser-capabilities.ts
@@ -620,6 +620,8 @@ export class ChromeLauncherBrowserCapabilities implements IBrowserCapabilities {
     this._connected = false;
     this.screencastListenerRegistered = false;
     this.startedAt = null;
+    this._pendingOptions = {};
+    this._inactivityPaused = false;
     this.networkEntries = [];
     this.pendingResponses.clear();
   }

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/types.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/types.ts
@@ -391,6 +391,17 @@ export interface JsonValidateResult {
 // ========================================
 
 /**
+ * Viewport dimensions in pixels.
+ * Used across browser session configuration, status reporting, and tool schemas.
+ */
+export interface ViewportDimensions {
+  /** Width in pixels (must be a positive integer, max 7680) */
+  width: number;
+  /** Height in pixels (must be a positive integer, max 7680) */
+  height: number;
+}
+
+/**
  * Browser navigation result
  */
 export interface BrowserNavigateResult {
@@ -507,7 +518,7 @@ export interface BrowserStatusResult {
   /** Whether recording is currently active */
   recording?: boolean;
   /** Current viewport dimensions */
-  viewport?: { width: number; height: number };
+  viewport?: ViewportDimensions;
 }
 
 // ========================================
@@ -579,7 +590,7 @@ export interface BrowserNamespace {
     /** Run browser in headless mode (default: false — visible browser window) */
     headless?: boolean;
     /** Viewport dimensions (default: 1920x1080 — desktop). Common presets: desktop 1920x1080, tablet 768x1024, mobile 375x812 */
-    viewport?: { width: number; height: number };
+    viewport?: ViewportDimensions;
   }): Promise<BrowserNavigateResult>;
 
   /**

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/types.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/types.ts
@@ -502,10 +502,12 @@ export interface BrowserStatusResult {
   autoCloseInMs?: number;
   /** Error message if status check failed */
   error?: string;
-  /** Whether the current session is running in headless mode (TASK_2025_254) */
+  /** Whether the current session is running in headless mode */
   headless?: boolean;
-  /** Whether recording is currently active (TASK_2025_254) */
+  /** Whether recording is currently active */
   recording?: boolean;
+  /** Current viewport dimensions */
+  viewport?: { width: number; height: number };
 }
 
 // ========================================
@@ -565,12 +567,19 @@ export interface BrowserNamespace {
    * URL is validated against a security blocklist before navigation.
    * If no browser session exists, one is lazily created.
    *
-   * @param params - Navigation parameters
+   * Session options (headless, viewport) only take effect when creating a new session.
+   * If a session already exists, they are stored for the next session creation.
+   *
+   * @param params - Navigation parameters and optional session configuration
    * @returns Navigation result with URL and page title
    */
   navigate(params: {
     url: string;
     waitForLoad?: boolean;
+    /** Run browser in headless mode (default: false — visible browser window) */
+    headless?: boolean;
+    /** Viewport dimensions (default: 1920x1080 — desktop). Common presets: desktop 1920x1080, tablet 768x1024, mobile 375x812 */
+    viewport?: { width: number; height: number };
   }): Promise<BrowserNavigateResult>;
 
   /**

--- a/libs/frontend/chat/src/lib/components/organisms/agent-monitor-panel.component.ts
+++ b/libs/frontend/chat/src/lib/components/organisms/agent-monitor-panel.component.ts
@@ -57,21 +57,22 @@ import { AgentCardComponent } from '../molecules/agent-card/agent-card.component
         <div class="flex items-center gap-2">
           <span class="text-sm font-semibold">Agents</span>
           @if (store.activeTabAgents().length > 0) {
-          <span class="badge badge-sm badge-neutral">{{
-            store.activeTabAgents().length
-          }}</span>
+            <span class="badge badge-sm badge-neutral">{{
+              store.activeTabAgents().length
+            }}</span>
           }
         </div>
         <div class="flex items-center gap-1">
-          @if (store.activeTabAgents().length > 0 && !store.hasRunningAgents())
-          {
-          <button
-            class="btn btn-ghost btn-xs btn-square"
-            title="Clear completed"
-            (click)="store.clearCompleted()"
-          >
-            <lucide-angular [img]="Trash2Icon" class="w-3.5 h-3.5" />
-          </button>
+          @if (
+            store.activeTabAgents().length > 0 && !store.hasRunningAgents()
+          ) {
+            <button
+              class="btn btn-ghost btn-xs btn-square"
+              title="Clear completed"
+              (click)="store.clearCompleted()"
+            >
+              <lucide-angular [img]="Trash2Icon" class="w-3.5 h-3.5" />
+            </button>
           }
           <button
             class="btn btn-ghost btn-xs btn-square"
@@ -83,84 +84,89 @@ import { AgentCardComponent } from '../molecules/agent-card/agent-card.component
         </div>
       </div>
 
-      <!-- Sticky permission banner — always visible at top when any agent has a pending permission -->
-      @if (store.pendingPermissions().length > 0) {
-      <div
-        class="flex-shrink-0 border-b border-warning/30"
-        style="min-width: 300px"
-      >
-        @for (agent of store.pendingPermissions(); track agent.agentId) {
-        <div
-          class="bg-warning/10 px-2.5 py-1.5 flex flex-col gap-1 border-b border-warning/10 last:border-b-0"
-        >
-          <div class="flex items-center gap-2">
-            <lucide-angular
-              [img]="ShieldAlertIcon"
-              class="w-3.5 h-3.5 text-warning flex-shrink-0"
-            />
-            <span class="badge badge-xs badge-warning">Permission</span>
-            <span class="text-[10px] text-base-content/50 truncate">
-              {{ agent.cli }} &middot; {{ agent.task | slice : 0 : 30 }}
-            </span>
-          </div>
-          <div class="flex items-center gap-1.5">
-            <code
-              class="text-[10px] font-mono text-accent bg-base-200/60 px-1.5 py-0.5 rounded"
-            >
-              {{ agent.permissionQueue[0].toolName }}
-            </code>
-            @if (agent.permissionQueue[0].toolArgs) {
-            <span class="text-[10px] text-base-content/40 font-mono truncate">
-              {{ agent.permissionQueue[0].toolArgs }}
-            </span>
+      <!-- Scrollable container: banner + agent cards share a single scroll area -->
+      <div class="flex-1 overflow-y-auto min-h-0" style="min-width: 300px">
+        <!-- Sticky permission banner — sticks to top of scroll area when scrolling through agent cards -->
+        @if (store.pendingPermissions().length > 0) {
+          <div class="sticky top-0 z-10 bg-base-200 border-b border-warning/30">
+            @for (agent of store.pendingPermissions(); track agent.agentId) {
+              <div
+                class="bg-warning/10 px-2.5 py-1.5 flex flex-col gap-1 border-b border-warning/10 last:border-b-0"
+              >
+                <div class="flex items-center gap-2">
+                  <lucide-angular
+                    [img]="ShieldAlertIcon"
+                    class="w-3.5 h-3.5 text-warning flex-shrink-0"
+                  />
+                  <span class="badge badge-xs badge-warning">Permission</span>
+                  <span class="text-[10px] text-base-content/50 truncate">
+                    {{ agent.cli }} &middot; {{ agent.task | slice: 0 : 30 }}
+                  </span>
+                </div>
+                <div class="flex items-center gap-1.5">
+                  <code
+                    class="text-[10px] font-mono text-accent bg-base-200/60 px-1.5 py-0.5 rounded"
+                  >
+                    {{ agent.permissionQueue[0].toolName }}
+                  </code>
+                  @if (agent.permissionQueue[0].toolArgs) {
+                    <span
+                      class="text-[10px] text-base-content/40 font-mono truncate"
+                    >
+                      {{ agent.permissionQueue[0].toolArgs }}
+                    </span>
+                  }
+                </div>
+                <div class="flex gap-2">
+                  <button
+                    type="button"
+                    class="btn btn-xs btn-success"
+                    (click)="
+                      allowPermission(agent.agentId, agent.permissionQueue[0])
+                    "
+                  >
+                    Allow
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-xs btn-error btn-outline"
+                    (click)="
+                      denyPermission(agent.agentId, agent.permissionQueue[0])
+                    "
+                  >
+                    Deny
+                  </button>
+                </div>
+              </div>
             }
           </div>
-          <div class="flex gap-2">
-            <button
-              type="button"
-              class="btn btn-xs btn-success"
-              (click)="allowPermission(agent.agentId, agent.permissionQueue[0])"
-            >
-              Allow
-            </button>
-            <button
-              type="button"
-              class="btn btn-xs btn-error btn-outline"
-              (click)="denyPermission(agent.agentId, agent.permissionQueue[0])"
-            >
-              Deny
-            </button>
-          </div>
-        </div>
         }
-      </div>
-      }
 
-      <!-- Agent list: accordion layout — expanded cards fill remaining space, collapsed cards auto-size to header -->
-      <div
-        class="flex-1 overflow-y-auto p-1.5 flex flex-col gap-1 min-h-0"
-        style="min-width: 300px"
-      >
-        @for (agent of store.activeTabAgents(); track agent.agentId) {
-        <div
-          [class.flex-1]="agent.expanded"
-          [class.flex-shrink-0]="!agent.expanded"
-          [style.min-height]="agent.expanded ? '50vh' : null"
-        >
-          <ptah-agent-card
-            class="block h-full"
-            [agent]="agent"
-            (toggleExpanded)="store.toggleAgentExpanded(agent.agentId)"
-          />
+        <!-- Agent list: accordion layout — expanded cards fill remaining space, collapsed cards auto-size to header -->
+        <div class="p-1.5 flex flex-col gap-1">
+          @for (agent of store.activeTabAgents(); track agent.agentId) {
+            <div
+              [class.flex-1]="agent.expanded"
+              [class.flex-shrink-0]="!agent.expanded"
+              [style.min-height]="agent.expanded ? '50vh' : null"
+            >
+              <ptah-agent-card
+                class="block h-full"
+                [agent]="agent"
+                (toggleExpanded)="store.toggleAgentExpanded(agent.agentId)"
+              />
+            </div>
+          } @empty {
+            <div
+              class="flex flex-col items-center justify-center h-32 text-center"
+            >
+              <span class="text-sm text-base-content/40">No agents</span>
+              <span class="text-xs text-base-content/25 mt-1"
+                >Agents will appear here when spawned</span
+              >
+            </div>
+          }
         </div>
-        } @empty {
-        <div class="flex flex-col items-center justify-center h-32 text-center">
-          <span class="text-sm text-base-content/40">No agents</span>
-          <span class="text-xs text-base-content/25 mt-1"
-            >Agents will appear here when spawned</span
-          >
-        </div>
-        }
       </div>
     </aside>
   `,

--- a/libs/frontend/chat/src/lib/components/organisms/execution/inline-agent-bubble.component.ts
+++ b/libs/frontend/chat/src/lib/components/organisms/execution/inline-agent-bubble.component.ts
@@ -78,7 +78,7 @@ import { DurationBadgeComponent } from '../../atoms/duration-badge.component';
         'border-dashed': isBackground() || isResumed(),
         'ring-info/20': isBackground() && !isInterrupted() && !isResumed(),
         'bg-success/5': isResumed(),
-        'ring-success/30': isResumed()
+        'ring-success/30': isResumed(),
       }"
       [style.border-left-color]="
         isInterrupted() ? null : isResumed() ? null : agentColor()
@@ -108,128 +108,162 @@ import { DurationBadgeComponent } from '../../atoms/duration-badge.component';
           </span>
         </div>
 
-        <!-- Agent type + description -->
+        <!-- Agent type + description (inline only when expanded) -->
         <div class="flex-1 min-w-0 flex items-center gap-2">
           <span class="text-[11px] font-semibold text-base-content/80">
             {{ node().agentType }}
           </span>
-          @if (node().agentDescription) {
-          <span
-            class="text-[10px] text-base-content/50 truncate"
-            [title]="node().agentDescription"
-          >
-            {{ node().agentDescription }}
-          </span>
+          @if (!isCollapsed() && node().agentDescription) {
+            <span
+              class="text-[10px] text-base-content/50 truncate"
+              [title]="node().agentDescription"
+            >
+              {{ node().agentDescription }}
+            </span>
           }
         </div>
 
         <!-- Streaming/Interrupted/Background badge or stats -->
         @if (isBackground() && isStreaming()) {
-        <span class="badge badge-xs badge-info gap-1 flex-shrink-0">
-          <lucide-angular [img]="LoaderIcon" class="w-2.5 h-2.5 animate-spin" />
-          <span class="text-[9px]">Background</span>
-        </span>
+          <span class="badge badge-xs badge-info gap-1 flex-shrink-0">
+            <lucide-angular
+              [img]="LoaderIcon"
+              class="w-2.5 h-2.5 animate-spin"
+            />
+            <span class="text-[9px]">Background</span>
+          </span>
         } @else if (isBackground() && !isInterrupted() && !isStreaming()) {
-        <span
-          class="badge badge-xs badge-outline badge-info gap-1 flex-shrink-0"
-        >
-          <span class="text-[9px]">Background</span>
-        </span>
+          <span
+            class="badge badge-xs badge-outline badge-info gap-1 flex-shrink-0"
+          >
+            <span class="text-[9px]">Background</span>
+          </span>
         } @else if (isStreaming()) {
-        <span class="badge badge-xs badge-info gap-1 flex-shrink-0">
-          <lucide-angular [img]="LoaderIcon" class="w-2.5 h-2.5 animate-spin" />
-          <span class="text-[9px]">Streaming</span>
-        </span>
+          <span class="badge badge-xs badge-info gap-1 flex-shrink-0">
+            <lucide-angular
+              [img]="LoaderIcon"
+              class="w-2.5 h-2.5 animate-spin"
+            />
+            <span class="text-[9px]">Streaming</span>
+          </span>
         } @else if (isResumed()) {
-        <!-- TASK_2025_211: Resumed indicator — agent was interrupted then continued -->
-        <span
-          class="badge badge-sm badge-success gap-1 flex-shrink-0"
-          title="This agent was resumed in a new session."
-        >
-          <span class="text-[10px] font-medium">Resumed</span>
-        </span>
+          <!-- TASK_2025_211: Resumed indicator — agent was interrupted then continued -->
+          <span
+            class="badge badge-sm badge-success gap-1 flex-shrink-0"
+            title="This agent was resumed in a new session."
+          >
+            <span class="text-[10px] font-medium">Resumed</span>
+          </span>
         } @else if (isInterrupted()) {
-        <!-- TASK_2025_109: Enhanced interrupted indicator with auto-resume hint -->
-        <span
-          class="badge badge-sm badge-warning gap-1 flex-shrink-0"
-          title="This agent was interrupted. It will auto-resume when you send a message."
-        >
-          <lucide-angular [img]="StopCircleIcon" class="w-3 h-3" />
-          <span class="text-[10px] font-medium">Interrupted</span>
-        </span>
+          <!-- TASK_2025_109: Enhanced interrupted indicator with auto-resume hint -->
+          <span
+            class="badge badge-sm badge-warning gap-1 flex-shrink-0"
+            title="This agent was interrupted. It will auto-resume when you send a message."
+          >
+            <lucide-angular [img]="StopCircleIcon" class="w-3 h-3" />
+            <span class="text-[10px] font-medium">Interrupted</span>
+          </span>
         } @else if (hasChildren()) {
-        <span class="badge badge-xs badge-ghost text-[9px] flex-shrink-0">
-          {{ childStats() }}
-        </span>
+          <span class="badge badge-xs badge-ghost text-[9px] flex-shrink-0">
+            {{ childStats() }}
+          </span>
         }
       </button>
 
+      <!-- Card description (visible when collapsed for card-like appearance) -->
+      @if (isCollapsed() && node().agentDescription) {
+        <button
+          type="button"
+          class="w-full text-left px-3 pb-2 cursor-pointer hover:bg-base-300/30 transition-colors"
+          aria-label="Expand agent"
+          (click)="toggleCollapse()"
+        >
+          <p
+            class="text-[11px] text-base-content/60 leading-relaxed line-clamp-2"
+          >
+            {{ node().agentDescription }}
+          </p>
+        </button>
+      }
+
       <!-- Collapsible Content: INTERLEAVED TIMELINE (text + tools in order) -->
       @if (!isCollapsed()) {
-      <div
-        #contentContainer
-        class="px-3 pb-2 max-h-80 overflow-y-auto border-t border-base-300/30"
-      >
-        <!-- TASK_2025_102 FIX: summaryContent is now rendered as a text child node
+        <div
+          #contentContainer
+          class="px-3 pb-2 max-h-80 overflow-y-auto border-t border-base-300/30"
+        >
+          <!-- TASK_2025_102 FIX: summaryContent is now rendered as a text child node
              instead of a separate block. This ensures agent text is properly
              interleaved with tool calls in chronological order. -->
-        @if (hasChildren()) {
-        <!-- Render all children in chronological order (text + tools interleaved) -->
-        @for (child of node().children; track child.id) {
-        <ptah-execution-node
-          [node]="child"
-          [isStreaming]="isStreaming()"
-          [getPermissionForTool]="getPermissionForTool()"
-          (permissionResponded)="permissionResponded.emit($event)"
-        />
-        } @if (isStreaming()) {
-        <div
-          class="flex items-center gap-1 text-[10px] text-base-content/40 mt-2"
-        >
-          <lucide-angular [img]="LoaderIcon" class="w-3 h-3 animate-spin" />
-          <span>Agent working</span>
-          <ptah-typing-cursor colorClass="text-base-content/40" />
+          @if (hasChildren()) {
+            <!-- Render all children in chronological order (text + tools interleaved) -->
+            @for (child of node().children; track child.id) {
+              <ptah-execution-node
+                [node]="child"
+                [isStreaming]="isStreaming()"
+                [getPermissionForTool]="getPermissionForTool()"
+                (permissionResponded)="permissionResponded.emit($event)"
+              />
+            }
+            @if (isStreaming()) {
+              <div
+                class="flex items-center gap-1 text-[10px] text-base-content/40 mt-2"
+              >
+                <lucide-angular
+                  [img]="LoaderIcon"
+                  class="w-3 h-3 animate-spin"
+                />
+                <span>Agent working</span>
+                <ptah-typing-cursor colorClass="text-base-content/40" />
+              </div>
+            }
+          } @else {
+            <!-- No children yet -->
+            @if (isStreaming()) {
+              <div
+                class="flex items-center gap-2 text-[10px] text-base-content/40 py-2"
+              >
+                <lucide-angular
+                  [img]="LoaderIcon"
+                  class="w-3 h-3 animate-spin"
+                />
+                <span>Starting agent execution</span>
+                <ptah-typing-cursor colorClass="text-base-content/40" />
+              </div>
+            } @else {
+              <div class="text-[10px] text-base-content/40 py-2">
+                No execution data
+              </div>
+            }
+          }
         </div>
-        } } @else {
-        <!-- No children yet -->
-        @if (isStreaming()) {
-        <div
-          class="flex items-center gap-2 text-[10px] text-base-content/40 py-2"
-        >
-          <lucide-angular [img]="LoaderIcon" class="w-3 h-3 animate-spin" />
-          <span>Starting agent execution</span>
-          <ptah-typing-cursor colorClass="text-base-content/40" />
-        </div>
-        } @else {
-        <div class="text-[10px] text-base-content/40 py-2">
-          No execution data
-        </div>
-        } }
-      </div>
       }
 
       <!-- Agent Stats Footer (shown when stats available and not streaming) -->
       @if (hasStats() && !isStreaming()) {
-      <div
-        class="flex items-center gap-1.5 px-3 py-1.5 border-t border-white/5 text-base-content/70 rounded-b-lg"
-        [style.background-color]="footerBgColor()"
-      >
-        @if (modelDisplayName()) {
-        <span
-          class="badge badge-xs text-[9px] font-medium flex-shrink-0 border-white/20 text-white/80"
-          [style.background-color]="agentColor()"
-          [title]="rawModelId() || ''"
+        <div
+          class="flex items-center gap-1.5 px-3 py-1.5 border-t border-white/5 text-base-content/70 rounded-b-lg"
+          [style.background-color]="footerBgColor()"
         >
-          {{ modelDisplayName() }}
-        </span>
-        } @if (agentTokenUsage()) {
-        <ptah-token-badge [tokens]="agentTokenUsage()!" />
-        } @if (agentCost() > 0) {
-        <ptah-cost-badge [cost]="agentCost()" />
-        } @if (agentDuration()) {
-        <ptah-duration-badge [durationMs]="agentDuration()!" />
-        }
-      </div>
+          @if (modelDisplayName()) {
+            <span
+              class="badge badge-xs text-[9px] font-medium flex-shrink-0 border-white/20 text-white/80"
+              [style.background-color]="agentColor()"
+              [title]="rawModelId() || ''"
+            >
+              {{ modelDisplayName() }}
+            </span>
+          }
+          @if (agentTokenUsage()) {
+            <ptah-token-badge [tokens]="agentTokenUsage()!" />
+          }
+          @if (agentCost() > 0) {
+            <ptah-cost-badge [cost]="agentCost()" />
+          }
+          @if (agentDuration()) {
+            <ptah-duration-badge [durationMs]="agentDuration()!" />
+          }
+        </div>
       }
     </div>
   `,
@@ -322,7 +356,7 @@ export class InlineAgentBubbleComponent {
       () => {
         this.setupMutationObserver();
       },
-      { injector: this.injector }
+      { injector: this.injector },
     );
 
     // Re-setup observer when component expands (container re-enters DOM)
@@ -339,7 +373,7 @@ export class InlineAgentBubbleComponent {
             this.setupMutationObserver();
             this.observerSetupPending = false;
           },
-          { injector: this.injector }
+          { injector: this.injector },
         );
       }
     });
@@ -450,7 +484,7 @@ export class InlineAgentBubbleComponent {
       return this.agentMonitorStore.isAgentResumed(
         node.id,
         node.toolCallId ?? undefined,
-        description
+        description,
       );
     }
     return false;
@@ -563,7 +597,7 @@ export class InlineAgentBubbleComponent {
    * Used for both display name formatting and tooltip.
    */
   readonly rawModelId = computed(
-    () => this.node().agentModel || this.node().model || null
+    () => this.node().agentModel || this.node().model || null,
   );
 
   /**

--- a/libs/frontend/chat/src/lib/components/organisms/message-bubble.component.html
+++ b/libs/frontend/chat/src/lib/components/organisms/message-bubble.component.html
@@ -35,9 +35,11 @@
       <!-- Collapsible Header (only for completed assistant messages) -->
       @if (messageSummary(); as summary) {
         @if (!isStreaming()) {
+          <!-- Header row -->
           <button
             type="button"
-            class="w-full flex items-center gap-2 text-left py-1 -mt-1 mb-1 hover:bg-base-200/30 rounded transition-colors"
+            class="w-full flex items-center gap-2 text-left py-1 -mt-1 hover:bg-base-200/30 rounded transition-colors"
+            [class.mb-1]="!isCollapsed()"
             (click)="toggleCollapse()"
             [attr.aria-expanded]="!isCollapsed()"
             [attr.aria-label]="
@@ -48,9 +50,13 @@
               [img]="isCollapsed() ? ChevronRightIcon : ChevronDownIcon"
               class="w-3.5 h-3.5 text-base-content/50 flex-shrink-0"
             />
-            <span class="flex-1 text-xs text-base-content/70 truncate min-w-0">
-              {{ summary.title }}
-            </span>
+            @if (!isCollapsed()) {
+              <span
+                class="flex-1 text-xs text-base-content/70 truncate min-w-0"
+              >
+                {{ summary.title }}
+              </span>
+            }
             @if (summary.toolCount > 0) {
               <span class="badge badge-ghost badge-xs text-[9px] flex-shrink-0">
                 {{ summary.toolCount }} tools
@@ -62,6 +68,22 @@
               </span>
             }
           </button>
+
+          <!-- Card body: description (only when collapsed) -->
+          @if (isCollapsed()) {
+            <button
+              type="button"
+              class="w-full text-left pl-6 pr-3 pb-1.5 hover:bg-base-200/30 rounded transition-colors cursor-pointer"
+              aria-label="Expand message"
+              (click)="toggleCollapse()"
+            >
+              <p
+                class="text-[11px] text-base-content/60 leading-relaxed line-clamp-2"
+              >
+                {{ summary.description ?? summary.title }}
+              </p>
+            </button>
+          }
         }
       }
 

--- a/libs/frontend/chat/src/lib/components/organisms/tab-bar.component.ts
+++ b/libs/frontend/chat/src/lib/components/organisms/tab-bar.component.ts
@@ -7,6 +7,9 @@ import {
   viewChild,
   ElementRef,
   DestroyRef,
+  afterNextRender,
+  Injector,
+  NgZone,
 } from '@angular/core';
 import { LucideAngularModule, ChevronLeft, ChevronRight } from 'lucide-angular';
 import { TabItemComponent } from '../molecules/session/tab-item.component';
@@ -26,6 +29,7 @@ import { TabManagerService } from '../../services/tab-manager.service';
   selector: 'ptah-tab-bar',
   standalone: true,
   imports: [TabItemComponent, LucideAngularModule],
+  host: { class: 'block min-w-0 overflow-hidden h-full' },
   template: `
     <div class="relative flex items-center h-full">
       <!-- Left scroll arrow -->
@@ -72,6 +76,9 @@ import { TabManagerService } from '../../services/tab-manager.service';
 })
 export class TabBarComponent {
   protected readonly tabManager = inject(TabManagerService);
+  private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly ngZone = inject(NgZone);
 
   readonly tabs = this.tabManager.tabs;
   readonly activeTabId = this.tabManager.activeTabId;
@@ -82,18 +89,42 @@ export class TabBarComponent {
   private readonly tabContainerRef =
     viewChild<ElementRef<HTMLDivElement>>('tabContainer');
 
-  readonly canScrollLeft = signal(false);
-  readonly canScrollRight = signal(false);
+  protected readonly canScrollLeft = signal(false);
+  protected readonly canScrollRight = signal(false);
 
-  private readonly destroyRef = inject(DestroyRef);
+  /** Timer ID for debouncing scroll-into-view on tab changes */
+  private scrollTimerId: ReturnType<typeof setTimeout> | null = null;
+
+  /** ResizeObserver for detecting container size changes */
+  private resizeObserver: ResizeObserver | null = null;
+
+  /** Bound wheel handler reference for cleanup */
+  private wheelHandler: ((e: WheelEvent) => void) | null = null;
 
   constructor() {
-    // Re-check scroll state when tabs change (schedule after DOM update)
+    // Re-check scroll state when tabs change and scroll active tab into view
     effect(() => {
       this.tabs(); // track dependency
-      const timerId = setTimeout(() => this.checkScroll(), 0);
-      this.destroyRef.onDestroy(() => clearTimeout(timerId));
+      const activeId = this.activeTabId();
+      // Clear previous timer to prevent stale callbacks on rapid switching
+      if (this.scrollTimerId) clearTimeout(this.scrollTimerId);
+      this.scrollTimerId = setTimeout(() => {
+        this.scrollActiveTabIntoView(activeId);
+        this.checkScroll();
+        this.scrollTimerId = null;
+      }, 0);
     });
+
+    // Setup non-passive wheel listener and ResizeObserver after first render
+    afterNextRender(
+      () => {
+        this.setupWheelListener();
+        this.setupResizeObserver();
+      },
+      { injector: this.injector },
+    );
+
+    this.destroyRef.onDestroy(() => this.cleanup());
   }
 
   protected onScroll(): void {
@@ -122,6 +153,64 @@ export class TabBarComponent {
     this.tabManager.closeTab(tabId);
   }
 
+  /**
+   * Register wheel listener with { passive: false } so preventDefault() works.
+   * Angular template `(wheel)` bindings are passive by default in Chromium,
+   * which silently ignores preventDefault().
+   */
+  private setupWheelListener(): void {
+    const el = this.tabContainerRef()?.nativeElement;
+    if (!el) return;
+
+    this.wheelHandler = (event: WheelEvent) => {
+      if (el.scrollWidth <= el.clientWidth) return;
+      event.preventDefault();
+      el.scrollBy({ left: event.deltaY, behavior: 'auto' });
+      this.ngZone.run(() => this.checkScroll());
+    };
+
+    el.addEventListener('wheel', this.wheelHandler, { passive: false });
+  }
+
+  /** Watch for container resizes to keep scroll arrows in sync */
+  private setupResizeObserver(): void {
+    const el = this.tabContainerRef()?.nativeElement;
+    if (!el) return;
+
+    this.resizeObserver = new ResizeObserver(() => {
+      this.ngZone.run(() => this.checkScroll());
+    });
+    this.resizeObserver.observe(el);
+  }
+
+  /** Scroll the active tab into view within the container */
+  private scrollActiveTabIntoView(activeId: string | null): void {
+    if (!activeId) return;
+    const container = this.tabContainerRef()?.nativeElement;
+    if (!container) return;
+
+    const tabElements = container.querySelectorAll('ptah-tab-item');
+    const tabs = this.tabs();
+    const activeIndex = tabs.findIndex((t) => t.id === activeId);
+    if (activeIndex < 0 || activeIndex >= tabElements.length) return;
+
+    const tabEl = tabElements[activeIndex] as HTMLElement;
+    const containerRect = container.getBoundingClientRect();
+    const tabRect = tabEl.getBoundingClientRect();
+
+    if (tabRect.right > containerRect.right) {
+      container.scrollBy({
+        left: tabRect.right - containerRect.right + 8,
+        behavior: 'smooth',
+      });
+    } else if (tabRect.left < containerRect.left) {
+      container.scrollBy({
+        left: tabRect.left - containerRect.left - 8,
+        behavior: 'smooth',
+      });
+    }
+  }
+
   private checkScroll(): void {
     const el = this.tabContainerRef()?.nativeElement;
     if (!el) return;
@@ -129,5 +218,21 @@ export class TabBarComponent {
     this.canScrollRight.set(
       el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
     );
+  }
+
+  private cleanup(): void {
+    if (this.scrollTimerId) {
+      clearTimeout(this.scrollTimerId);
+      this.scrollTimerId = null;
+    }
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
+    if (this.wheelHandler) {
+      const el = this.tabContainerRef()?.nativeElement;
+      if (el) el.removeEventListener('wheel', this.wheelHandler);
+      this.wheelHandler = null;
+    }
   }
 }

--- a/libs/frontend/chat/src/lib/components/templates/app-shell.component.html
+++ b/libs/frontend/chat/src/lib/components/templates/app-shell.component.html
@@ -167,60 +167,93 @@
           <ul class="flex flex-col gap-0.5 p-0" role="list">
             @for (session of filteredSessions(); track session.id) {
               <li class="group relative" role="listitem">
-                <button
-                  type="button"
-                  class="flex flex-col items-start gap-1 py-2.5 px-3 pr-8 w-full text-left rounded-md transition-all duration-200 border-l-2 border-transparent hover:bg-base-300/50"
-                  [class.sidebar-item-active]="
-                    session.id === chatStore.currentSession()?.id
-                  "
-                  [class.sidebar-item-open-tab]="
-                    isSessionOpen(session.id) &&
-                    session.id !== chatStore.currentSession()?.id
-                  "
-                  [attr.aria-current]="
-                    session.id === chatStore.currentSession()?.id
-                      ? 'true'
-                      : null
-                  "
-                  (click)="chatStore.switchSession(session.id)"
-                >
-                  <!-- Session name -->
-                  <span
-                    class="font-medium text-sm truncate w-full leading-snug"
-                    [class.text-primary]="
-                      session.id === chatStore.currentSession()?.id ||
-                      isSessionOpen(session.id)
+                @if (editingSessionId() === session.id) {
+                  <!-- Inline edit mode -->
+                  <div class="flex items-center gap-1 py-2.5 px-3 w-full">
+                    <input
+                      #editSessionInput
+                      type="text"
+                      class="input input-xs input-bordered flex-1 text-sm bg-base-100"
+                      maxlength="200"
+                      aria-label="Edit session name"
+                      [ngModel]="editingSessionName()"
+                      (ngModelChange)="editingSessionName.set($event)"
+                      (keydown.enter)="saveSessionName($event, session)"
+                      (keydown.escape)="cancelEditingSession()"
+                      (blur)="saveSessionName($event, session)"
+                    />
+                  </div>
+                } @else {
+                  <button
+                    type="button"
+                    class="flex flex-col items-start gap-1 py-2.5 px-3 pr-16 w-full text-left rounded-md transition-all duration-200 border-l-2 border-transparent hover:bg-base-300/50"
+                    [class.sidebar-item-active]="
+                      session.id === chatStore.currentSession()?.id
                     "
-                    [title]="session.name"
+                    [class.sidebar-item-open-tab]="
+                      isSessionOpen(session.id) &&
+                      session.id !== chatStore.currentSession()?.id
+                    "
+                    [attr.aria-current]="
+                      session.id === chatStore.currentSession()?.id
+                        ? 'true'
+                        : null
+                    "
+                    (click)="chatStore.switchSession(session.id)"
                   >
-                    {{ getSessionDisplayName(session) }}
-                  </span>
-                  <!-- Session metadata row -->
-                  <span
-                    class="text-xs text-base-content/50 flex items-center gap-2 w-full"
+                    <!-- Session name -->
+                    <span
+                      class="font-medium text-sm truncate w-full leading-snug"
+                      [class.text-primary]="
+                        session.id === chatStore.currentSession()?.id ||
+                        isSessionOpen(session.id)
+                      "
+                      [title]="session.name"
+                    >
+                      {{ getSessionDisplayName(session) }}
+                    </span>
+                    <!-- Session metadata row -->
+                    <span
+                      class="text-xs text-base-content/50 flex items-center gap-2 w-full"
+                    >
+                      <span>{{
+                        formatRelativeDate(session.lastActivityAt)
+                      }}</span>
+                      @if (session.messageCount > 0) {
+                        <span class="text-base-content/40"
+                          >{{ session.messageCount }} msgs</span
+                        >
+                      }
+                    </span>
+                  </button>
+                  <!-- Action buttons (hover reveal) -->
+                  <div
+                    class="absolute right-1.5 top-1/2 -translate-y-1/2 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity duration-200"
                   >
-                    <span>{{
-                      formatRelativeDate(session.lastActivityAt)
-                    }}</span>
-                    @if (session.messageCount > 0) {
-                      <span class="text-base-content/40"
-                        >{{ session.messageCount }} msgs</span
-                      >
-                    }
-                  </span>
-                </button>
-                <!-- Delete button (hover reveal) -->
-                <button
-                  type="button"
-                  class="absolute right-1.5 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs btn-square rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 text-base-content/40 hover:text-error hover:bg-error/10"
-                  title="Delete session"
-                  [attr.aria-label]="
-                    'Delete session: ' + getSessionDisplayName(session)
-                  "
-                  (click)="deleteSession($event, session)"
-                >
-                  <lucide-angular [img]="Trash2Icon" class="w-3.5 h-3.5" />
-                </button>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs btn-square rounded text-base-content/40 hover:text-primary hover:bg-primary/10"
+                      title="Rename session"
+                      [attr.aria-label]="
+                        'Rename session: ' + getSessionDisplayName(session)
+                      "
+                      (click)="startEditingSession($event, session)"
+                    >
+                      <lucide-angular [img]="PencilIcon" class="w-3.5 h-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs btn-square rounded text-base-content/40 hover:text-error hover:bg-error/10"
+                      title="Delete session"
+                      [attr.aria-label]="
+                        'Delete session: ' + getSessionDisplayName(session)
+                      "
+                      (click)="deleteSession($event, session)"
+                    >
+                      <lucide-angular [img]="Trash2Icon" class="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                }
               </li>
             } @empty {
               <li

--- a/libs/frontend/chat/src/lib/components/templates/app-shell.component.ts
+++ b/libs/frontend/chat/src/lib/components/templates/app-shell.component.ts
@@ -17,6 +17,7 @@ import {
   ChevronDown,
   ExternalLink,
   MessageSquare,
+  Pencil,
   Plus,
   Search,
   Settings,
@@ -137,10 +138,15 @@ export class AppShellComponent {
   readonly PlusIcon = Plus;
   readonly SearchIcon = Search;
   readonly SettingsIcon = Settings;
+  readonly PencilIcon = Pencil;
   readonly Trash2Icon = Trash2;
   readonly XIcon = X;
   readonly ExternalLinkIcon = ExternalLink;
   readonly BarChart3Icon = BarChart3;
+
+  // Inline edit state for session renaming
+  readonly editingSessionId = signal<string | null>(null);
+  readonly editingSessionName = signal('');
 
   // Agent monitor badge type for the sidebar tab
   readonly agentBadgeType = computed<'warning' | 'info' | 'neutral' | null>(
@@ -230,6 +236,10 @@ export class AppShellComponent {
   readonly sessionNameInputRef = viewChild<ElementRef<HTMLInputElement>>(
     'sessionNameInputRef',
   );
+
+  // ViewChild for inline session rename input
+  readonly editSessionInput =
+    viewChild<ElementRef<HTMLInputElement>>('editSessionInput');
 
   /**
    * TASK_2025_194: Flag to ensure auth redirect check runs only once.
@@ -518,6 +528,74 @@ export class AppShellComponent {
    * Delete session from storage (TASK_2025_086)
    * Shows confirmation dialog before deleting
    */
+  /**
+   * Start inline editing of a session name
+   */
+  startEditingSession(event: Event, session: ChatSessionSummary): void {
+    event.stopPropagation();
+    this.editingSessionId.set(session.id);
+    this.editingSessionName.set(session.name || '');
+    // Programmatic focus — HTML autofocus doesn't work on dynamically rendered elements
+    setTimeout(() => this.editSessionInput()?.nativeElement.focus(), 0);
+  }
+
+  /**
+   * Cancel inline editing
+   */
+  cancelEditingSession(): void {
+    this.editingSessionId.set(null);
+    this.editingSessionName.set('');
+  }
+
+  /**
+   * Save the edited session name via RPC.
+   * Guarded against double-fire (Enter + blur).
+   */
+  async saveSessionName(
+    event: Event,
+    session: ChatSessionSummary,
+  ): Promise<void> {
+    event.stopPropagation();
+
+    // Guard: skip if already saved/cancelled (prevents Enter + blur double-fire)
+    if (this.editingSessionId() !== session.id) {
+      return;
+    }
+
+    const newName = this.editingSessionName().trim();
+    if (!newName || newName === (session.name || '')) {
+      this.cancelEditingSession();
+      return;
+    }
+
+    // Clear edit state immediately to prevent double-fire
+    this.cancelEditingSession();
+
+    try {
+      const result = await this.rpcService.renameSession(
+        session.id as SessionId,
+        newName,
+      );
+
+      if (result.isSuccess() && result.data?.success) {
+        this.chatStore.updateSessionName(session.id as SessionId, newName);
+
+        // Update open tab title if this session has one
+        const tab = this.tabManager.findTabBySessionId(session.id);
+        if (tab) {
+          this.tabManager.updateTab(tab.id, { title: newName });
+        }
+      } else {
+        console.error(
+          '[AppShell] Failed to rename session:',
+          result.error || result.data?.error,
+        );
+      }
+    } catch (error) {
+      console.error('[AppShell] Error renaming session:', error);
+    }
+  }
+
   async deleteSession(
     event: Event,
     session: ChatSessionSummary,

--- a/libs/frontend/chat/src/lib/components/templates/welcome.component.ts
+++ b/libs/frontend/chat/src/lib/components/templates/welcome.component.ts
@@ -116,7 +116,7 @@ export class WelcomeComponent implements OnInit {
       case 'trial_ended':
         return 'Subscribe to Pro for premium features.';
       default:
-        return 'Create your account and start a 15-day free trial of premium features. No credit card required.';
+        return 'Create your account and start a 30-day free trial of premium features. No credit card required.';
     }
   });
 

--- a/libs/frontend/chat/src/lib/services/agent-monitor.store.ts
+++ b/libs/frontend/chat/src/lib/services/agent-monitor.store.ts
@@ -80,6 +80,16 @@ export class AgentMonitorStore implements OnDestroy {
   private _expandOrder = 0;
 
   /**
+   * Buffer for permission requests that arrive before the agent spawn event.
+   * Keyed by agentId. Replayed in onAgentSpawned() when the agent card is created.
+   * Prevents silent permission loss due to message ordering (TASK_2025_255).
+   */
+  private _pendingPermissionBuffer = new Map<
+    string,
+    AgentPermissionRequest[]
+  >();
+
+  /**
    * TASK_2025_211: Tracks agent descriptions (tasks) that have been resumed.
    * Used by inline-agent-bubble to upgrade 'interrupted' → 'resumed' visuals.
    * Key: `${parentSessionId}::${task}` for scoped matching (CLI agent case).
@@ -310,6 +320,20 @@ export class AgentMonitorStore implements OnDestroy {
       return next;
     });
 
+    // TASK_2025_255: Replay any buffered permission requests that arrived before spawn.
+    const buffered = this._pendingPermissionBuffer.get(info.agentId);
+    if (buffered && buffered.length > 0) {
+      this._pendingPermissionBuffer.delete(info.agentId);
+      console.log(
+        '[AgentMonitorStore] Replaying buffered permissions:',
+        info.agentId,
+        buffered.length,
+      );
+      for (const req of buffered) {
+        this.onPermissionRequest(req);
+      }
+    }
+
     // Auto-open panel on 0→1 agent transition (unless user explicitly closed)
     if (!hadAgents && !this._userExplicitlyClosed) {
       this._panelOpen.set(true);
@@ -404,11 +428,23 @@ export class AgentMonitorStore implements OnDestroy {
     this.syncTick();
   }
 
-  /** Handle incoming permission request from Copilot SDK agent */
+  /** Handle incoming permission request from CLI agent (Copilot SDK or Ptah CLI) */
   onPermissionRequest(request: AgentPermissionRequest): void {
     this._agents.update((map) => {
       const agent = map.get(request.agentId);
-      if (!agent) return map;
+      if (!agent) {
+        // Agent not yet in store (spawn event hasn't arrived yet).
+        // Buffer the request — it will be replayed in onAgentSpawned().
+        // TASK_2025_255: Prevents silent permission loss from message ordering.
+        console.warn(
+          '[AgentMonitorStore] Permission buffered — agent not yet spawned:',
+          request.agentId,
+        );
+        const buf = this._pendingPermissionBuffer.get(request.agentId) ?? [];
+        buf.push(request);
+        this._pendingPermissionBuffer.set(request.agentId, buf);
+        return map;
+      }
       const next = new Map(map);
 
       // Auto-expand the card so the user can see and respond to the permission

--- a/libs/frontend/chat/src/lib/services/agent-monitor.store.ts
+++ b/libs/frontend/chat/src/lib/services/agent-monitor.store.ts
@@ -164,6 +164,7 @@ export class AgentMonitorStore implements OnDestroy {
 
   ngOnDestroy(): void {
     this.stopTick();
+    this._pendingPermissionBuffer.clear();
   }
 
   private startTick(): void {

--- a/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts
@@ -318,6 +318,27 @@ export class SessionLoaderService {
   }
 
   // ============================================================================
+  // SESSION RENAME
+  // ============================================================================
+
+  /**
+   * Update a session's name in the local list (UI only)
+   * Called after successful backend rename to update UI state.
+   */
+  updateSessionName(sessionId: SessionId, name: string): void {
+    this._sessions.update((current) =>
+      current.map((s) => (s.id === sessionId ? { ...s, name } : s)),
+    );
+
+    // Update cache for the active workspace
+    const workspacePath =
+      this.currentWorkspacePath || this.vscodeService.config().workspaceRoot;
+    if (workspacePath) {
+      this.updateCache(workspacePath);
+    }
+  }
+
+  // ============================================================================
   // WORKSPACE SWITCHING (per-workspace session cache)
   // ============================================================================
 

--- a/libs/frontend/chat/src/lib/services/chat.store.ts
+++ b/libs/frontend/chat/src/lib/services/chat.store.ts
@@ -165,7 +165,7 @@ export class ChatStore {
 
   // License status signal (TASK_2025_142)
   private readonly _licenseStatus = signal<LicenseGetStatusResponse | null>(
-    null
+    null,
   );
   readonly licenseStatus = this._licenseStatus.asReadonly();
 
@@ -204,10 +204,10 @@ export class ChatStore {
 
   // Computed from active tab (delegated to TabManager)
   readonly currentSessionId = computed(
-    () => this.tabManager.activeTab()?.claudeSessionId ?? null
+    () => this.tabManager.activeTab()?.claudeSessionId ?? null,
   );
   readonly messages = computed(
-    () => this.tabManager.activeTab()?.messages ?? []
+    () => this.tabManager.activeTab()?.messages ?? [],
   );
   /**
    * PERFORMANCE OPTIMIZATION: Computed signal for current execution tree
@@ -257,7 +257,7 @@ export class ChatStore {
    * Used by SessionStatsSummaryComponent to display cost/tokens without recalculation
    */
   readonly preloadedStats = computed(
-    () => this.tabManager.activeTab()?.preloadedStats ?? null
+    () => this.tabManager.activeTab()?.preloadedStats ?? null,
   );
 
   /**
@@ -266,7 +266,7 @@ export class ChatStore {
    * Used by SessionStatsSummaryComponent to display context usage
    */
   readonly liveModelStats = computed(
-    () => this.tabManager.activeTab()?.liveModelStats ?? null
+    () => this.tabManager.activeTab()?.liveModelStats ?? null,
   );
 
   /**
@@ -274,7 +274,7 @@ export class ChatStore {
    * Contains all models used in the session with their individual cost/token stats.
    */
   readonly modelUsageList = computed(
-    () => this.tabManager.activeTab()?.modelUsageList ?? null
+    () => this.tabManager.activeTab()?.modelUsageList ?? null,
   );
 
   /**
@@ -282,7 +282,7 @@ export class ChatStore {
    * Delegates to PermissionHandlerService
    */
   getPermissionForTool(
-    toolCallId: string | undefined
+    toolCallId: string | undefined,
   ): PermissionRequest | null {
     return this.permissionHandler.getPermissionForTool(toolCallId);
   }
@@ -369,12 +369,21 @@ export class ChatStore {
   }
 
   /**
+   * Update a session's name in the local list (UI only)
+   * Called after successful backend rename to update UI state
+   * Delegates to SessionLoaderService
+   */
+  updateSessionName(sessionId: SessionId, name: string): void {
+    return this.sessionLoader.updateSessionName(sessionId, name);
+  }
+
+  /**
    * Send a message - automatically determines whether to start new or continue
    * Delegates to MessageSenderService (TASK_2025_054 Batch 3 - eliminates callback indirection)
    */
   async sendMessage(
     content: string,
-    options?: SendMessageOptions
+    options?: SendMessageOptions,
   ): Promise<void> {
     return this.messageSender.send(content, options);
   }
@@ -386,7 +395,7 @@ export class ChatStore {
    */
   async sendOrQueueMessage(
     content: string,
-    options?: SendMessageOptions
+    options?: SendMessageOptions,
   ): Promise<void> {
     // Check if streaming via active tab status
     const activeTab = this.tabManager.activeTab();
@@ -408,7 +417,7 @@ export class ChatStore {
         }
         console.log(
           '[ChatStore] Auto-denied permissions on message send:',
-          activePermissions.length
+          activePermissions.length,
         );
       }
 
@@ -487,7 +496,7 @@ export class ChatStore {
       try {
         const result = await this._claudeRpcService.call(
           'license:getStatus',
-          {} as Record<string, never>
+          {} as Record<string, never>,
         );
 
         if (result.isSuccess()) {
@@ -498,7 +507,7 @@ export class ChatStore {
           if (attempt === retries) {
             console.error(
               '[ChatStore] Failed to fetch license status after retries:',
-              result.error
+              result.error,
             );
             this._licenseStatus.set(null);
           }
@@ -507,7 +516,7 @@ export class ChatStore {
         if (attempt === retries) {
           console.error(
             '[ChatStore] Error fetching license status after retries:',
-            error
+            error,
           );
           this._licenseStatus.set(null);
         } else {
@@ -559,7 +568,7 @@ export class ChatStore {
       this._isCompacting.set(false);
       this.compactionTimeoutId = null;
       console.warn(
-        '[ChatStore] Compaction safety timeout reached — compaction_complete event may have been lost'
+        '[ChatStore] Compaction safety timeout reached — compaction_complete event may have been lost',
       );
     }, ChatStore.COMPACTION_SAFETY_TIMEOUT_MS);
   }
@@ -625,7 +634,7 @@ export class ChatStore {
     if (!activeTab?.streamingState) {
       console.warn(
         '[ChatStore] No active tab with streamingState for summary chunk:',
-        { toolUseId, agentId }
+        { toolUseId, agentId },
       );
       return;
     }
@@ -717,7 +726,7 @@ export class ChatStore {
    */
   private async sendQueuedMessage(
     tabId: string,
-    content: string
+    content: string,
   ): Promise<void> {
     try {
       console.log('[ChatStore] sendQueuedMessage: clearing queue and sending');
@@ -738,11 +747,11 @@ export class ChatStore {
       // Pass files from stored options (effort is set at session config level, not per-message for continue).
       await this.conversation.continueConversation(
         content,
-        queuedOptions?.files
+        queuedOptions?.files,
       );
 
       console.log(
-        '[ChatStore] sendQueuedMessage: queued message sent successfully'
+        '[ChatStore] sendQueuedMessage: queued message sent successfully',
       );
     } catch (error) {
       console.error('[ChatStore] sendQueuedMessage failed:', error);
@@ -766,12 +775,12 @@ export class ChatStore {
   processStreamEvent(
     event: FlatStreamEventUnion,
     tabId?: string,
-    sessionId?: string
+    sessionId?: string,
   ): void {
     const result = this.streamingHandler.processStreamEvent(
       event,
       tabId,
-      sessionId
+      sessionId,
     );
 
     // Handle compaction complete: dismiss banner, reset tree, clear finalized messages
@@ -884,7 +893,7 @@ export class ChatStore {
    */
   public queueOrAppendMessage(
     content: string,
-    options?: SendMessageOptions
+    options?: SendMessageOptions,
   ): void {
     this.conversation.queueOrAppendMessage(content, options);
   }
@@ -949,7 +958,7 @@ export class ChatStore {
         stats.modelUsage.length === 1
           ? stats.modelUsage[0]
           : stats.modelUsage.reduce((best, current) =>
-              current.outputTokens > best.outputTokens ? current : best
+              current.outputTokens > best.outputTokens ? current : best,
             );
       // Context usage = input + output tokens only.
       // Cache-read tokens are NOT included: they represent prompt cache hits (a billing/perf metric)
@@ -1048,7 +1057,7 @@ export class ChatStore {
     // SESSION_STATS (from type=result) is the authoritative completion signal.
     console.log(
       '[ChatStore] chat:complete received (no-op, streaming managed by SESSION_STATS):',
-      data
+      data,
     );
   }
 
@@ -1101,7 +1110,7 @@ export class ChatStore {
     this.sessionLoader.loadSessions().catch((err) => {
       console.warn(
         '[ChatStore] Failed to refresh sessions after ID resolved:',
-        err
+        err,
       );
     });
   }

--- a/libs/frontend/chat/src/lib/utils/message-summary.utils.ts
+++ b/libs/frontend/chat/src/lib/utils/message-summary.utils.ts
@@ -7,6 +7,8 @@ import type { ExecutionNode } from '@ptah-extension/shared';
 export interface MessageSummary {
   /** First ~80 chars of agent's text response, truncated at word boundary */
   readonly title: string;
+  /** Longer excerpt (~300 chars) for card-like collapsed display, null when title covers full text */
+  readonly description: string | null;
   /** Count of unique file paths referenced in tool calls */
   readonly filesChanged: number;
   /** Total number of tool invocations */
@@ -51,10 +53,10 @@ const FILE_PATH_KEYS = ['file_path', 'notebook_path', 'filePath'] as const;
  */
 function walkNode(
   node: ExecutionNode,
-  state: { title: string; files: Set<string>; toolCount: number },
+  state: { rawText: string; files: Set<string>; toolCount: number },
 ): void {
-  if (node.type === 'text' && !state.title && node.content) {
-    state.title = truncateAtWordBoundary(node.content, 80);
+  if (node.type === 'text' && !state.rawText && node.content) {
+    state.rawText = node.content.replace(/\s+/g, ' ').trim();
   }
 
   if (node.type === 'tool') {
@@ -93,14 +95,18 @@ export function extractMessageSummary(
   messageCost?: number,
   messageDuration?: number,
 ): MessageSummary {
-  const state = { title: '', files: new Set<string>(), toolCount: 0 };
+  const state = { rawText: '', files: new Set<string>(), toolCount: 0 };
 
   if (rootNode) {
     walkNode(rootNode, state);
   }
 
+  const rawText = state.rawText;
+
   return {
-    title: state.title || 'Assistant response',
+    title: rawText ? truncateAtWordBoundary(rawText, 80) : 'Assistant response',
+    description:
+      rawText.length > 80 ? truncateAtWordBoundary(rawText, 300) : null,
     filesChanged: state.files.size,
     toolCount: state.toolCount,
     cost: messageCost,

--- a/libs/frontend/core/src/lib/services/claude-rpc.service.ts
+++ b/libs/frontend/core/src/lib/services/claude-rpc.service.ts
@@ -36,7 +36,7 @@ export class RpcResult<T> {
      * - 'LICENSE_REQUIRED': No valid license (subscription expired or not found)
      * - 'PRO_TIER_REQUIRED': Pro subscription required for this feature
      */
-    public readonly errorCode?: 'LICENSE_REQUIRED' | 'PRO_TIER_REQUIRED'
+    public readonly errorCode?: 'LICENSE_REQUIRED' | 'PRO_TIER_REQUIRED',
   ) {}
 
   /**
@@ -171,18 +171,18 @@ export class ClaudeRpcService implements MessageHandler {
   async call<T extends RpcMethodName>(
     method: T,
     params: RpcMethodParams<T>,
-    options?: RpcCallOptions
+    options?: RpcCallOptions,
   ): Promise<RpcResult<RpcMethodResult<T>>> {
     // Check license before making RPC call
     if (!this.isMethodAllowed(method)) {
       console.warn(
-        `[ClaudeRpcService] RPC blocked - method "${method}" requires license`
+        `[ClaudeRpcService] RPC blocked - method "${method}" requires license`,
       );
       return new RpcResult<RpcMethodResult<T>>(
         false,
         undefined,
         `License required: ${method}`,
-        'LICENSE_REQUIRED'
+        'LICENSE_REQUIRED',
       );
     }
 
@@ -194,7 +194,7 @@ export class ClaudeRpcService implements MessageHandler {
       // The map stores callbacks as RpcResponse<unknown> for type erasure;
       // at call-site we know the concrete type so the cast is safe.
       this.pendingCalls.set(correlationId, ((
-        response: RpcResponse<RpcMethodResult<T>>
+        response: RpcResponse<RpcMethodResult<T>>,
       ) => {
         this.pendingCalls.delete(correlationId);
         clearTimeout(timer);
@@ -206,8 +206,8 @@ export class ClaudeRpcService implements MessageHandler {
             response.success,
             response.data,
             errorStr,
-            response.errorCode
-          )
+            response.errorCode,
+          ),
         );
       }) as (response: RpcResponse<unknown>) => void);
 
@@ -220,8 +220,8 @@ export class ClaudeRpcService implements MessageHandler {
             new RpcResult<RpcMethodResult<T>>(
               false,
               undefined,
-              `RPC timeout: ${method}`
-            )
+              `RPC timeout: ${method}`,
+            ),
           );
         }
       }, timeout);
@@ -239,7 +239,7 @@ export class ClaudeRpcService implements MessageHandler {
    * Backend may send error as a string or as { message: string } depending on code path.
    */
   private normalizeError(
-    error: string | { message: string } | undefined
+    error: string | { message: string } | undefined,
   ): string | undefined {
     if (error === undefined) return undefined;
     if (typeof error === 'string') return error;
@@ -290,10 +290,10 @@ export class ClaudeRpcService implements MessageHandler {
   async listSessions(
     workspacePath: string,
     limit?: number,
-    offset?: number
+    offset?: number,
   ): Promise<RpcResult<SessionListResult>> {
     console.log(
-      '🔵 [ClaudeRpcService] listSessions() called - Sending RPC request...'
+      '🔵 [ClaudeRpcService] listSessions() called - Sending RPC request...',
     );
     const result = await this.call('session:list', {
       workspacePath,
@@ -315,7 +315,7 @@ export class ClaudeRpcService implements MessageHandler {
    * @returns Session with messages
    */
   async loadSession(
-    sessionId: SessionId
+    sessionId: SessionId,
   ): Promise<RpcResult<SessionLoadResult>> {
     return this.call('session:load', { sessionId });
   }
@@ -328,7 +328,7 @@ export class ClaudeRpcService implements MessageHandler {
    */
   async openFile(
     path: string,
-    line?: number
+    line?: number,
   ): Promise<RpcResult<FileOpenResult>> {
     return this.call('file:open', { path, line });
   }
@@ -339,10 +339,10 @@ export class ClaudeRpcService implements MessageHandler {
    * @returns Promise with success status
    */
   async deleteSession(
-    sessionId: SessionId
+    sessionId: SessionId,
   ): Promise<RpcResult<{ success: boolean; error?: string }>> {
     console.log(
-      '🗑️ [ClaudeRpcService] deleteSession() called - Sending RPC request...'
+      '🗑️ [ClaudeRpcService] deleteSession() called - Sending RPC request...',
     );
     const result = await this.call('session:delete', { sessionId });
     console.log('✅ [ClaudeRpcService] deleteSession() response:', {
@@ -350,6 +350,19 @@ export class ClaudeRpcService implements MessageHandler {
       error: result.error,
     });
     return result;
+  }
+
+  /**
+   * Rename a chat session
+   * @param sessionId - Session ID to rename
+   * @param name - New session name
+   * @returns Promise with success status
+   */
+  async renameSession(
+    sessionId: SessionId,
+    name: string,
+  ): Promise<RpcResult<{ success: boolean; error?: string }>> {
+    return this.call('session:rename', { sessionId, name });
   }
 
   // ============================================================================
@@ -367,7 +380,7 @@ export class ClaudeRpcService implements MessageHandler {
    */
   async querySubagents(): Promise<RpcResult<SubagentQueryResult>> {
     console.log(
-      '🔍 [ClaudeRpcService] querySubagents() called - Sending RPC request...'
+      '🔍 [ClaudeRpcService] querySubagents() called - Sending RPC request...',
     );
     const result = await this.call('chat:subagent-query', {});
     console.log('✅ [ClaudeRpcService] querySubagents() response:', {

--- a/libs/frontend/editor/src/lib/git-status-bar/git-status-bar.component.ts
+++ b/libs/frontend/editor/src/lib/git-status-bar/git-status-bar.component.ts
@@ -229,9 +229,11 @@ export class GitStatusBarComponent {
   /** Close the worktree dropdown when clicking outside the component. */
   @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent): void {
+    const target = event.target;
     if (
       this.showWorktreeList() &&
-      !this.elementRef.nativeElement.contains(event.target)
+      target instanceof Node &&
+      !this.elementRef.nativeElement.contains(target)
     ) {
       this.showWorktreeList.set(false);
     }

--- a/libs/frontend/editor/src/lib/git-status-bar/git-status-bar.component.ts
+++ b/libs/frontend/editor/src/lib/git-status-bar/git-status-bar.component.ts
@@ -4,7 +4,6 @@ import {
   signal,
   computed,
   ChangeDetectionStrategy,
-  HostListener,
   ElementRef,
 } from '@angular/core';
 import {
@@ -219,6 +218,7 @@ import type { GitWorktreeInfo } from '@ptah-extension/shared';
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { '(document:click)': 'onDocumentClick($event)' },
 })
 export class GitStatusBarComponent {
   protected readonly gitStatus = inject(GitStatusService);
@@ -227,7 +227,6 @@ export class GitStatusBarComponent {
   private readonly elementRef = inject(ElementRef);
 
   /** Close the worktree dropdown when clicking outside the component. */
-  @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent): void {
     const target = event.target;
     if (

--- a/libs/frontend/editor/src/lib/git-status-bar/git-status-bar.component.ts
+++ b/libs/frontend/editor/src/lib/git-status-bar/git-status-bar.component.ts
@@ -4,6 +4,8 @@ import {
   signal,
   computed,
   ChangeDetectionStrategy,
+  HostListener,
+  ElementRef,
 } from '@angular/core';
 import {
   LucideAngularModule,
@@ -13,16 +15,19 @@ import {
   FileEdit,
   GitFork,
   Plus,
+  FolderOpen,
 } from 'lucide-angular';
+import { ElectronLayoutService } from '@ptah-extension/core';
 import { GitStatusService } from '../services/git-status.service';
 import { WorktreeService } from '../services/worktree.service';
 import { AddWorktreeDialogComponent } from '../worktree/add-worktree-dialog.component';
+import type { GitWorktreeInfo } from '@ptah-extension/shared';
 
 /**
  * GitStatusBarComponent - Horizontal bar showing git branch info, ahead/behind counts,
- * changed file count, worktree indicator, and add-worktree action.
+ * changed file count, worktree indicator with dropdown, and add-worktree action.
  *
- * Complexity Level: 2 (Medium - delegates to two services, toggles dialog visibility)
+ * Complexity Level: 2 (Medium - delegates to two services, toggles dialog/dropdown visibility)
  * Patterns: Standalone component, OnPush, signal-based delegation, composition
  *
  * Renders only when the active workspace is a git repository (isGitRepo guard).
@@ -30,7 +35,8 @@ import { AddWorktreeDialogComponent } from '../worktree/add-worktree-dialog.comp
  *
  * Worktree integration (TASK_2025_227 Batch 6):
  * - Loads worktrees on init via WorktreeService
- * - Shows worktree count with GitFork icon when > 1
+ * - Shows worktree count with GitFork icon when > 1 (clickable dropdown)
+ * - Clicking a worktree in the dropdown switches the file explorer to show its files
  * - Provides "Add Worktree" button that toggles the AddWorktreeDialogComponent
  */
 @Component({
@@ -60,18 +66,75 @@ import { AddWorktreeDialogComponent } from '../worktree/add-worktree-dialog.comp
           </span>
         </div>
 
-        <!-- Worktree count indicator (only when more than 1 worktree) -->
+        <!-- Worktree count indicator (clickable when > 1 to show dropdown) -->
         @if (worktreeCount() > 1) {
-          <div
-            class="flex items-center gap-0.5 opacity-60"
-            [title]="worktreeCount() + ' active worktrees'"
-          >
-            <lucide-angular
-              [img]="GitForkIcon"
-              class="w-3 h-3"
-              aria-hidden="true"
-            />
-            <span>{{ worktreeCount() }}</span>
+          <div class="relative">
+            <button
+              type="button"
+              class="flex items-center gap-0.5 opacity-60 hover:opacity-100
+                     cursor-pointer transition-opacity"
+              [title]="worktreeCount() + ' active worktrees — click to browse'"
+              aria-label="Show worktree list"
+              [attr.aria-expanded]="showWorktreeList()"
+              (click)="toggleWorktreeList()"
+            >
+              <lucide-angular
+                [img]="GitForkIcon"
+                class="w-3 h-3"
+                aria-hidden="true"
+              />
+              <span>{{ worktreeCount() }}</span>
+            </button>
+
+            <!-- Worktree dropdown list -->
+            @if (showWorktreeList()) {
+              <div
+                class="absolute left-0 top-full mt-1 z-50 min-w-[280px] max-w-[400px]
+                       bg-base-300 border border-base-content/10 rounded-lg shadow-lg
+                       py-1 text-xs"
+                role="listbox"
+                aria-label="Worktree list"
+              >
+                <div
+                  class="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider
+                         opacity-50 border-b border-base-content/5"
+                >
+                  Git Worktrees
+                </div>
+                @for (wt of worktreeService.worktrees(); track wt.path) {
+                  <button
+                    type="button"
+                    class="flex items-center gap-2 w-full px-3 py-1.5 text-left
+                           hover:bg-base-content/10 transition-colors"
+                    [class.bg-primary]="wt.isMain"
+                    [class.bg-opacity-10]="wt.isMain"
+                    role="option"
+                    [attr.aria-selected]="wt.isMain"
+                    [title]="'Open ' + wt.path + ' in file explorer'"
+                    (click)="onWorktreeSelect(wt)"
+                  >
+                    <lucide-angular
+                      [img]="wt.isMain ? GitBranchIcon : FolderOpenIcon"
+                      class="w-3.5 h-3.5 flex-shrink-0 opacity-60"
+                      aria-hidden="true"
+                    />
+                    <div class="flex flex-col min-w-0 gap-0.5">
+                      <span class="font-medium truncate">
+                        {{ extractBranchName(wt.branch) }}
+                        @if (wt.isMain) {
+                          <span class="text-primary opacity-70 ml-1"
+                            >(main)</span
+                          >
+                        }
+                      </span>
+                      <span class="opacity-40 truncate text-[10px]">{{
+                        wt.path
+                      }}</span>
+                    </div>
+                  </button>
+                }
+              </div>
+            }
           </div>
         }
 
@@ -159,7 +222,20 @@ import { AddWorktreeDialogComponent } from '../worktree/add-worktree-dialog.comp
 })
 export class GitStatusBarComponent {
   protected readonly gitStatus = inject(GitStatusService);
-  private readonly worktreeService = inject(WorktreeService);
+  protected readonly worktreeService = inject(WorktreeService);
+  private readonly layoutService = inject(ElectronLayoutService);
+  private readonly elementRef = inject(ElementRef);
+
+  /** Close the worktree dropdown when clicking outside the component. */
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (
+      this.showWorktreeList() &&
+      !this.elementRef.nativeElement.contains(event.target)
+    ) {
+      this.showWorktreeList.set(false);
+    }
+  }
 
   // ============================================================================
   // ICONS
@@ -171,6 +247,7 @@ export class GitStatusBarComponent {
   protected readonly FileEditIcon = FileEdit;
   protected readonly GitForkIcon = GitFork;
   protected readonly PlusIcon = Plus;
+  protected readonly FolderOpenIcon = FolderOpen;
 
   // ============================================================================
   // WORKTREE STATE
@@ -178,6 +255,9 @@ export class GitStatusBarComponent {
 
   /** Whether the add-worktree dialog is visible. */
   protected readonly showAddWorktreeDialog = signal(false);
+
+  /** Whether the worktree list dropdown is visible. */
+  protected readonly showWorktreeList = signal(false);
 
   /** Number of active worktrees, derived from WorktreeService. */
   protected readonly worktreeCount = computed(
@@ -187,6 +267,37 @@ export class GitStatusBarComponent {
   constructor() {
     // Load worktrees on init so the count indicator is populated
     this.worktreeService.loadWorktrees();
+  }
+
+  // ============================================================================
+  // WORKTREE LIST ACTIONS
+  // ============================================================================
+
+  /** Toggle the worktree list dropdown. */
+  protected toggleWorktreeList(): void {
+    this.showWorktreeList.update((v) => !v);
+  }
+
+  /**
+   * Handle worktree selection from the dropdown.
+   * Adds the worktree as a workspace folder and switches to it,
+   * which triggers the file tree to reload with the worktree's files.
+   */
+  protected onWorktreeSelect(worktree: GitWorktreeInfo): void {
+    this.showWorktreeList.set(false);
+    if (worktree.path) {
+      this.layoutService.addFolderByPath(worktree.path);
+    }
+  }
+
+  /**
+   * Display-friendly branch name with fallback for detached HEAD.
+   * parseWorktreeList() already strips refs/heads/ prefix, so this
+   * is purely a null/detached-state fallback.
+   */
+  protected extractBranchName(branch: string | undefined): string {
+    if (!branch) return '(detached)';
+    return branch;
   }
 
   // ============================================================================

--- a/libs/frontend/ui/src/lib/native/dropdown/native-dropdown.component.ts
+++ b/libs/frontend/ui/src/lib/native/dropdown/native-dropdown.component.ts
@@ -46,7 +46,6 @@ import {
   inject,
   effect,
   OnDestroy,
-  HostListener,
 } from '@angular/core';
 import { Placement } from '@floating-ui/dom';
 import { FloatingUIService } from '../shared';
@@ -70,27 +69,27 @@ import { FloatingUIService } from '../shared';
 
     <!-- Dropdown panel (conditionally rendered) -->
     @if (isOpen()) {
-    <!-- Backdrop for click-outside detection -->
-    @if (hasBackdrop()) {
-    <div
-      class="fixed inset-0 z-40"
-      [class]="backdropClass() === 'dark' ? 'bg-black/20' : ''"
-      (click)="handleBackdropClick()"
-      tabindex="-1"
-      role="presentation"
-      aria-hidden="true"
-    ></div>
-    }
+      <!-- Backdrop for click-outside detection -->
+      @if (hasBackdrop()) {
+        <div
+          class="fixed inset-0 z-40"
+          [class]="backdropClass() === 'dark' ? 'bg-black/20' : ''"
+          (click)="handleBackdropClick()"
+          tabindex="-1"
+          role="presentation"
+          aria-hidden="true"
+        ></div>
+      }
 
-    <!-- Floating content - starts hidden until positioned -->
-    <div
-      #floatingRef
-      class="dropdown-panel bg-base-200 border border-base-300 rounded-lg shadow-lg z-50"
-      style="visibility: hidden;"
-      role="listbox"
-    >
-      <ng-content select="[content]" />
-    </div>
+      <!-- Floating content - starts hidden until positioned -->
+      <div
+        #floatingRef
+        class="dropdown-panel bg-base-200 border border-base-300 rounded-lg shadow-lg z-50"
+        style="visibility: hidden;"
+        role="listbox"
+      >
+        <ng-content select="[content]" />
+      </div>
     }
   `,
   styles: [
@@ -101,6 +100,7 @@ import { FloatingUIService } from '../shared';
       }
     `,
   ],
+  host: { '(document:click)': 'onDocumentClick($event)' },
 })
 export class NativeDropdownComponent implements OnDestroy {
   private readonly floatingUI = inject(FloatingUIService);
@@ -225,7 +225,6 @@ export class NativeDropdownComponent implements OnDestroy {
    * Handle outside clicks when hasBackdrop is false.
    * Closes dropdown if click is outside trigger and floating panel.
    */
-  @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent): void {
     if (!this.isOpen() || this.hasBackdrop()) return;
 

--- a/libs/shared/src/lib/types/rpc.types.ts
+++ b/libs/shared/src/lib/types/rpc.types.ts
@@ -57,6 +57,8 @@ import type {
   SessionLoadResult,
   SessionDeleteParams,
   SessionDeleteResult,
+  SessionRenameParams,
+  SessionRenameResult,
   SessionValidateParams,
   SessionValidateResult,
   SessionCliSessionsParams,
@@ -260,6 +262,10 @@ export interface RpcMethodRegistry {
   'session:delete': {
     params: SessionDeleteParams;
     result: SessionDeleteResult;
+  };
+  'session:rename': {
+    params: SessionRenameParams;
+    result: SessionRenameResult;
   };
   'session:validate': {
     params: SessionValidateParams;
@@ -863,6 +869,7 @@ export const RPC_METHOD_NAMES: RpcMethodName[] = [
   'session:list',
   'session:load',
   'session:delete',
+  'session:rename',
   'session:validate',
   'session:cli-sessions',
   'session:stats-batch',

--- a/libs/shared/src/lib/types/rpc/rpc-session.types.ts
+++ b/libs/shared/src/lib/types/rpc/rpc-session.types.ts
@@ -62,6 +62,20 @@ export interface SessionDeleteResult {
   error?: string;
 }
 
+/** Parameters for session:rename RPC method */
+export interface SessionRenameParams {
+  /** Session ID to rename */
+  sessionId: SessionId;
+  /** New session name */
+  name: string;
+}
+
+/** Response from session:rename RPC method */
+export interface SessionRenameResult {
+  success: boolean;
+  error?: string;
+}
+
 /** Parameters for session:validate RPC method */
 export interface SessionValidateParams {
   /** Session ID to validate */


### PR DESCRIPTION
Move browser session configuration (headless/viewport) from VS Code settings to agent-controlled parameters on ptah_browser_navigate. The agent now decides per-session whether to run headless and at what viewport size, with sensible defaults (visible, 1920x1080 desktop).

- Add headless and viewport params to ptah_browser_navigate tool
- Add configureSession() to IBrowserCapabilities interface
- Update ChromeLauncherBrowserCapabilities with CDP viewport emulation
- Update ElectronBrowserCapabilities with BrowserWindow sizing
- Remove ptah.browser.headless VS Code setting
- Default headless=false (visible), viewport=1920x1080 (desktop)
- Update system prompt with responsive testing examples
- Fix @nx/enforce-module-boundaries: convert dynamic import of parseWorktreeList to static import (already imported in same file)