### PR TITLE
fix: address Copilot PR #113 review — security and correctness fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
   "ptah.authMethod": "oauth",
   "ptah.model.selected": "opus",
-  "ptah.reasoningEffort": "high",
-  "ptah.autopilot.enabled": true,
-  "ptah.autopilot.permissionLevel": "yolo"
+  "ptah.reasoningEffort": "high"
 }

--- a/apps/ptah-tui/src/services/platform/cli-save-dialog.ts
+++ b/apps/ptah-tui/src/services/platform/cli-save-dialog.ts
@@ -18,11 +18,17 @@ export class CliSaveDialog implements ISaveDialogProvider {
     content: Buffer;
   }): Promise<string | null> {
     try {
-      const filePath = path.join(process.cwd(), options.defaultFilename);
+      // Sanitize filename to prevent path traversal — strip directory components
+      const safeName = path.basename(options.defaultFilename);
+      if (!safeName) return null;
 
-      // Ensure the parent directory exists
-      const dir = path.dirname(filePath);
-      await fs.mkdir(dir, { recursive: true });
+      const cwd = process.cwd();
+      const filePath = path.resolve(cwd, safeName);
+
+      // Verify the resolved path is still under cwd
+      if (!filePath.startsWith(cwd + path.sep) && filePath !== cwd) {
+        return null;
+      }
 
       await fs.writeFile(filePath, options.content);
 

--- a/libs/backend/platform-cli/src/implementations/cli-user-interaction.ts
+++ b/libs/backend/platform-cli/src/implementations/cli-user-interaction.ts
@@ -20,26 +20,35 @@ import type {
   ICancellationToken,
 } from '@ptah-extension/platform-core';
 import { createEvent } from '@ptah-extension/platform-core';
-import { exec } from 'child_process';
+import { spawn } from 'child_process';
 
 export class CliUserInteraction implements IUserInteraction {
   async openExternal(url: string): Promise<boolean> {
-    // Attempt to open URL in the default browser using platform-specific commands
+    // Validate URL scheme to prevent arbitrary command execution
+    try {
+      const parsed = new URL(url);
+      if (!['http:', 'https:', 'mailto:'].includes(parsed.protocol)) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+
+    // Use spawn with argument arrays (no shell interpolation) to prevent injection
     return new Promise<boolean>((resolve) => {
       const platform = process.platform;
-      let command: string;
+      let child;
 
       if (platform === 'win32') {
-        command = `start "" "${url}"`;
+        child = spawn('cmd', ['/c', 'start', '', url], { stdio: 'ignore' });
       } else if (platform === 'darwin') {
-        command = `open "${url}"`;
+        child = spawn('open', [url], { stdio: 'ignore' });
       } else {
-        command = `xdg-open "${url}"`;
+        child = spawn('xdg-open', [url], { stdio: 'ignore' });
       }
 
-      exec(command, (error) => {
-        resolve(!error);
-      });
+      child.on('close', (code) => resolve(code === 0));
+      child.on('error', () => resolve(false));
     });
   }
 

--- a/libs/frontend/chat/src/lib/services/chat-store/permission-handler.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/permission-handler.service.ts
@@ -116,12 +116,13 @@ export class PermissionHandlerService {
   /**
    * Cache keys for toolIdsInExecutionTree memoization.
    * The computed re-evaluates on every activeTab() change (frequent during streaming).
-   * By tracking message count and toolCallMap size, we can skip the full traversal
-   * when nothing relevant has changed.
+   * We track message count and a fingerprint of toolCallMap keys to skip the full
+   * traversal when nothing relevant has changed. Using a key fingerprint (sorted+joined)
+   * instead of just `.size` avoids stale cache when keys change but size stays the same.
    */
   private _lastToolIdsTabId: string | null = null;
   private _lastToolIdsMsgCount = -1;
-  private _lastToolIdsToolCallMapSize = -1;
+  private _lastToolIdsKeyFingerprint = '';
   private _cachedToolIds = new Set<string>();
 
   /**
@@ -183,16 +184,21 @@ export class PermissionHandlerService {
     const streamingState = this.tabManager.activeTabStreamingState();
 
     const msgCount = messages.length;
-    const toolCallMapSize = streamingState?.toolCallMap?.size ?? 0;
+    const toolCallMap = streamingState?.toolCallMap;
+    // Build fingerprint from actual keys — catches cases where size stays the
+    // same but keys differ (e.g., one tool removed + another added simultaneously).
+    const keyFingerprint = toolCallMap
+      ? Array.from(toolCallMap.keys()).sort().join(',')
+      : '';
 
-    // TASK_2025_264 P3: Memoize by message count + toolCallMap size.
+    // TASK_2025_264 P3: Memoize by message count + toolCallMap key fingerprint.
     // These are the two inputs that change the result. When both are stable
     // (e.g., during streaming text deltas that don't add new tools),
     // we skip the full O(messages * children) traversal.
     if (
       tabId === this._lastToolIdsTabId &&
       msgCount === this._lastToolIdsMsgCount &&
-      toolCallMapSize === this._lastToolIdsToolCallMapSize
+      keyFingerprint === this._lastToolIdsKeyFingerprint
     ) {
       return this._cachedToolIds;
     }
@@ -219,7 +225,7 @@ export class PermissionHandlerService {
     // Update cache keys
     this._lastToolIdsTabId = tabId;
     this._lastToolIdsMsgCount = msgCount;
-    this._lastToolIdsToolCallMapSize = toolCallMapSize;
+    this._lastToolIdsKeyFingerprint = keyFingerprint;
     this._cachedToolIds = toolIds;
 
     return toolIds;

--- a/libs/frontend/editor/src/lib/git-status-bar/git-changed-files.component.ts
+++ b/libs/frontend/editor/src/lib/git-status-bar/git-changed-files.component.ts
@@ -24,7 +24,7 @@ import type { GitFileStatus } from '@ptah-extension/shared';
  * Renders below the git status bar when toggled. Shows changed files grouped as:
  * - Staged changes (index)
  * - Unstaged changes (worktree)
- * Clicking a file emits the absolute path for the parent to open in the editor.
+ * Clicking a file emits the relative git path for the parent to resolve and open.
  */
 @Component({
   selector: 'ptah-git-changed-files',

--- a/libs/frontend/editor/src/lib/git-status-bar/git-status-bar.component.ts
+++ b/libs/frontend/editor/src/lib/git-status-bar/git-status-bar.component.ts
@@ -356,15 +356,21 @@ export class GitStatusBarComponent {
     const workspaceRoot = this.gitStatus.activeWorkspacePath;
     if (!workspaceRoot) return;
 
-    // Guard against path traversal (git status paths should never contain these)
-    if (relativePath.startsWith('/') || relativePath.includes('..')) return;
+    // Guard against path traversal — validate each segment individually.
+    // Git status paths are always relative with forward slashes, never absolute.
+    const normalized = relativePath.replace(/\\/g, '/');
+    const segments = normalized.split('/');
+    const isAbsolute =
+      normalized.startsWith('/') || /^[a-zA-Z]:/.test(normalized);
+    const hasTraversal = segments.some((s) => s === '..' || s === '.');
+    if (isAbsolute || hasTraversal || segments.length === 0) return;
 
     // Build absolute path from workspace root + relative path
     const normalizedRoot = workspaceRoot.replace(/\\/g, '/');
     const root = normalizedRoot.endsWith('/')
       ? normalizedRoot
       : normalizedRoot + '/';
-    const absolutePath = root + relativePath;
+    const absolutePath = root + normalized;
 
     void this.editorService.openFile(absolutePath);
   }


### PR DESCRIPTION
Fix command injection in CliUserInteraction.openExternal() by replacing shell-interpolated exec() with spawn() argument arrays and URL scheme validation. Fix path traversal in CliSaveDialog via path.basename() sanitization. Harden git-status-bar path validation with segment-level traversal checks and Windows drive letter detection. Replace memoization cache key (toolCallMap.size) with key fingerprint to prevent stale cache on same-size key changes. Fix doc/code mismatch in GitChangedFilesComponent. Remove unsafe autopilot/yolo defaults from .vscode/settings.json.