### PR TITLE
fix: move attachment buttons to input area, update domain and config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
   "ptah.authMethod": "oauth",
   "ptah.model.selected": "opus",
-  "ptah.reasoningEffort": "high",
-  "ptah.autopilot.enabled": true,
-  "ptah.autopilot.permissionLevel": "yolo"
+  "ptah.reasoningEffort": "high"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "ptah.authMethod": "oauth",
   "ptah.model.selected": "opus",
-  "ptah.reasoningEffort": "high"
+  "ptah.reasoningEffort": "high",
+  "ptah.autopilot.enabled": true,
+  "ptah.autopilot.permissionLevel": "yolo"
 }

--- a/apps/ptah-electron/src/menu/application-menu.ts
+++ b/apps/ptah-electron/src/menu/application-menu.ts
@@ -35,7 +35,7 @@ const isMac = process.platform === 'darwin';
  */
 export function createApplicationMenu(
   container: DependencyContainer,
-  getWindow: () => BrowserWindow | null
+  getWindow: () => BrowserWindow | null,
 ): void {
   const template: MenuItemConstructorOptions[] = [];
 
@@ -182,13 +182,13 @@ export function createApplicationMenu(
       {
         label: 'Open Website',
         click: async () => {
-          await shell.openExternal('https://ptah.dev');
+          await shell.openExternal('https://ptah.live');
         },
       },
       {
         label: 'Documentation',
         click: async () => {
-          await shell.openExternal('https://ptah.dev/docs');
+          await shell.openExternal('https://ptah.live/docs');
         },
       },
       { type: 'separator' },
@@ -224,7 +224,7 @@ export function createApplicationMenu(
  */
 async function handleOpenFolder(
   container: DependencyContainer,
-  getWindow: () => BrowserWindow | null
+  getWindow: () => BrowserWindow | null,
 ): Promise<void> {
   const win = getWindow();
   const dialogOptions = {
@@ -245,7 +245,7 @@ async function handleOpenFolder(
 
   try {
     const workspaceProvider = container.resolve<IWorkspaceProvider>(
-      PLATFORM_TOKENS.WORKSPACE_PROVIDER
+      PLATFORM_TOKENS.WORKSPACE_PROVIDER,
     );
 
     // ElectronWorkspaceProvider has setWorkspaceFolders()
@@ -269,7 +269,7 @@ async function handleOpenFolder(
   } catch (error) {
     console.error(
       '[ApplicationMenu] Failed to set workspace folder:',
-      error instanceof Error ? error.message : String(error)
+      error instanceof Error ? error.message : String(error),
     );
   }
 }
@@ -282,7 +282,7 @@ async function handleOpenFolder(
 function sendRendererMessage(
   getWindow: () => BrowserWindow | null,
   type: string,
-  payload?: unknown
+  payload?: unknown,
 ): void {
   const win = getWindow();
   if (win) {

--- a/apps/ptah-extension-vscode/src/main.ts
+++ b/apps/ptah-extension-vscode/src/main.ts
@@ -471,34 +471,25 @@ async function handleLicenseBlocking(
     }),
   );
 
-  console.log(
-    '[Activate] Webview registered with welcome view for unlicensed user',
-  );
   // DO NOT call showLicenseRequiredUI() - webview handles onboarding
 }
 
 export async function activate(
   context: vscode.ExtensionContext,
 ): Promise<void> {
-  console.log('===== PTAH ACTIVATION START =====');
   try {
     // ========================================
     // STEP 1: MINIMAL DI SETUP FOR LICENSE CHECK (TASK_2025_121)
     // ========================================
     // Initialize minimal DI container with only license-related services
     // This allows license verification before full service initialization
-    console.log(
-      '[Activate] Step 1: Setting up minimal DI for license check...',
-    );
     DIContainer.setupMinimal(context);
-    console.log('[Activate] Step 1: Minimal DI setup complete');
 
     // ========================================
     // STEP 2: LICENSE VERIFICATION (BLOCKING)
     // ========================================
     // CRITICAL: License verification MUST happen BEFORE full service init
     // If license is invalid, block extension and show license UI
-    console.log('[Activate] Step 2: Verifying license (BLOCKING)...');
     const licenseService = DIContainer.resolve<LicenseService>(
       TOKENS.LICENSE_SERVICE,
     );
@@ -509,56 +500,39 @@ export async function activate(
     // Community users (no license key) have valid: true and bypass this block
     if (!licenseStatus.valid) {
       // BLOCK EXTENSION - Only for revoked/payment-failed licenses
-      console.log(
-        `[Activate] BLOCKED: License invalid (reason: ${
-          licenseStatus.reason || 'unknown'
-        })`,
-      );
-
       // Handle blocking flow (show UI, register minimal commands)
       await handleLicenseBlocking(context, licenseService, licenseStatus);
 
       // DO NOT continue with normal activation
-      console.log('[Activate] Extension blocked - awaiting valid license');
       return;
     }
 
     // Community and Pro users both reach here
-    console.log(
-      `[Activate] Step 2: License verified (tier: ${licenseStatus.tier})`,
-    );
 
     // ========================================
     // STEP 3: FULL DI SETUP (Licensed users only)
     // ========================================
-    console.log('[Activate] Step 3: Setting up full DI Container...');
     DIContainer.setup(context);
-    console.log('[Activate] Step 3: Full DI Container setup complete');
 
     // ========================================
     // STEP 3.5: MIGRATE FILE-BASED SETTINGS (TASK_2025_247)
 
     // Get logger from DI container
-    console.log('[Activate] Step 4: Resolving Logger...');
     const logger = DIContainer.resolve<Logger>(TOKENS.LOGGER);
     logger.info('Activating Ptah extension (licensed user)...', {
       tier: licenseStatus.tier,
       valid: licenseStatus.valid,
     });
-    console.log('[Activate] Step 4: Logger resolved');
 
     // Register RPC Methods (Phase 2 - TASK_2025_021)
     // Extracted to RpcMethodRegistrationService for clean separation
-    console.log('[Activate] Step 5: Registering RPC methods...');
     const rpcMethodRegistration = DIContainer.resolve(
       TOKENS.RPC_METHOD_REGISTRATION_SERVICE,
     ) as { registerAll: () => void };
     rpcMethodRegistration.registerAll();
-    console.log('[Activate] Step 5: RPC methods registered');
 
     // Initialize autocomplete discovery watchers (TASK_2025_019 Phase 2)
     // NOTE: MCP discovery service was planned but never implemented - only agent and command discovery exist
-    console.log('[Activate] Step 6: Initializing autocomplete watchers...');
     const agentDiscovery = DIContainer.resolve(
       TOKENS.AGENT_DISCOVERY_SERVICE,
     ) as { initializeWatchers: () => void };
@@ -568,10 +542,8 @@ export async function activate(
     agentDiscovery.initializeWatchers();
     commandDiscovery.initializeWatchers();
     logger.info('Autocomplete discovery watchers initialized (2 services)');
-    console.log('[Activate] Step 6: Autocomplete watchers initialized');
 
     // Step 7: Initialize SDK authentication (TASK_2025_057 Batch 1)
-    console.log('[Activate] Step 7: Initializing SDK authentication...');
     const sdkAdapter = DIContainer.resolve(TOKENS.SDK_AGENT_ADAPTER) as {
       initialize: () => Promise<boolean>;
       preloadSdk: () => Promise<void>;
@@ -587,17 +559,12 @@ export async function activate(
 
       // Pre-load SDK in background (non-blocking) to speed up first chat
       // This shifts ~100-200ms import cost from first user interaction to activation
-      console.log('[Activate] Step 7.1: Pre-loading SDK in background...');
       sdkAdapter.preloadSdk().catch((err) => {
         logger.warn('SDK preload failed (will retry on first use)', {
           error: err instanceof Error ? err.message : String(err),
         });
       });
     }
-    console.log(
-      '[Activate] Step 7: SDK authentication initialization complete',
-    );
-
     // Step 7.1.4: Ensure plugin/template content from GitHub (non-blocking)
     // TASK_2025_248: Plugins and templates are no longer bundled in the VSIX.
     // ContentDownloadService downloads them to ~/.ptah/ on first launch and
@@ -615,7 +582,6 @@ export async function activate(
     });
 
     // Step 7.1.5: Initialize plugin loader with extension path (TASK_2025_153)
-    console.log('[Activate] Step 7.1.5: Initializing plugin loader...');
     try {
       const pluginLoader = DIContainer.resolve<PluginLoaderService>(
         SDK_TOKENS.SDK_PLUGIN_LOADER,
@@ -652,14 +618,9 @@ export async function activate(
             : String(pluginLoaderError),
       });
     }
-    console.log('[Activate] Step 7.1.5: Plugin loader initialized');
-
     // Step 7.1.5.1: Create workspace skill junctions (TASK_2025_201)
     // Project skill files from extension assets into workspace .ptah/skills/ via junctions
     // So third-party providers (Copilot, Codex) can find skills via MCP workspace search
-    console.log(
-      '[Activate] Step 7.1.5.1: Creating workspace skill junctions...',
-    );
     try {
       const skillJunction = DIContainer.resolve<SkillJunctionService>(
         SDK_TOKENS.SDK_SKILL_JUNCTION,
@@ -701,12 +662,9 @@ export async function activate(
             : String(skillJunctionError),
       });
     }
-    console.log('[Activate] Step 7.1.5.1: Skill junctions ready');
-
     // Step 7.1.6: CLI Skill Sync (TASK_2025_160)
     // Sync Ptah plugin skills to installed CLI agent directories (Copilot, Gemini)
     // Premium-only, non-blocking, fire-and-forget
-    console.log('[Activate] Step 7.1.6: CLI skill sync...');
     if (licenseStatus.tier === 'pro' || licenseStatus.tier === 'trial_pro') {
       try {
         const cliPluginSync = DIContainer.getContainer().resolve(
@@ -771,12 +729,9 @@ export async function activate(
         'CLI skill sync skipped (Community tier - Pro feature only)',
       );
     }
-    console.log('[Activate] Step 7.1.6: CLI skill sync initiated');
-
     // Step 7.2: Pre-fetch model pricing from OpenRouter (non-blocking, no auth needed)
     // OpenRouter's /api/v1/models endpoint is publicly accessible and returns
     // pricing data for 200+ models. This replaces hardcoded pricing with live data.
-    console.log('[Activate] Step 7.2: Pre-fetching model pricing...');
     try {
       const providerModels = DIContainer.getContainer().resolve(
         SDK_TOKENS.SDK_PROVIDER_MODELS,
@@ -792,13 +747,8 @@ export async function activate(
             : String(prefetchError),
       });
     }
-    console.log(
-      '[Activate] Step 7.2: Pricing pre-fetch initiated (background)',
-    );
-
     // Step 7.3: Proactive CLI detection (non-blocking, warms cache for agent orchestration)
     // TASK_2025_157: Detect installed CLI agents (Gemini, Codex) early so settings UI is instant
-    console.log('[Activate] Step 7.3: Proactive CLI detection...');
     try {
       const cliDetection = DIContainer.getContainer().resolve(
         TOKENS.CLI_DETECTION_SERVICE,
@@ -848,15 +798,8 @@ export async function activate(
             : String(cliDetectError),
       });
     }
-    console.log('[Activate] Step 7.3: CLI detection initiated (background)');
-
     // Step 8: Import existing Claude sessions (TASK_2025_091)
-    console.log('[Activate] Step 8: Importing existing sessions...');
     const workspacePath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-    console.log(
-      '[Activate] Step 8: workspacePath for session import:',
-      JSON.stringify(workspacePath),
-    );
     if (workspacePath) {
       try {
         const sessionImporter = DIContainer.getContainer().resolve(
@@ -877,10 +820,7 @@ export async function activate(
         });
       }
     }
-    console.log('[Activate] Step 8: Session import complete');
-
     // Step 8.1: Register Settings Export/Import commands (TASK_2025_210)
-    console.log('[Activate] Step 8.1: Registering settings commands...');
     try {
       const settingsExportService = DIContainer.getContainer().resolve(
         SDK_TOKENS.SDK_SETTINGS_EXPORT,
@@ -903,36 +843,24 @@ export async function activate(
             : String(settingsError),
       });
     }
-    console.log('[Activate] Step 8.1: Settings commands registered');
-
     // Initialize main extension controller
-    console.log('[Activate] Step 9: Creating PtahExtension instance...');
     ptahExtension = new PtahExtension(context);
-    console.log('[Activate] Step 9: PtahExtension instance created');
 
-    console.log('[Activate] Step 10: Calling ptahExtension.initialize()...');
     await ptahExtension.initialize();
-    console.log('[Activate] Step 10: ptahExtension.initialize() complete');
 
     // Auth not configured is a normal state on first install — no popup needed.
     // Users can configure authentication via Ptah Settings > Authentication tab.
     if (!authInitialized) {
-      console.log(
-        '[Activate] Step 10.1: Auth not configured — users can set up in Ptah Settings',
-      );
+      // Auth not configured — normal on first install
     }
 
     // Register all providers, commands, and services
-    console.log('[Activate] Step 11: Calling ptahExtension.registerAll()...');
     await ptahExtension.registerAll();
-    console.log('[Activate] Step 11: ptahExtension.registerAll() complete');
 
     // ========================================
     // STEP 12: CONDITIONAL MCP SERVER START (TASK_2025_121)
     // ========================================
     // MCP Server only starts for Pro tier users (Pro-only feature)
-    console.log('[Activate] Step 12: Conditional MCP Server registration...');
-
     if (licenseStatus.tier === 'pro' || licenseStatus.tier === 'trial_pro') {
       // PRO USER: Register MCP Server (Pro-only feature)
       // Non-blocking: MCP server failure should NOT crash the extension
@@ -947,26 +875,17 @@ export async function activate(
         // (may differ from default 51820 if fallback to OS-assigned port)
         setPtahMcpPort(mcpPort);
         logger.info(`Code Execution MCP Server started on port ${mcpPort}`);
-        console.log(
-          `[Activate] Step 12: Pro MCP Server started (port ${mcpPort})`,
-        );
       } catch (mcpError) {
         logger.warn('MCP server failed to start (non-blocking)', {
           error:
             mcpError instanceof Error ? mcpError.message : String(mcpError),
         });
-        console.log(
-          `[Activate] Step 12: MCP Server failed to start: ${mcpError instanceof Error ? mcpError.message : String(mcpError)}`,
-        );
       }
     } else {
       // COMMUNITY USER: Skip MCP Server (Pro-only feature)
       logger.info('Skipping MCP server (Community tier - Pro feature only)', {
         tier: licenseStatus.tier,
       });
-      console.log(
-        `[Activate] Step 12: MCP Server skipped (tier: ${licenseStatus.tier})`,
-      );
     }
 
     // Note: MCP config (.mcp.json) writing removed - SDK tools are now native
@@ -977,8 +896,6 @@ export async function activate(
     // ========================================
     // STEP 13: LICENSE STATUS WATCHER
     // ========================================
-    console.log('[Activate] Step 13: Setting up license status watcher...');
-
     // Handle dynamic license changes (upgrade/expire)
     licenseService.on('license:verified', async (newStatus: LicenseStatus) => {
       logger.info('License status changed', { newStatus });
@@ -1018,8 +935,6 @@ export async function activate(
       }
     });
 
-    console.log('[Activate] Step 13: License status watcher initialized');
-
     // Background revalidation (every 24 hours)
     const revalidationInterval = setInterval(
       () => licenseService.revalidate(),
@@ -1030,7 +945,6 @@ export async function activate(
     });
 
     logger.info('Ptah extension activated successfully');
-    console.log('===== PTAH ACTIVATION COMPLETE =====');
 
     // Show welcome message for first-time users
     const isFirstTime = context.globalState.get('ptah.firstActivation', true);

--- a/apps/ptah-extension-vscode/src/services/webview-html-generator.ts
+++ b/apps/ptah-extension-vscode/src/services/webview-html-generator.ts
@@ -44,7 +44,7 @@ export class WebviewHtmlGenerator {
           initialSessionId?: string;
           initialSessionName?: string;
         }
-      | Record<string, unknown>
+      | Record<string, unknown>,
   ): string {
     try {
       // Support both new options object and legacy workspaceInfo object
@@ -87,7 +87,7 @@ export class WebviewHtmlGenerator {
         isLicensed,
         panelId,
         initialSessionId,
-        initialSessionName
+        initialSessionName,
       );
       return htmlContent;
     } catch (error) {
@@ -95,7 +95,7 @@ export class WebviewHtmlGenerator {
       // Fallback to basic HTML
       return this.generateFallbackHtml(
         webview,
-        options as Record<string, unknown>
+        options as Record<string, unknown>,
       );
     }
   }
@@ -111,7 +111,7 @@ export class WebviewHtmlGenerator {
     isLicensed = true,
     panelId?: string,
     initialSessionId?: string,
-    initialSessionName?: string
+    initialSessionName?: string,
   ): string {
     // CRITICAL: Validate initialView to prevent invalid views from crashing navigation
     const VALID_VIEWS = [
@@ -127,8 +127,8 @@ export class WebviewHtmlGenerator {
     if (initialView && !VALID_VIEWS.includes(initialView)) {
       throw new Error(
         `Invalid initialView: "${initialView}". Valid values are: ${VALID_VIEWS.join(
-          ', '
-        )}`
+          ', ',
+        )}`,
       );
     }
     // Path to Angular dist folder (browser build output)
@@ -136,7 +136,7 @@ export class WebviewHtmlGenerator {
     const appDistPath = path.join(
       this.context.extensionPath,
       'webview',
-      'browser'
+      'browser',
     );
     const appDistPathUri = vscode.Uri.file(appDistPath);
 
@@ -164,7 +164,7 @@ export class WebviewHtmlGenerator {
     indexHtml = indexHtml.replace(
       '<meta charset="utf-8">',
       `<meta charset="utf-8">
-        <meta http-equiv="Content-Security-Policy" content="${cspContent}">`
+        <meta http-equiv="Content-Security-Policy" content="${cspContent}">`,
     );
 
     // Add VS Code integration and theme support
@@ -177,7 +177,7 @@ export class WebviewHtmlGenerator {
       isLicensed,
       panelId,
       initialSessionId,
-      initialSessionName
+      initialSessionName,
     );
     const themeStyles = this.getThemeStyles();
 
@@ -187,13 +187,13 @@ export class WebviewHtmlGenerator {
       `  <style nonce="${nonce}">
           ${themeStyles}
         </style>
-      </head>`
+      </head>`,
     );
 
     // Add VS Code theme class to body
     indexHtml = indexHtml.replace(
       '<body>',
-      `<body class="vscode-body ${this.getThemeClass(theme)}">`
+      `<body class="vscode-body ${this.getThemeClass(theme)}">`,
     );
 
     // Inject VS Code integration script before closing body
@@ -205,7 +205,7 @@ export class WebviewHtmlGenerator {
         <script nonce="${nonce}">
           ${this.getStartupScript()}
         </script>
-      </body>`
+      </body>`,
     );
 
     // Transform all asset URIs (styles.css, main.js, polyfills.js) to webview URIs
@@ -233,13 +233,10 @@ export class WebviewHtmlGenerator {
 
         // Transform relative URIs to webview URIs
         const fullUri = webview.asWebviewUri(
-          vscode.Uri.joinPath(appDistPathUri, uri)
-        );
-        console.log(
-          `[WebviewHtmlGenerator] Transforming ${attribute}="${uri}" -> "${fullUri}"`
+          vscode.Uri.joinPath(appDistPathUri, uri),
         );
         return `${attribute}="${fullUri}"`;
-      }
+      },
     );
 
     // Add nonce to inline styles (Angular critical CSS)
@@ -263,11 +260,6 @@ export class WebviewHtmlGenerator {
         return match;
       });
 
-    console.log('[WebviewHtmlGenerator] Base URI set to:', String(baseUri));
-    console.log(
-      '[WebviewHtmlGenerator] All assets transformed to webview URIs'
-    );
-
     return indexHtml;
   }
 
@@ -280,7 +272,7 @@ export class WebviewHtmlGenerator {
     html: string,
     webview: vscode.Webview,
     baseUri: vscode.Uri,
-    nonce: string
+    nonce: string,
   ): string {
     // Transform all src and href attributes using the specified regex pattern
     const transformedHtml = html.replace(
@@ -301,11 +293,8 @@ export class WebviewHtmlGenerator {
 
         // Transform relative URIs to webview URIs
         const fullUri = webview.asWebviewUri(vscode.Uri.joinPath(baseUri, uri));
-        console.log(
-          `[WebviewHtmlGenerator] Transforming ${attribute}="${uri}" -> "${fullUri}"`
-        );
         return `${attribute}="${fullUri}"`;
-      }
+      },
     );
 
     // Add nonce to script and link tags that don't have it
@@ -349,7 +338,7 @@ export class WebviewHtmlGenerator {
    */
   private generateFallbackHtml(
     webview: vscode.Webview,
-    workspaceInfo?: Record<string, unknown>
+    workspaceInfo?: Record<string, unknown>,
   ): string {
     const { scriptUri, stylesUri } = this.getAssetUris(webview);
     const nonce = this.generateNonce();
@@ -362,12 +351,12 @@ export class WebviewHtmlGenerator {
         <meta charset="utf-8">
         <title>Ptah - AI Coding Orchestra</title>
         <base href="${webview.asWebviewUri(
-          vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'browser')
+          vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'browser'),
         )}/">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta http-equiv="Content-Security-Policy" content="${this.getImprovedCSP(
           webview,
-          nonce
+          nonce,
         )}">
 
         <!-- Angular Styles -->
@@ -404,15 +393,15 @@ export class WebviewHtmlGenerator {
     const angularDistPath = vscode.Uri.joinPath(
       this.context.extensionUri,
       'webview',
-      'browser'
+      'browser',
     );
 
     return {
       scriptUri: webview.asWebviewUri(
-        vscode.Uri.joinPath(angularDistPath, 'main.js')
+        vscode.Uri.joinPath(angularDistPath, 'main.js'),
       ),
       stylesUri: webview.asWebviewUri(
-        vscode.Uri.joinPath(angularDistPath, 'styles.css')
+        vscode.Uri.joinPath(angularDistPath, 'styles.css'),
       ),
     };
   }
@@ -440,26 +429,26 @@ export class WebviewHtmlGenerator {
     isLicensed = true,
     panelId?: string,
     initialSessionId?: string,
-    initialSessionName?: string
+    initialSessionName?: string,
   ): string {
     // Generate proper webview URIs for assets
     const appDistPath = path.join(
       this.context.extensionPath,
       'webview',
-      'browser'
+      'browser',
     );
     const appDistPathUri = vscode.Uri.file(appDistPath);
     const baseUri = webview?.asWebviewUri(appDistPathUri).toString() || '';
     const iconUri =
       webview
         ?.asWebviewUri(
-          vscode.Uri.joinPath(appDistPathUri, 'images', 'ptah-icon.png')
+          vscode.Uri.joinPath(appDistPathUri, 'images', 'ptah-icon.png'),
         )
         .toString() || '';
     const userIconUri =
       webview
         ?.asWebviewUri(
-          vscode.Uri.joinPath(appDistPathUri, 'images', 'user-icon.png')
+          vscode.Uri.joinPath(appDistPathUri, 'images', 'user-icon.png'),
         )
         .toString() || '';
 
@@ -474,10 +463,10 @@ export class WebviewHtmlGenerator {
         isLicensed: ${isLicensed},
         theme: '${this.getThemeString(theme)}',
         workspaceRoot: '${this.escapeJsString(
-          String(workspaceInfo?.['path'] || '')
+          String(workspaceInfo?.['path'] || ''),
         )}',
         workspaceName: '${this.escapeJsString(
-          String(workspaceInfo?.['name'] || '')
+          String(workspaceInfo?.['name'] || ''),
         )}',
         extensionUri: '${this.context.extensionUri.toString()}',
         baseUri: '${baseUri}',
@@ -521,23 +510,14 @@ export class WebviewHtmlGenerator {
         }
       });
 
-      console.log('Ptah WebView: VS Code API initialized', window.ptahConfig);
     `;
   }
 
   private getStartupScript(): string {
     return `
-      // DIAGNOSTIC: Log to confirm script execution
-      console.log('===================================================');
-      console.log('PTAH STARTUP SCRIPT EXECUTING');
-      console.log('window.vscode exists:', !!window.vscode);
-      console.log('window.ptahConfig exists:', !!window.ptahConfig);
-      console.log('===================================================');
-
       // Notify extension that webview is ready
       setTimeout(() => {
         if (window.vscode) {
-          console.log('Sending webview-ready message to extension...');
           window.vscode.postMessage({ type: '${MESSAGE_TYPES.WEBVIEW_READY}' });
         } else {
           console.error('CRITICAL: window.vscode is not available!');

--- a/apps/ptah-extension-webview/src/app/app.ts
+++ b/apps/ptah-extension-webview/src/app/app.ts
@@ -53,27 +53,17 @@ export class App implements OnInit, OnDestroy {
 
   // ANGULAR 20 PATTERN: Computed signals for derived state
   public readonly isReady = computed(() => {
-    const status = this.initializationStatus();
-    const ready = status === 'ready';
-    console.log('🔍 [App] isReady computed:', {
-      initializationStatus: status,
-      isReady: ready,
-    });
-    return ready;
+    return this.initializationStatus() === 'ready';
   });
 
   public readonly hasError = computed(
-    () => this.initializationStatus() === 'error'
+    () => this.initializationStatus() === 'error',
   );
   public readonly isInitializing = computed(
-    () => this.initializationStatus() === 'initializing'
+    () => this.initializationStatus() === 'initializing',
   );
 
   public async ngOnInit(): Promise<void> {
-    console.log('=================================================');
-    console.log('PTAH APP NGONINIT STARTING');
-    console.log('=================================================');
-
     this.initializationStatus.set('initializing');
 
     try {
@@ -92,21 +82,16 @@ export class App implements OnInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
-    console.log('Ptah App - disposing...');
     this.destroy$.next();
     this.destroy$.complete();
     this.appState.setConnected(false);
   }
 
   public async onViewChanged(view: ViewType): Promise<void> {
-    console.log('Ptah App - View changed to:', view);
-
     // Use navigation service for reliable navigation
     const success = await this.navigationService.navigateToView(view);
 
-    if (success) {
-      console.log(`Ptah App - Navigation to ${view} completed successfully`);
-    } else {
+    if (!success) {
       console.error(`Ptah App - Navigation to ${view} failed`);
       // Show user-friendly error message
       this.appState.handleError(`Failed to navigate to ${view}`);
@@ -116,8 +101,6 @@ export class App implements OnInit, OnDestroy {
   // REMOVED: setupRouterLogging - no longer using Angular Router
 
   private async handleInitialView(): Promise<void> {
-    console.log('Setting up initial view with pure signal navigation');
-
     // Check for initialView in ptahConfig (set by extension for specific views like wizard)
     const ptahConfig = (
       window as unknown as { ptahConfig?: { initialView?: string } }
@@ -146,20 +129,15 @@ export class App implements OnInit, OnDestroy {
     if (rawInitialView && !isValidView) {
       console.warn(
         `Invalid initialView "${rawInitialView}" in ptahConfig. Valid values are: ${VALID_VIEWS.join(
-          ', '
-        )}. Defaulting to 'chat'.`
+          ', ',
+        )}. Defaulting to 'chat'.`,
       );
     }
-
-    console.log(`Initial view target: ${targetView}`, {
-      fromConfig: !!rawInitialView,
-      wasValid: isValidView,
-    });
 
     const success = await this.navigationService.navigateToView(targetView);
     if (!success) {
       console.warn(
-        `Initial navigation to ${targetView} failed, using fallback`
+        `Initial navigation to ${targetView} failed, using fallback`,
       );
       this.appState.setCurrentView(targetView);
     }

--- a/apps/ptah-extension-webview/src/main.ts
+++ b/apps/ptah-extension-webview/src/main.ts
@@ -15,10 +15,6 @@ declare global {
   }
 }
 
-bootstrapApplication(App, appConfig)
-  .then(() => {
-    console.log('=== PTAH WEBVIEW BOOTSTRAP COMPLETE ===');
-  })
-  .catch((err) => {
-    console.error('=== PTAH WEBVIEW BOOTSTRAP FAILED ===', err);
-  });
+bootstrapApplication(App, appConfig).catch((err) => {
+  console.error('=== PTAH WEBVIEW BOOTSTRAP FAILED ===', err);
+});

--- a/apps/ptah-landing-page/src/app/interceptors/api.interceptor.ts
+++ b/apps/ptah-landing-page/src/app/interceptors/api.interceptor.ts
@@ -9,7 +9,7 @@ import { environment } from '../../environments/environment';
  * 2. Sets withCredentials: true for cookie-based authentication
  *
  * Why needed:
- * - Production deployment uses separate domains (e.g., ptah.dev vs api.ptah.dev)
+ * - Production deployment uses separate domains (e.g., ptah.live vs api.ptah.live)
  * - Auth cookies (ptah_auth) must be sent with cross-origin requests
  * - Without withCredentials, cookies are not sent on cross-origin requests
  *

--- a/apps/ptah-landing-page/src/app/pages/profile/profile-page.component.ts
+++ b/apps/ptah-landing-page/src/app/pages/profile/profile-page.component.ts
@@ -80,170 +80,174 @@ export type ProfileTab = 'account' | 'sessions' | 'contact';
 
       <!-- Loading State -->
       @if (isLoading()) {
-      <div class="min-h-screen flex items-center justify-center">
-        <div class="text-center">
-          <span
-            class="loading loading-spinner loading-lg text-secondary"
-          ></span>
-          <p class="mt-4 text-neutral-content">Loading your account...</p>
+        <div class="min-h-screen flex items-center justify-center">
+          <div class="text-center">
+            <span
+              class="loading loading-spinner loading-lg text-secondary"
+            ></span>
+            <p class="mt-4 text-neutral-content">Loading your account...</p>
+          </div>
         </div>
-      </div>
       }
 
       <!-- Error State -->
       @if (errorMessage() && !isLoading()) {
-      <div class="min-h-screen flex items-center justify-center p-4">
-        <div
-          class="max-w-md w-full bg-base-200/95 backdrop-blur-xl border border-error/30 rounded-3xl p-8 shadow-2xl"
-        >
-          <div class="alert alert-error mb-4">
-            <h3 class="font-bold">Error Loading Account</h3>
-            <p>{{ errorMessage() }}</p>
+        <div class="min-h-screen flex items-center justify-center p-4">
+          <div
+            class="max-w-md w-full bg-base-200/95 backdrop-blur-xl border border-error/30 rounded-3xl p-8 shadow-2xl"
+          >
+            <div class="alert alert-error mb-4">
+              <h3 class="font-bold">Error Loading Account</h3>
+              <p>{{ errorMessage() }}</p>
+            </div>
+            <button class="btn btn-error w-full" (click)="loadLicense()">
+              Retry
+            </button>
           </div>
-          <button class="btn btn-error w-full" (click)="loadLicense()">
-            Retry
-          </button>
         </div>
-      </div>
       }
 
       <!-- Main Profile Content -->
       @if (license() && !isLoading()) {
-      <!-- Profile Header with Avatar, Stats, Badges -->
-      <ptah-profile-header [license]="license()" />
+        <!-- Profile Header with Avatar, Stats, Badges -->
+        <ptah-profile-header [license]="license()" />
 
-      <!-- Content Container -->
-      <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 mt-6">
-        <!-- Tab Navigation -->
-        <div
-          class="flex gap-1 bg-base-200/50 border border-white/10 rounded-xl p-1 mb-6"
-          role="tablist"
-        >
-          <button
-            type="button"
-            role="tab"
-            [attr.aria-selected]="activeTab() === 'account'"
-            class="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all duration-200"
-            [class]="
-              activeTab() === 'account'
-                ? 'bg-base-300 text-amber-400 shadow-sm'
-                : 'text-white/50 hover:text-white/80 hover:bg-base-300/50'
-            "
-            (click)="activeTab.set('account')"
+        <!-- Content Container -->
+        <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 mt-6">
+          <!-- Tab Navigation -->
+          <div
+            class="flex gap-1 bg-base-200/50 border border-white/10 rounded-xl p-1 mb-6"
+            role="tablist"
           >
-            <lucide-angular
-              [img]="UserIcon"
-              class="w-4 h-4"
-              aria-hidden="true"
-            />
-            Account
-          </button>
-          <button
-            type="button"
-            role="tab"
-            [attr.aria-selected]="activeTab() === 'sessions'"
-            class="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all duration-200"
-            [class]="
-              activeTab() === 'sessions'
-                ? 'bg-base-300 text-amber-400 shadow-sm'
-                : 'text-white/50 hover:text-white/80 hover:bg-base-300/50'
-            "
-            (click)="activeTab.set('sessions')"
-          >
-            <lucide-angular
-              [img]="GraduationCapIcon"
-              class="w-4 h-4"
-              aria-hidden="true"
-            />
-            Sessions
-          </button>
-          <button
-            type="button"
-            role="tab"
-            [attr.aria-selected]="activeTab() === 'contact'"
-            class="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all duration-200"
-            [class]="
-              activeTab() === 'contact'
-                ? 'bg-base-300 text-amber-400 shadow-sm'
-                : 'text-white/50 hover:text-white/80 hover:bg-base-300/50'
-            "
-            (click)="activeTab.set('contact')"
-          >
-            <lucide-angular
-              [img]="MessageSquareIcon"
-              class="w-4 h-4"
-              aria-hidden="true"
-            />
-            Contact
-          </button>
-        </div>
+            <button
+              type="button"
+              role="tab"
+              [attr.aria-selected]="activeTab() === 'account'"
+              class="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all duration-200"
+              [class]="
+                activeTab() === 'account'
+                  ? 'bg-base-300 text-amber-400 shadow-sm'
+                  : 'text-white/50 hover:text-white/80 hover:bg-base-300/50'
+              "
+              (click)="activeTab.set('account')"
+            >
+              <lucide-angular
+                [img]="UserIcon"
+                class="w-4 h-4"
+                aria-hidden="true"
+              />
+              Account
+            </button>
+            <button
+              type="button"
+              role="tab"
+              [attr.aria-selected]="activeTab() === 'sessions'"
+              class="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all duration-200"
+              [class]="
+                activeTab() === 'sessions'
+                  ? 'bg-base-300 text-amber-400 shadow-sm'
+                  : 'text-white/50 hover:text-white/80 hover:bg-base-300/50'
+              "
+              (click)="activeTab.set('sessions')"
+            >
+              <lucide-angular
+                [img]="GraduationCapIcon"
+                class="w-4 h-4"
+                aria-hidden="true"
+              />
+              Sessions
+            </button>
+            <button
+              type="button"
+              role="tab"
+              [attr.aria-selected]="activeTab() === 'contact'"
+              class="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all duration-200"
+              [class]="
+                activeTab() === 'contact'
+                  ? 'bg-base-300 text-amber-400 shadow-sm'
+                  : 'text-white/50 hover:text-white/80 hover:bg-base-300/50'
+              "
+              (click)="activeTab.set('contact')"
+            >
+              <lucide-angular
+                [img]="MessageSquareIcon"
+                class="w-4 h-4"
+                aria-hidden="true"
+              />
+              Contact
+            </button>
+          </div>
 
-        <!-- Tab Content -->
-        @switch (activeTab()) { @case ('account') {
-        <!-- Account Details & Upgrade CTA -->
-        <ptah-profile-details
-          [license]="license()"
-          [isSyncing]="isSyncing()"
-          [syncError]="syncError()"
-          [syncSuccess]="syncSuccess()"
-          [licenseKey]="licenseKey()"
-          [isRevealingKey]="isRevealingKey()"
-          [revealKeyError]="revealKeyError()"
-          (syncRequested)="handleSyncWithPaddle()"
-          (manageSubscriptionRequested)="handleManageSubscription()"
-          (revealKeyRequested)="handleRevealLicenseKey()"
-        />
+          <!-- Tab Content -->
+          @switch (activeTab()) {
+            @case ('account') {
+              <!-- Account Details & Upgrade CTA -->
+              <ptah-profile-details
+                [license]="license()"
+                [isSyncing]="isSyncing()"
+                [syncError]="syncError()"
+                [syncSuccess]="syncSuccess()"
+                [licenseKey]="licenseKey()"
+                [isRevealingKey]="isRevealingKey()"
+                [revealKeyError]="revealKeyError()"
+                (syncRequested)="handleSyncWithPaddle()"
+                (manageSubscriptionRequested)="handleManageSubscription()"
+                (revealKeyRequested)="handleRevealLicenseKey()"
+              />
 
-        <!-- Features Section -->
-        <div class="mt-6">
-          <ptah-profile-features [features]="license()?.features ?? []" />
-        </div>
+              <!-- Features Section -->
+              <div class="mt-6">
+                <ptah-profile-features [features]="license()?.features ?? []" />
+              </div>
 
-        <!-- Actions -->
-        <div
-          viewportAnimation
-          [viewportConfig]="actionsConfig"
-          class="mt-6 mb-12 grid grid-cols-1 sm:grid-cols-2 gap-4"
-        >
-          <a routerLink="/pricing" class="btn btn-outline btn-secondary">
-            <lucide-angular
-              [img]="SettingsIcon"
-              class="w-4 h-4"
-              aria-hidden="true"
-            />
-            {{
-              license()?.plan === 'community' ||
-              license()?.plan?.startsWith('trial_')
-                ? 'View Pricing Plans'
-                : 'Manage Subscription'
-            }}
-          </a>
-          <a
-            href="https://docs.ptah.dev"
-            target="_blank"
-            rel="noopener"
-            class="btn btn-ghost"
-          >
-            <lucide-angular
-              [img]="ShieldIcon"
-              class="w-4 h-4"
-              aria-hidden="true"
-            />
-            Documentation
-          </a>
+              <!-- Actions -->
+              <div
+                viewportAnimation
+                [viewportConfig]="actionsConfig"
+                class="mt-6 mb-12 grid grid-cols-1 sm:grid-cols-2 gap-4"
+              >
+                <a routerLink="/pricing" class="btn btn-outline btn-secondary">
+                  <lucide-angular
+                    [img]="SettingsIcon"
+                    class="w-4 h-4"
+                    aria-hidden="true"
+                  />
+                  {{
+                    license()?.plan === 'community' ||
+                    license()?.plan?.startsWith('trial_')
+                      ? 'View Pricing Plans'
+                      : 'Manage Subscription'
+                  }}
+                </a>
+                <a
+                  href="https://docs.ptah.live"
+                  target="_blank"
+                  rel="noopener"
+                  class="btn btn-ghost"
+                >
+                  <lucide-angular
+                    [img]="ShieldIcon"
+                    class="w-4 h-4"
+                    aria-hidden="true"
+                  />
+                  Documentation
+                </a>
+              </div>
+            }
+            @case ('sessions') {
+              <!-- Sessions Tab -->
+              <div class="mb-8">
+                <ptah-sessions-grid />
+              </div>
+            }
+            @case ('contact') {
+              <!-- Contact Tab -->
+              <div class="mb-8">
+                <ptah-contact-form />
+              </div>
+            }
+          }
         </div>
-        } @case ('sessions') {
-        <!-- Sessions Tab -->
-        <div class="mb-8">
-          <ptah-sessions-grid />
-        </div>
-        } @case ('contact') {
-        <!-- Contact Tab -->
-        <div class="mb-8">
-          <ptah-contact-form />
-        </div>
-        } }
-      </div>
       }
     </div>
   `,
@@ -339,7 +343,7 @@ export class ProfilePageComponent implements OnInit, OnDestroy {
       error: (error) => {
         this.isLoading.set(false);
         this.errorMessage.set(
-          error.error?.message || 'Failed to load account details'
+          error.error?.message || 'Failed to load account details',
         );
       },
     });
@@ -374,7 +378,7 @@ export class ProfilePageComponent implements OnInit, OnDestroy {
       .subscribe((event) => {
         console.log(
           '[Profile] Reconciliation completed event received:',
-          event
+          event,
         );
         // Refresh license data to reflect synced state
         this.refreshLicenseData();
@@ -413,7 +417,7 @@ export class ProfilePageComponent implements OnInit, OnDestroy {
         console.log(
           '[Profile] License data refreshed:',
           data.plan,
-          data.status
+          data.status,
         );
       },
       error: (error) => {
@@ -545,7 +549,7 @@ export class ProfilePageComponent implements OnInit, OnDestroy {
             this.licenseKey.set(response.licenseKey);
           } else {
             this.revealKeyError.set(
-              response.message || 'Failed to retrieve license key'
+              response.message || 'Failed to retrieve license key',
             );
           }
         },
@@ -553,16 +557,16 @@ export class ProfilePageComponent implements OnInit, OnDestroy {
           this.isRevealingKey.set(false);
           if (error.status === 429) {
             this.revealKeyError.set(
-              'Too many requests. Please wait a moment and try again.'
+              'Too many requests. Please wait a moment and try again.',
             );
           } else if (error.status === 401) {
             this.revealKeyError.set(
-              'Your session has expired. Please log in again.'
+              'Your session has expired. Please log in again.',
             );
           } else {
             this.revealKeyError.set(
               error.error?.message ||
-                'Failed to retrieve license key. Please try again.'
+                'Failed to retrieve license key. Please try again.',
             );
           }
         },

--- a/apps/ptah-landing-page/src/app/pages/profile/profile-page.component.ts
+++ b/apps/ptah-landing-page/src/app/pages/profile/profile-page.component.ts
@@ -220,7 +220,7 @@ export type ProfileTab = 'account' | 'sessions' | 'contact';
                   }}
                 </a>
                 <a
-                  href="https://docs.ptah.live"
+                  href="https://ptah.live/docs"
                   target="_blank"
                   rel="noopener"
                   class="btn btn-ghost"

--- a/apps/ptah-landing-page/src/environments/environment.ts
+++ b/apps/ptah-landing-page/src/environments/environment.ts
@@ -12,7 +12,7 @@ export const environment = {
   /**
    * API base URL
    * - Development: Empty string (same origin, proxy handles routing)
-   * - Production: Full URL to license server (e.g., https://api.ptah.dev)
+   * - Production: Full URL to license server (e.g., https://api.ptah.live)
    */
   apiBaseUrl: '',
 

--- a/apps/ptah-license-server/src/app/auth/services/token/magic-link.service.ts
+++ b/apps/ptah-license-server/src/app/auth/services/token/magic-link.service.ts
@@ -63,7 +63,7 @@ export class MagicLinkService {
    *
    * @param email - User's email address
    * @param options - Optional returnUrl and plan for post-auth redirect
-   * @returns Full magic link URL (e.g., https://ptah.dev/api/auth/verify?token=abc123...)
+   * @returns Full magic link URL (e.g., https://ptah.live/api/auth/verify?token=abc123...)
    */
   async createMagicLink(
     email: string,

--- a/libs/backend/agent-sdk/src/lib/helpers/build-safe-env.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/build-safe-env.ts
@@ -13,9 +13,10 @@
  * @returns Minimal env safe for custom agent processes
  */
 import type { AuthEnv } from '@ptah-extension/shared';
+import { getActiveProviderId } from './sdk-query-options-builder';
 
 export function buildSafeEnv(
-  authEnv: AuthEnv
+  authEnv: AuthEnv,
 ): Record<string, string | undefined> {
   return {
     // Platform essentials for process execution
@@ -61,5 +62,10 @@ export function buildSafeEnv(
     SHELL: process.env['SHELL'],
     // Provider-specific auth and config (e.g., ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL)
     ...authEnv,
+    // Disable experimental betas for third-party providers — prevents the SDK from
+    // enabling context-management-2025-06-27 which non-Anthropic endpoints don't support
+    ...(getActiveProviderId(authEnv)
+      ? { CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: '1' }
+      : {}),
   };
 }

--- a/libs/backend/agent-sdk/src/lib/helpers/build-safe-env.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/build-safe-env.ts
@@ -13,7 +13,6 @@
  * @returns Minimal env safe for custom agent processes
  */
 import type { AuthEnv } from '@ptah-extension/shared';
-import { getActiveProviderId } from './sdk-query-options-builder';
 
 export function buildSafeEnv(
   authEnv: AuthEnv,
@@ -62,10 +61,13 @@ export function buildSafeEnv(
     SHELL: process.env['SHELL'],
     // Provider-specific auth and config (e.g., ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL)
     ...authEnv,
-    // Disable experimental betas for third-party providers — prevents the SDK from
-    // enabling context-management-2025-06-27 which non-Anthropic endpoints don't support
-    ...(getActiveProviderId(authEnv)
-      ? { CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: '1' }
-      : {}),
+    // Disable experimental betas for any non-Anthropic base URL — prevents the SDK
+    // from enabling context-management-2025-06-27 which third-party endpoints don't support
+    ...(() => {
+      const baseUrl = authEnv.ANTHROPIC_BASE_URL?.trim();
+      return baseUrl && !/^https?:\/\/api\.anthropic\.com\/?$/i.test(baseUrl)
+        ? { CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: '1' }
+        : {};
+    })(),
   };
 }

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.ts
@@ -536,10 +536,17 @@ export class SdkQueryOptionsBuilder {
           : ['user', 'project', 'local'],
         // Merge AuthEnv with process.env — AuthEnv values override process.env (TASK_2025_164)
         // Set NO_PROXY to prevent corporate proxy interception of localhost requests
+        // Disable experimental betas for third-party providers — the SDK classifies
+        // non-Bedrock/Vertex/Foundry providers as "firstParty" and enables the
+        // context-management-2025-06-27 beta header, which third-party providers
+        // (OpenRouter, Moonshot, etc.) don't support, causing 400 errors.
         env: {
           ...process.env,
           ...this.authEnv,
           NO_PROXY: '127.0.0.1,localhost',
+          ...(getActiveProviderId(this.authEnv)
+            ? { CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: '1' }
+            : {}),
         } as Record<string, string | undefined>,
         // Capture stderr — the SDK writes debug/info/warn/error to stderr;
         // parse the level and route to the appropriate logger method

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.ts
@@ -536,17 +536,22 @@ export class SdkQueryOptionsBuilder {
           : ['user', 'project', 'local'],
         // Merge AuthEnv with process.env — AuthEnv values override process.env (TASK_2025_164)
         // Set NO_PROXY to prevent corporate proxy interception of localhost requests
-        // Disable experimental betas for third-party providers — the SDK classifies
-        // non-Bedrock/Vertex/Foundry providers as "firstParty" and enables the
-        // context-management-2025-06-27 beta header, which third-party providers
-        // (OpenRouter, Moonshot, etc.) don't support, causing 400 errors.
+        // Disable experimental betas for any non-Anthropic base URL — the SDK
+        // enables context-management-2025-06-27 for "firstParty" providers, which
+        // third-party endpoints (OpenRouter, Moonshot, unknown proxies, etc.)
+        // don't support, causing 400 errors. Check the URL directly instead of
+        // relying on provider registry detection, which misses unknown providers.
         env: {
           ...process.env,
           ...this.authEnv,
           NO_PROXY: '127.0.0.1,localhost',
-          ...(getActiveProviderId(this.authEnv)
-            ? { CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: '1' }
-            : {}),
+          ...(() => {
+            const baseUrl = this.authEnv.ANTHROPIC_BASE_URL?.trim();
+            return baseUrl &&
+              !/^https?:\/\/api\.anthropic\.com\/?$/i.test(baseUrl)
+              ? { CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: '1' }
+              : {};
+          })(),
         } as Record<string, string | undefined>,
         // Capture stderr — the SDK writes debug/info/warn/error to stderr;
         // parse the level and route to the appropriate logger method

--- a/libs/backend/workspace-intelligence/src/workspace/workspace.service.ts
+++ b/libs/backend/workspace-intelligence/src/workspace/workspace.service.ts
@@ -202,7 +202,6 @@ export class WorkspaceService implements IDisposable {
 
     if (!workspaceRoot) {
       this.currentAnalysis = undefined;
-      console.info('No workspace folder detected');
       return undefined;
     }
 
@@ -271,12 +270,6 @@ export class WorkspaceService implements IDisposable {
         totalFiles,
         hasGitRepository,
       };
-
-      console.info(
-        `Workspace analyzed: ${workspaceName} (${projectType}${
-          framework ? ` - ${framework}` : ''
-        })`,
-      );
 
       return this.currentAnalysis;
     } catch (error) {
@@ -792,7 +785,6 @@ export class WorkspaceService implements IDisposable {
    * Dispose service and cleanup resources
    */
   dispose(): void {
-    console.info('Disposing WorkspaceService...');
     this.disposables.forEach((d) => d.dispose());
     this.disposables = [];
   }

--- a/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.ts
+++ b/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.ts
@@ -1139,10 +1139,6 @@ export class ChatInputComponent implements OnInit {
           if (this._lastSessionId !== null && currentSessionId !== null) {
             // Clear command autocomplete cache on session switch
             this.commandDiscovery.clearCache();
-            console.log('[ChatInputComponent] Session changed, cache cleared', {
-              from: this._lastSessionId,
-              to: currentSessionId,
-            });
           }
           this._lastSessionId = currentSessionId;
         }

--- a/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.ts
+++ b/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.ts
@@ -167,9 +167,28 @@ interface PastedImage {
       <div class="flex items-end gap-2">
         <!-- Textarea + Suggestions Dropdown -->
         <div class="relative flex-1">
+          <!-- Attachment buttons overlaid at top-right of textarea -->
+          <div class="absolute top-1.5 right-2 z-10 flex items-center gap-0.5">
+            <button
+              class="btn btn-ghost btn-xs btn-square text-base-content/50 hover:text-base-content/80"
+              (click)="handleAttachFiles()"
+              title="Attach files"
+              type="button"
+            >
+              <lucide-angular [img]="PaperclipIcon" class="w-3.5 h-3.5" />
+            </button>
+            <button
+              class="btn btn-ghost btn-xs btn-square text-base-content/50 hover:text-base-content/80"
+              (click)="handleAttachImages()"
+              title="Attach images"
+              type="button"
+            >
+              <lucide-angular [img]="ImagePlusIcon" class="w-3.5 h-3.5" />
+            </button>
+          </div>
           <textarea
             #inputElement
-            class="textarea textarea-bordered flex-1 min-h-[2.5rem] max-h-[10rem] resize-none transition-colors w-full"
+            class="textarea textarea-bordered flex-1 min-h-[2.5rem] max-h-[10rem] resize-none transition-colors w-full pr-16"
             [class.border-info]="
               autopilotState.agentPlanMode() ||
               autopilotState.permissionLevel() === 'plan'
@@ -270,26 +289,6 @@ interface PastedImage {
               <span class="text-[10px]">{{ authMethodLabel() }}</span>
             </div>
           }
-
-          <!-- Attach Files Button -->
-          <button
-            class="btn btn-ghost btn-xs btn-square"
-            (click)="handleAttachFiles()"
-            title="Attach files"
-            type="button"
-          >
-            <lucide-angular [img]="PaperclipIcon" class="w-3.5 h-3.5" />
-          </button>
-
-          <!-- Attach Images Button -->
-          <button
-            class="btn btn-ghost btn-xs btn-square"
-            (click)="handleAttachImages()"
-            title="Attach images"
-            type="button"
-          >
-            <lucide-angular [img]="ImagePlusIcon" class="w-3.5 h-3.5" />
-          </button>
 
           <!-- Model Selector Component -->
           <ptah-model-selector />

--- a/libs/frontend/chat/src/lib/components/molecules/question-card.component.ts
+++ b/libs/frontend/chat/src/lib/components/molecules/question-card.component.ts
@@ -16,6 +16,7 @@ import {
   ChevronRight,
   Send,
   Clock,
+  PenLine,
 } from 'lucide-angular';
 import type {
   AskUserQuestionRequest,
@@ -73,89 +74,147 @@ import type {
 
       <!-- Steps indicator (only for multiple questions) -->
       @if (hasMultipleQuestions()) {
-      <div class="px-2 py-1.5 border-b border-base-300/30">
-        <ul class="steps steps-horizontal w-full text-[9px]">
-          @for (q of request().questions; track q.header; let i = $index) {
-          <li
-            class="step"
-            [class.step-info]="i <= currentStep()"
-            [attr.data-content]="isStepAnswered(i) ? '✓' : i + 1"
-          >
-            <span class="hidden sm:inline truncate max-w-16">{{
-              q.header
-            }}</span>
-          </li>
-          }
-        </ul>
-      </div>
+        <div class="px-2 py-1.5 border-b border-base-300/30">
+          <ul class="steps steps-horizontal w-full text-[9px]">
+            @for (q of request().questions; track q.header; let i = $index) {
+              <li
+                class="step"
+                [class.step-info]="i <= currentStep()"
+                [attr.data-content]="isStepAnswered(i) ? '✓' : i + 1"
+              >
+                <span class="hidden sm:inline truncate max-w-16">{{
+                  q.header
+                }}</span>
+              </li>
+            }
+          </ul>
+        </div>
       }
 
       <!-- Current question -->
       <div class="py-2 px-2">
         @if (currentQuestion(); as question) {
-        <p class="text-[11px] font-medium text-base-content/90 mb-1.5">
-          {{ question.question }}
-        </p>
+          <p class="text-[11px] font-medium text-base-content/90 mb-1.5">
+            {{ question.question }}
+          </p>
 
-        <!-- Options list - single column for clarity -->
-        <div class="space-y-0.5">
-          @if (question.multiSelect) {
-          <!-- Multi-select: checkboxes -->
-          @for (option of question.options; track option.label) {
-          <label
-            class="flex items-start gap-2 cursor-pointer hover:bg-info/10 rounded px-1.5 py-1 text-[10px] transition-colors"
-            [class.bg-info]="isOptionSelected(question.question, option.label)"
-            [class.bg-opacity-15]="
-              isOptionSelected(question.question, option.label)
-            "
-          >
-            <input
-              type="checkbox"
-              [value]="option.label"
-              [checked]="isOptionSelected(question.question, option.label)"
-              (change)="onOptionToggle(question.question, option.label, $event)"
-              class="checkbox checkbox-xs checkbox-info mt-0.5"
-            />
-            <div class="flex-1 min-w-0">
-              <span class="font-medium">{{ option.label }}</span>
-              @if (option.description) {
-              <p class="text-[9px] text-base-content/50 leading-tight">
-                {{ option.description }}
-              </p>
+          <!-- Options list - single column for clarity -->
+          <div class="space-y-0.5">
+            @if (question.multiSelect) {
+              <!-- Multi-select: checkboxes -->
+              @for (option of question.options; track option.label) {
+                <label
+                  class="flex items-start gap-2 cursor-pointer hover:bg-info/10 rounded px-1.5 py-1 text-[10px] transition-colors"
+                  [class.bg-info]="
+                    isOptionSelected(question.question, option.label)
+                  "
+                  [class.bg-opacity-15]="
+                    isOptionSelected(question.question, option.label)
+                  "
+                >
+                  <input
+                    type="checkbox"
+                    [value]="option.label"
+                    [checked]="
+                      isOptionSelected(question.question, option.label)
+                    "
+                    (change)="
+                      onOptionToggle(question.question, option.label, $event)
+                    "
+                    class="checkbox checkbox-xs checkbox-info mt-0.5"
+                  />
+                  <div class="flex-1 min-w-0">
+                    <span class="font-medium">{{ option.label }}</span>
+                    @if (option.description) {
+                      <p class="text-[9px] text-base-content/50 leading-tight">
+                        {{ option.description }}
+                      </p>
+                    }
+                  </div>
+                </label>
               }
-            </div>
-          </label>
-          } } @else {
-          <!-- Single-select: radio buttons -->
-          @for (option of question.options; track option.label) {
-          <label
-            class="flex items-start gap-2 cursor-pointer hover:bg-info/10 rounded px-1.5 py-1 text-[10px] transition-colors"
-            [class.bg-info]="
-              selectedAnswers()[question.question] === option.label
-            "
-            [class.bg-opacity-15]="
-              selectedAnswers()[question.question] === option.label
-            "
-          >
-            <input
-              type="radio"
-              [name]="'q-' + currentStep()"
-              [value]="option.label"
-              [checked]="selectedAnswers()[question.question] === option.label"
-              (change)="onOptionSelect(question.question, option.label)"
-              class="radio radio-xs radio-info mt-0.5"
-            />
-            <div class="flex-1 min-w-0">
-              <span class="font-medium">{{ option.label }}</span>
-              @if (option.description) {
-              <p class="text-[9px] text-base-content/50 leading-tight">
-                {{ option.description }}
-              </p>
+            } @else {
+              <!-- Single-select: radio buttons -->
+              @for (option of question.options; track option.label) {
+                <label
+                  class="flex items-start gap-2 cursor-pointer hover:bg-info/10 rounded px-1.5 py-1 text-[10px] transition-colors"
+                  [class.bg-info]="
+                    selectedAnswers()[question.question] === option.label
+                  "
+                  [class.bg-opacity-15]="
+                    selectedAnswers()[question.question] === option.label
+                  "
+                >
+                  <input
+                    type="radio"
+                    [name]="'q-' + currentStep()"
+                    [value]="option.label"
+                    [checked]="
+                      selectedAnswers()[question.question] === option.label
+                    "
+                    (change)="onOptionSelect(question.question, option.label)"
+                    class="radio radio-xs radio-info mt-0.5"
+                  />
+                  <div class="flex-1 min-w-0">
+                    <span class="font-medium">{{ option.label }}</span>
+                    @if (option.description) {
+                      <p class="text-[9px] text-base-content/50 leading-tight">
+                        {{ option.description }}
+                      </p>
+                    }
+                  </div>
+                </label>
               }
-            </div>
-          </label>
-          } }
-        </div>
+            }
+
+            <!-- Custom response option -->
+            <label
+              class="flex items-start gap-2 cursor-pointer hover:bg-info/10 rounded px-1.5 py-1 text-[10px] transition-colors"
+              [class.bg-info]="isCustomMode()"
+              [class.bg-opacity-15]="isCustomMode()"
+            >
+              <input
+                type="radio"
+                [name]="'q-' + currentStep()"
+                [value]="'__custom__'"
+                [checked]="isCustomMode()"
+                (change)="onCustomSelect(question.question)"
+                class="radio radio-xs radio-info mt-0.5"
+              />
+              <div class="flex-1 min-w-0">
+                <span class="font-medium flex items-center gap-1">
+                  <lucide-angular [img]="PenLineIcon" class="w-2.5 h-2.5" />
+                  Other
+                </span>
+                <p class="text-[9px] text-base-content/50 leading-tight">
+                  Type a custom response
+                </p>
+              </div>
+            </label>
+
+            <!-- Custom input field (shown when custom option selected) -->
+            @if (isCustomMode()) {
+              <div class="flex gap-1 mt-1 px-1.5">
+                <input
+                  type="text"
+                  [value]="customText()"
+                  (input)="onCustomTextInput($event)"
+                  (keydown.enter)="onCustomTextConfirm(question.question)"
+                  placeholder="Type your response..."
+                  class="input input-xs input-bordered input-info flex-1 text-[10px] bg-base-100/50"
+                />
+                <button
+                  (click)="onCustomTextConfirm(question.question)"
+                  [disabled]="!customText().trim()"
+                  class="btn btn-xs btn-info btn-outline px-1.5"
+                  type="button"
+                  title="Confirm custom response"
+                >
+                  <lucide-angular [img]="SendIcon" class="w-3 h-3" />
+                </button>
+              </div>
+            }
+          </div>
         }
       </div>
 
@@ -165,15 +224,15 @@ import type {
       >
         <!-- Prev button -->
         @if (hasMultipleQuestions()) {
-        <button
-          (click)="prevStep()"
-          [disabled]="currentStep() === 0"
-          class="btn btn-xs btn-ghost gap-0.5 px-1.5"
-          type="button"
-        >
-          <lucide-angular [img]="ChevronLeftIcon" class="w-3 h-3" />
-          Prev
-        </button>
+          <button
+            (click)="prevStep()"
+            [disabled]="currentStep() === 0"
+            class="btn btn-xs btn-ghost gap-0.5 px-1.5"
+            type="button"
+          >
+            <lucide-angular [img]="ChevronLeftIcon" class="w-3 h-3" />
+            Prev
+          </button>
         }
 
         <!-- Progress text -->
@@ -183,25 +242,25 @@ import type {
 
         <!-- Next or Submit button -->
         @if (isLastStep()) {
-        <button
-          (click)="onSubmit()"
-          [disabled]="!canSubmit()"
-          class="btn btn-xs btn-info gap-0.5 px-2"
-          type="button"
-        >
-          <lucide-angular [img]="SendIcon" class="w-3 h-3" />
-          Submit
-        </button>
+          <button
+            (click)="onSubmit()"
+            [disabled]="!canSubmit()"
+            class="btn btn-xs btn-info gap-0.5 px-2"
+            type="button"
+          >
+            <lucide-angular [img]="SendIcon" class="w-3 h-3" />
+            Submit
+          </button>
         } @else {
-        <button
-          (click)="nextStep()"
-          [disabled]="!isCurrentStepAnswered()"
-          class="btn btn-xs btn-info btn-outline gap-0.5 px-1.5"
-          type="button"
-        >
-          Next
-          <lucide-angular [img]="ChevronRightIcon" class="w-3 h-3" />
-        </button>
+          <button
+            (click)="nextStep()"
+            [disabled]="!isCurrentStepAnswered()"
+            class="btn btn-xs btn-info btn-outline gap-0.5 px-1.5"
+            type="button"
+          >
+            Next
+            <lucide-angular [img]="ChevronRightIcon" class="w-3 h-3" />
+          </button>
         }
       </div>
     </div>
@@ -214,6 +273,7 @@ export class QuestionCardComponent implements OnInit, OnDestroy {
   protected readonly ChevronRightIcon = ChevronRight;
   protected readonly SendIcon = Send;
   protected readonly ClockIcon = Clock;
+  protected readonly PenLineIcon = PenLine;
 
   /** The question request containing questions to display */
   readonly request = input.required<AskUserQuestionRequest>();
@@ -223,6 +283,12 @@ export class QuestionCardComponent implements OnInit, OnDestroy {
 
   /** Tracks selected answers for each question (question text -> selected option(s)) */
   protected readonly selectedAnswers = signal<Record<string, string>>({});
+
+  /** Whether the current question is in custom input mode */
+  protected readonly isCustomMode = signal(false);
+
+  /** Text entered in the custom input field */
+  protected readonly customText = signal('');
 
   /** Current step index (0-based) */
   protected readonly currentStep = signal(0);
@@ -235,17 +301,17 @@ export class QuestionCardComponent implements OnInit, OnDestroy {
 
   /** Whether there are multiple questions */
   protected readonly hasMultipleQuestions = computed(
-    () => this.request().questions.length > 1
+    () => this.request().questions.length > 1,
   );
 
   /** Current question being displayed */
   protected readonly currentQuestion = computed(
-    () => this.request().questions[this.currentStep()]
+    () => this.request().questions[this.currentStep()],
   );
 
   /** Whether we're on the last step */
   protected readonly isLastStep = computed(
-    () => this.currentStep() === this.request().questions.length - 1
+    () => this.currentStep() === this.request().questions.length - 1,
   );
 
   /** Whether all questions have answers */
@@ -303,6 +369,7 @@ export class QuestionCardComponent implements OnInit, OnDestroy {
   protected prevStep(): void {
     if (this.currentStep() > 0) {
       this.currentStep.update((s) => s - 1);
+      this.resetCustomState();
     }
   }
 
@@ -310,13 +377,20 @@ export class QuestionCardComponent implements OnInit, OnDestroy {
   protected nextStep(): void {
     if (this.currentStep() < this.request().questions.length - 1) {
       this.currentStep.update((s) => s + 1);
+      this.resetCustomState();
     }
+  }
+
+  /** Reset custom input state when switching questions */
+  private resetCustomState(): void {
+    this.isCustomMode.set(false);
+    this.customText.set('');
   }
 
   private updateTimeRemaining(): number {
     const remaining = Math.max(
       0,
-      Math.floor((this.request().timeoutAt - Date.now()) / 1000)
+      Math.floor((this.request().timeoutAt - Date.now()) / 1000),
     );
     this.timeRemaining.set(remaining);
     return remaining;
@@ -338,6 +412,8 @@ export class QuestionCardComponent implements OnInit, OnDestroy {
 
   /** Handle single-select option selection (radio button) */
   protected onOptionSelect(question: string, option: string): void {
+    this.isCustomMode.set(false);
+    this.customText.set('');
     this.selectedAnswers.update((a) => ({ ...a, [question]: option }));
   }
 
@@ -345,7 +421,7 @@ export class QuestionCardComponent implements OnInit, OnDestroy {
   protected onOptionToggle(
     question: string,
     option: string,
-    event: Event
+    event: Event,
   ): void {
     const checked = (event.target as HTMLInputElement).checked;
     this.selectedAnswers.update((a) => {
@@ -365,6 +441,28 @@ export class QuestionCardComponent implements OnInit, OnDestroy {
 
       return { ...a, [question]: options.join(', ') };
     });
+  }
+
+  /** Activate custom input mode for a question */
+  protected onCustomSelect(question: string): void {
+    this.isCustomMode.set(true);
+    // Clear the predefined selection so custom text takes over
+    this.selectedAnswers.update((a) => {
+      const { [question]: _, ...rest } = a;
+      return rest;
+    });
+  }
+
+  /** Handle typing in the custom input field */
+  protected onCustomTextInput(event: Event): void {
+    this.customText.set((event.target as HTMLInputElement).value);
+  }
+
+  /** Confirm custom text as the answer for a question */
+  protected onCustomTextConfirm(question: string): void {
+    const text = this.customText().trim();
+    if (!text) return;
+    this.selectedAnswers.update((a) => ({ ...a, [question]: text }));
   }
 
   /** Submit answers to parent component */

--- a/libs/frontend/chat/src/lib/components/molecules/session/session-stats-summary.component.ts
+++ b/libs/frontend/chat/src/lib/components/molecules/session/session-stats-summary.component.ts
@@ -70,16 +70,18 @@ export interface ModelUsageEntry {
               class="flex items-center gap-1.5 flex-1 min-w-0 overflow-x-auto text-xs"
             >
               @if (liveModelStats()) {
-                <span
-                  class="inline-flex items-center gap-1 bg-purple-600/15 border border-purple-600/25 rounded px-1.5 py-0.5 whitespace-nowrap"
-                >
-                  <span class="text-[10px] uppercase text-base-content/50"
-                    >Model</span
+                @if (!hasMultipleModels()) {
+                  <span
+                    class="inline-flex items-center gap-1 bg-purple-600/15 border border-purple-600/25 rounded px-1.5 py-0.5 whitespace-nowrap"
                   >
-                  <span class="text-purple-400 font-semibold">{{
-                    formatModelName(liveModelStats()!.model)
-                  }}</span>
-                </span>
+                    <span class="text-[10px] uppercase text-base-content/50"
+                      >Model</span
+                    >
+                    <span class="text-purple-400 font-semibold">{{
+                      formatModelName(liveModelStats()!.model)
+                    }}</span>
+                  </span>
+                }
                 <span
                   class="inline-flex items-center gap-1 bg-cyan-600/15 border border-cyan-600/25 rounded px-1.5 py-0.5 whitespace-nowrap"
                   [title]="contextTooltip()"

--- a/libs/frontend/chat/src/lib/components/templates/app-shell.component.ts
+++ b/libs/frontend/chat/src/lib/components/templates/app-shell.component.ts
@@ -638,8 +638,6 @@ export class AppShellComponent {
         if (tab) {
           this.tabManager.closeTab(tab.id);
         }
-
-        console.log(`[AppShell] Session ${session.id} deleted successfully`);
       } else {
         console.error(
           '[AppShell] Failed to delete session:',

--- a/libs/frontend/chat/src/lib/services/chat-store/message-finalization.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/message-finalization.service.ts
@@ -65,21 +65,6 @@ export class MessageFinalizationService {
     // Deep-copy state to prevent race condition (TASK_2025_084 Batch 1 Task 1.3)
     const stateCopy = this.deepCopyStreamingState(streamingState);
 
-    // DIAGNOSTIC: Log accumulator state at finalization time
-    const textKeys = [...stateCopy.textAccumulators.keys()].filter((k) =>
-      k.includes('-block-'),
-    );
-    const thinkKeys = [...stateCopy.textAccumulators.keys()].filter((k) =>
-      k.includes('-thinking-'),
-    );
-    console.log('[Finalization] Building final tree from state:', {
-      eventCount: stateCopy.events.size,
-      messageIds: stateCopy.messageEventIds.length,
-      textAccumulatorKeys: textKeys,
-      thinkingAccumulatorKeys: thinkKeys,
-      totalAccumulators: stateCopy.textAccumulators.size,
-    });
-
     // Build final tree using ExecutionTreeBuilderService (TASK_2025_082 Batch 6)
     // PERFORMANCE: Use unique cache key for finalization to avoid stale cache
     const cacheKey = `finalize-${targetTabId}-${Date.now()}`;
@@ -471,9 +456,6 @@ export class MessageFinalizationService {
     };
 
     this.tabManager.updateTab(tabId, { messages: updatedMessages });
-    console.log(
-      '[MessageFinalizationService] Marked last agent as interrupted (hard deny)',
-    );
   }
 
   /**
@@ -548,10 +530,6 @@ export class MessageFinalizationService {
     };
 
     this.tabManager.updateTab(tabId, { messages: updatedMessages });
-    console.log(
-      '[MessageFinalizationService] Marked agents as interrupted by toolCallIds',
-      { toolCallIds: [...toolCallIds] },
-    );
   }
 
   /**

--- a/libs/frontend/chat/src/lib/services/chat-store/permission-handler.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/permission-handler.service.ts
@@ -92,10 +92,6 @@ export class PermissionHandlerService {
         .map((r) => r.id);
 
       if (expiredIds.length > 0) {
-        console.log(
-          '[PermissionHandlerService] Cleaning up expired question requests:',
-          expiredIds,
-        );
         this._questionRequests.update((reqs) =>
           reqs.filter((r) => r.timeoutAt <= 0 || r.timeoutAt > now),
         );
@@ -241,16 +237,6 @@ export class PermissionHandlerService {
     const latencyMs =
       request.timestamp !== undefined ? receiveTime - request.timestamp : null;
 
-    console.log('[PermissionHandlerService] Permission request received:', {
-      requestId: request.id,
-      toolName: request.toolName,
-      toolUseId: request.toolUseId,
-      receiveTime,
-      backendTimestamp: request.timestamp ?? 'N/A',
-      latencyMs: latencyMs !== null ? `${latencyMs}ms` : 'N/A',
-      timeoutAt: request.timeoutAt,
-    });
-
     // Performance warning if latency exceeds expected threshold (100ms)
     if (latencyMs !== null && latencyMs > 100) {
       console.warn(
@@ -274,10 +260,6 @@ export class PermissionHandlerService {
     id: string;
     toolName: string;
   }): void {
-    console.log(
-      '[PermissionHandlerService] Permission auto-resolved:',
-      payload,
-    );
     this._permissionRequests.update((requests) =>
       requests.filter((r) => r.id !== payload.id),
     );
@@ -291,8 +273,6 @@ export class PermissionHandlerService {
    * Extracted from chat.store.ts:1344-1364
    */
   handlePermissionResponse(response: PermissionResponse): void {
-    console.log('[PermissionHandlerService] Permission response:', response);
-
     // Track hard deny IDs for targeted interrupted badge display.
     // TASK_2025_213: Prefer agentToolCallId (the parent Task tool's ID) over
     // toolUseId (the denied tool's own ID). The frontend's markAgentsAsInterruptedByToolCallIds
@@ -361,17 +341,6 @@ export class PermissionHandlerService {
 
     const permission = this.getPermissionByToolId(toolCallId);
 
-    // Debug logging for ID correlation issues
-    if (!permission && this._permissionRequests().length > 0) {
-      console.debug('[PermissionHandlerService] Permission lookup miss:', {
-        lookupKey: toolCallId,
-        availableToolUseIds: this._permissionRequests()
-          .map((req) => req.toolUseId)
-          .filter(Boolean),
-        pendingCount: this._permissionRequests().length,
-      });
-    }
-
     return permission ?? null;
   }
 
@@ -396,16 +365,6 @@ export class PermissionHandlerService {
     const latencyMs =
       request.timestamp !== undefined ? receiveTime - request.timestamp : null;
 
-    console.log('[PermissionHandlerService] Question request received:', {
-      id: request.id,
-      questionCount: request.questions.length,
-      toolUseId: request.toolUseId,
-      receiveTime,
-      backendTimestamp: request.timestamp ?? 'N/A',
-      latencyMs: latencyMs !== null ? `${latencyMs}ms` : 'N/A',
-      timeoutAt: request.timeoutAt,
-    });
-
     // Performance warning if latency exceeds expected threshold (100ms)
     if (latencyMs !== null && latencyMs > 100) {
       console.warn(
@@ -428,11 +387,6 @@ export class PermissionHandlerService {
    * @param response The user's answers to the questions
    */
   handleQuestionResponse(response: AskUserQuestionResponse): void {
-    console.log('[PermissionHandlerService] Question response sent:', {
-      id: response.id,
-      answerCount: Object.keys(response.answers).length,
-    });
-
     // Remove from pending requests
     this._questionRequests.update((requests) =>
       requests.filter((r) => r.id !== response.id),
@@ -469,8 +423,6 @@ export class PermissionHandlerService {
    * Prevents stale permission/question cards from lingering in the UI.
    */
   cleanupSession(sessionId: string): void {
-    console.log('[PermissionHandlerService] Session cleanup:', sessionId);
-
     this._permissionRequests.update((requests) =>
       requests.filter((r) => r.sessionId !== sessionId),
     );

--- a/libs/frontend/chat/src/lib/services/chat.store.ts
+++ b/libs/frontend/chat/src/lib/services/chat.store.ts
@@ -951,14 +951,16 @@ export class ChatStore {
 
     // Process modelUsage to update liveModelStats for context display
     if (stats.modelUsage && stats.modelUsage.length > 0) {
-      // Use the model with the highest output tokens (the one that did the most work).
-      // Backend sorts modelUsage[0] to be the primary model, but as a safety net
-      // we also verify by selecting the highest-output model if there are multiple.
+      // Use the model with the highest cost (the user's primary model).
+      // Backend sorts modelUsage[0] by costUSD descending, but as a safety net
+      // we verify by selecting the highest-cost model. This ensures the user's
+      // main model (e.g. Opus) is shown even when a cheaper subagent (e.g. Haiku)
+      // produces more output tokens.
       const primaryModel =
         stats.modelUsage.length === 1
           ? stats.modelUsage[0]
           : stats.modelUsage.reduce((best, current) =>
-              current.outputTokens > best.outputTokens ? current : best,
+              current.costUSD > best.costUSD ? current : best,
             );
       // Context usage = input + cache-read + output tokens.
       // Cache-read tokens represent cached prompt content that still occupies context window space.

--- a/libs/frontend/chat/src/lib/services/chat.store.ts
+++ b/libs/frontend/chat/src/lib/services/chat.store.ts
@@ -951,10 +951,11 @@ export class ChatStore {
 
     // Process modelUsage to update liveModelStats for context display
     if (stats.modelUsage && stats.modelUsage.length > 0) {
-      // Use the model with the highest cost (the user's primary model).
-      // Backend sorts modelUsage[0] by costUSD descending, but as a safety net
-      // we verify by selecting the highest-cost model. This ensures the user's
-      // main model (e.g. Opus) is shown even when a cheaper subagent (e.g. Haiku)
+      // Select the model with the highest cost as the user's primary model.
+      // The live stream path sorts modelUsage[0] by initialModel match then
+      // outputTokens, while the history path sorts by costUSD. As a unified
+      // safety net we pick the highest-cost model, ensuring the user's main
+      // model (e.g. Opus) is shown even when a cheaper subagent (e.g. Haiku)
       // produces more output tokens.
       const primaryModel =
         stats.modelUsage.length === 1

--- a/libs/frontend/chat/src/lib/services/keyboard-shortcuts.service.ts
+++ b/libs/frontend/chat/src/lib/services/keyboard-shortcuts.service.ts
@@ -59,8 +59,6 @@ export class KeyboardShortcutsService {
             break;
         }
       });
-
-    console.log('[KeyboardShortcuts] Global shortcuts initialized');
   }
 
   /**
@@ -69,7 +67,6 @@ export class KeyboardShortcutsService {
   private createNewTab(): void {
     const newTabId = this.tabManager.createTab();
     this.tabManager.switchTab(newTabId);
-    console.log('[KeyboardShortcuts] New tab created via shortcut:', newTabId);
   }
 
   /**
@@ -79,10 +76,6 @@ export class KeyboardShortcutsService {
     const activeId = this.tabManager.activeTabId();
     if (activeId) {
       this.tabManager.closeTab(activeId);
-      console.log(
-        '[KeyboardShortcuts] Active tab closed via shortcut:',
-        activeId
-      );
     }
   }
 
@@ -102,10 +95,5 @@ export class KeyboardShortcutsService {
     // Wrap around using modulo
     const nextIndex = (currentIndex + direction + tabs.length) % tabs.length;
     this.tabManager.switchTab(tabs[nextIndex].id);
-    console.log(
-      '[KeyboardShortcuts] Cycled to tab:',
-      nextIndex,
-      direction === 1 ? '(next)' : '(previous)'
-    );
   }
 }

--- a/libs/frontend/chat/src/lib/services/message-sender.service.ts
+++ b/libs/frontend/chat/src/lib/services/message-sender.service.ts
@@ -193,7 +193,6 @@ export class MessageSenderService {
     if (isStreaming) {
       // Queue for later - delegate to ConversationService via ChatStore
       // We don't queue directly to avoid circular dependency
-      console.log('[MessageSender] Streaming active, message will be queued');
       // Note: Queue handling is done by caller (ChatStore/ConversationService)
       // This method just checks the condition
       return;
@@ -309,11 +308,6 @@ export class MessageSenderService {
       // Session ID will be initialized by StreamingHandler on first event
       // No tracking needed - removed PendingSessionManager
 
-      console.log('[MessageSender] Starting NEW conversation:', {
-        tabId: activeTabId,
-        // No placeholder sessionId - backend will use SDK's real UUID
-      });
-
       // Call RPC to start NEW chat
       // TASK_2025_092: Use tabId for frontend correlation instead of placeholder sessionId
       // TASK_2025_170: Pass ptahCliId if a Ptah CLI agent is selected
@@ -338,11 +332,6 @@ export class MessageSenderService {
         this.tabManager.updateTab(activeTabId, { status: 'loaded' });
         this.sessionManager.setStatus('loaded');
         this.sessionManager.failSession();
-      } else {
-        console.log('[MessageSender] New conversation started:', result.data);
-
-        // Note: Sessions list refresh moved to handleSessionIdResolved() in ChatStore
-        // At this point metadata doesn't exist yet, so loadSessions() would miss this session
       }
     } catch (error) {
       console.error('[MessageSender] Failed to start new conversation:', error);
@@ -460,11 +449,6 @@ export class MessageSenderService {
         messages: [...(activeTab?.messages ?? []), userMessage],
       });
 
-      console.log('[MessageSender] Continuing EXISTING session:', {
-        sessionId,
-        tabId: activeTabId,
-      });
-
       // Call RPC to CONTINUE existing chat (uses --resume flag)
       // TASK_2025_092: Include tabId for event routing
       const result = await this.claudeRpcService.call('chat:continue', {
@@ -485,7 +469,6 @@ export class MessageSenderService {
         this.tabManager.markTabIdle(activeTabId);
         this.sessionManager.setStatus('loaded');
       } else {
-        console.log('[MessageSender] Conversation continued:', result.data);
         this.sessionManager.setStatus('streaming');
         this.tabManager.updateTab(activeTabId, { status: 'streaming' });
         this.tabManager.markTabStreaming(activeTabId);

--- a/libs/frontend/core/src/lib/services/agent-discovery.facade.ts
+++ b/libs/frontend/core/src/lib/services/agent-discovery.facade.ts
@@ -29,19 +29,13 @@ export class AgentDiscoveryFacade {
   async fetchAgents(): Promise<void> {
     // Cache check - skip RPC if already cached
     if (this._isCached()) {
-      console.log('[AgentDiscoveryFacade] Cache hit, skipping RPC');
       return;
     }
 
     // Prevent duplicate in-flight requests
     if (this._isLoading()) {
-      console.log(
-        '[AgentDiscoveryFacade] Request in-flight, skipping duplicate'
-      );
       return;
     }
-
-    console.log('[AgentDiscoveryFacade] fetchAgents called');
     this._isLoading.set(true);
     this._error.set(null);
 
@@ -59,9 +53,9 @@ export class AgentDiscoveryFacade {
               a.scope === 'builtin'
                 ? '🤖'
                 : a.scope === 'project'
-                ? '🛠️'
-                : '👤',
-          }))
+                  ? '🛠️'
+                  : '👤',
+          })),
         );
         // Only mark cache as valid when we have actual data
         if (result.data.agents.length > 0) {
@@ -87,29 +81,17 @@ export class AgentDiscoveryFacade {
    */
   searchAgents(query: string): AgentSuggestion[] {
     const allAgents = this._agents();
-    console.log('[AgentDiscoveryFacade] searchAgents called', {
-      query,
-      totalAgents: allAgents.length,
-    });
 
     if (!query) {
-      console.log('[AgentDiscoveryFacade] Returning all agents', {
-        count: allAgents.length,
-      });
       return allAgents;
     }
 
     const lowerQuery = query.toLowerCase();
-    const results = allAgents.filter(
+    return allAgents.filter(
       (a) =>
         a.name.toLowerCase().includes(lowerQuery) ||
-        a.description.toLowerCase().includes(lowerQuery)
+        a.description.toLowerCase().includes(lowerQuery),
     );
-
-    console.log('[AgentDiscoveryFacade] Filtered results', {
-      count: results.length,
-    });
-    return results;
   }
 
   /**
@@ -119,6 +101,5 @@ export class AgentDiscoveryFacade {
     this._isCached.set(false);
     this._agents.set([]);
     this._error.set(null);
-    console.log('[AgentDiscoveryFacade] Cache cleared');
   }
 }

--- a/libs/frontend/core/src/lib/services/app-state.service.ts
+++ b/libs/frontend/core/src/lib/services/app-state.service.ts
@@ -50,9 +50,6 @@ export class AppStateManager implements MessageHandler {
       'welcome',
     ];
     if (view && validViews.includes(view as ViewType)) {
-      console.log(
-        `[AppStateManager] Backend requested view switch to: ${view}`,
-      );
       this.handleViewSwitch(view as ViewType);
     } else {
       console.warn(
@@ -169,11 +166,6 @@ export class AppStateManager implements MessageHandler {
     }
 
     const initialView = windowWithState.initialView || 'chat';
-    console.log(
-      `[AppStateManager] Initializing with view: ${initialView}, isLicensed: ${isLicensed}, workspace: ${
-        workspaceRoot || 'none'
-      }`,
-    );
     this._currentView.set(initialView);
     if (initialView !== 'chat' && initialView !== 'welcome') {
       this._openViews.update((views) => {

--- a/libs/frontend/core/src/lib/services/claude-rpc.service.ts
+++ b/libs/frontend/core/src/lib/services/claude-rpc.service.ts
@@ -129,7 +129,6 @@ export class ClaudeRpcService implements MessageHandler {
   readonly handledMessageTypes = [MESSAGE_TYPES.RPC_RESPONSE] as const;
 
   handleMessage(message: { type: string; payload?: unknown }): void {
-    console.log('[ClaudeRpcService] Received RPC response:', message);
     this.handleResponse(message as unknown as RpcResponse);
   }
 
@@ -292,21 +291,11 @@ export class ClaudeRpcService implements MessageHandler {
     limit?: number,
     offset?: number,
   ): Promise<RpcResult<SessionListResult>> {
-    console.log(
-      '🔵 [ClaudeRpcService] listSessions() called - Sending RPC request...',
-    );
-    const result = await this.call('session:list', {
+    return this.call('session:list', {
       workspacePath,
       limit,
       offset,
     });
-    console.log('✅ [ClaudeRpcService] listSessions() response:', {
-      success: result.success,
-      sessionCount: result.data?.sessions?.length ?? 0,
-      total: result.data?.total ?? 0,
-      error: result.error,
-    });
-    return result;
   }
 
   /**
@@ -341,15 +330,7 @@ export class ClaudeRpcService implements MessageHandler {
   async deleteSession(
     sessionId: SessionId,
   ): Promise<RpcResult<{ success: boolean; error?: string }>> {
-    console.log(
-      '🗑️ [ClaudeRpcService] deleteSession() called - Sending RPC request...',
-    );
-    const result = await this.call('session:delete', { sessionId });
-    console.log('✅ [ClaudeRpcService] deleteSession() response:', {
-      success: result.success,
-      error: result.error,
-    });
-    return result;
+    return this.call('session:delete', { sessionId });
   }
 
   /**
@@ -379,15 +360,6 @@ export class ClaudeRpcService implements MessageHandler {
    * @returns Promise with array of SubagentRecord
    */
   async querySubagents(): Promise<RpcResult<SubagentQueryResult>> {
-    console.log(
-      '🔍 [ClaudeRpcService] querySubagents() called - Sending RPC request...',
-    );
-    const result = await this.call('chat:subagent-query', {});
-    console.log('✅ [ClaudeRpcService] querySubagents() response:', {
-      success: result.success,
-      count: result.data?.subagents?.length ?? 0,
-      error: result.error,
-    });
-    return result;
+    return this.call('chat:subagent-query', {});
   }
 }

--- a/libs/frontend/core/src/lib/services/command-discovery.facade.ts
+++ b/libs/frontend/core/src/lib/services/command-discovery.facade.ts
@@ -30,19 +30,13 @@ export class CommandDiscoveryFacade {
   async fetchCommands(): Promise<void> {
     // Cache check - skip RPC if already cached
     if (this._isCached()) {
-      console.log('[CommandDiscoveryFacade] Cache hit, skipping RPC');
       return;
     }
 
     // Prevent duplicate in-flight requests
     if (this._isLoading()) {
-      console.log(
-        '[CommandDiscoveryFacade] Request in-flight, skipping duplicate'
-      );
       return;
     }
-
-    console.log('[CommandDiscoveryFacade] fetchCommands called');
     this._isLoading.set(true);
     this._error.set(null);
 
@@ -57,7 +51,7 @@ export class CommandDiscoveryFacade {
           result.data.commands.map((c) => ({
             ...c,
             icon: this.getCommandIcon(c.scope),
-          }))
+          })),
         );
         // Only mark cache as valid when we have actual data
         if (result.data.commands.length > 0) {
@@ -66,7 +60,7 @@ export class CommandDiscoveryFacade {
       } else if (result.error) {
         console.warn(
           '[CommandDiscoveryFacade] Discovery failed:',
-          result.error
+          result.error,
         );
         this._commands.set([]);
       }
@@ -76,7 +70,7 @@ export class CommandDiscoveryFacade {
       this._error.set(message);
       console.error(
         '[CommandDiscoveryFacade] Failed to fetch commands:',
-        error
+        error,
       );
       this._commands.set([]);
     } finally {
@@ -89,29 +83,17 @@ export class CommandDiscoveryFacade {
    */
   searchCommands(query: string): CommandSuggestion[] {
     const allCommands = this._commands();
-    console.log('[CommandDiscoveryFacade] searchCommands called', {
-      query,
-      totalCommands: allCommands.length,
-    });
 
     if (!query) {
-      console.log('[CommandDiscoveryFacade] Returning all commands', {
-        count: allCommands.length,
-      });
       return allCommands;
     }
 
     const lowerQuery = query.toLowerCase();
-    const results = allCommands.filter(
+    return allCommands.filter(
       (c) =>
         c.name.toLowerCase().includes(lowerQuery) ||
-        c.description.toLowerCase().includes(lowerQuery)
+        c.description.toLowerCase().includes(lowerQuery),
     );
-
-    console.log('[CommandDiscoveryFacade] Filtered results', {
-      count: results.length,
-    });
-    return results;
   }
 
   private getCommandIcon(scope: string): string {
@@ -138,6 +120,5 @@ export class CommandDiscoveryFacade {
     this._isCached.set(false);
     this._commands.set([]);
     this._error.set(null);
-    console.log('[CommandDiscoveryFacade] Cache cleared');
   }
 }

--- a/libs/frontend/core/src/lib/services/message-router.service.ts
+++ b/libs/frontend/core/src/lib/services/message-router.service.ts
@@ -39,10 +39,6 @@ export class MessageRouterService {
         }
       }
     }
-
-    console.log(
-      `[MessageRouterService] Registered ${this.handlers.length} handlers for ${this.handlerMap.size} message types`
-    );
   }
 
   /**
@@ -69,7 +65,7 @@ export class MessageRouterService {
  * so the message listener is active before any components render.
  */
 export function initializeMessageRouter(
-  _router: MessageRouterService
+  _router: MessageRouterService,
 ): () => void {
   return () => {
     // Service is already initialized in constructor

--- a/libs/shared/src/lib/utils/pricing.utils.ts
+++ b/libs/shared/src/lib/utils/pricing.utils.ts
@@ -54,13 +54,13 @@ export const DEFAULT_MODEL_PRICING: Record<string, ModelPricing> = {
   // Anthropic Claude Models
   // ============================================================================
 
-  // Claude 4.6 Opus (latest flagship)
+  // Claude 4.6 Opus (latest flagship — 1M context window)
   'claude-opus-4-6-20250623': {
     inputCostPerToken: 5e-6, // $5.00 per 1M tokens
     outputCostPerToken: 25e-6, // $25.00 per 1M tokens
     cacheReadCostPerToken: 5e-7, // $0.50 per 1M tokens
     cacheCreationCostPerToken: 6.25e-6, // $6.25 per 1M tokens
-    maxTokens: 200_000,
+    maxTokens: 1_000_000,
     provider: 'anthropic',
   },
 
@@ -70,7 +70,7 @@ export const DEFAULT_MODEL_PRICING: Record<string, ModelPricing> = {
     outputCostPerToken: 25e-6,
     cacheReadCostPerToken: 5e-7,
     cacheCreationCostPerToken: 6.25e-6,
-    maxTokens: 200_000,
+    maxTokens: 1_000_000,
     provider: 'anthropic',
   },
 


### PR DESCRIPTION
## Summary
- Move file/image attachment buttons from bottom toolbar to top-right of textarea input area with subtle hover styling
- Fix primary model selection to use cost instead of output tokens (shows Opus over Haiku subagent)
- Hide model name badge when multiple models are used in a session
- Update Claude Opus 4.6 context window from 200K to 1M tokens
- Migrate domain references from ptah.dev to ptah.live across landing page, license server, and electron app
- Disable experimental betas for third-party providers

## Test plan
- [ ] Verify attachment buttons appear at top-right of input textarea and are clickable
- [ ] Verify textarea text doesn't overlap the attachment buttons
- [ ] Confirm model badge shows correct primary model when using multi-model sessions
- [ ] Verify domain links in electron Help menu and landing page point to ptah.live

🤖 Generated with [Claude Code](https://claude.com/claude-code)