### PR TITLE
feat: subagent models, Electron file open & editor enhancements

### DIFF
--- a/apps/ptah-electron/package.json
+++ b/apps/ptah-electron/package.json
@@ -39,6 +39,8 @@
     "@anthropic-ai/claude-agent-sdk": "^0.2.81",
     "@github/copilot-sdk": "^0.1.25",
     "@openai/codex-sdk": "^0.104.0",
+    "chrome-launcher": "^1.2.1",
+    "chrome-remote-interface": "^0.34.0",
     "gifenc": "^1.0.3",
     "jpeg-js": "^0.4.4"
   }

--- a/apps/ptah-electron/project.json
+++ b/apps/ptah-electron/project.json
@@ -60,6 +60,8 @@
           "gpt-tokenizer",
           "web-tree-sitter",
           "@tavily/core",
+          "chrome-launcher",
+          "chrome-remote-interface",
           "gifenc",
           "jpeg-js"
         ],

--- a/apps/ptah-electron/src/di/container.ts
+++ b/apps/ptah-electron/src/di/container.ts
@@ -94,8 +94,8 @@ import { registerTemplateGenerationServices } from '@ptah-extension/template-gen
 import {
   registerVsCodeLmToolsServices,
   BROWSER_CAPABILITIES_TOKEN,
+  ChromeLauncherBrowserCapabilities,
 } from '@ptah-extension/vscode-lm-tools';
-import { ElectronBrowserCapabilities } from '../services/electron-browser-capabilities';
 
 // Electron-specific adapters (defined below)
 import {
@@ -699,15 +699,16 @@ export class ElectronDIContainer {
     registerVsCodeLmToolsServices(container, logger);
 
     // Phase 4.0.1: Browser capabilities (TASK_2025_244)
-    // ElectronBrowserCapabilities uses Electron's native BrowserWindow + webContents.debugger
-    // for CDP browser automation. Zero external dependencies.
-    // Headless/viewport are agent-controlled via ptah_browser_navigate params.
+    // Uses ChromeLauncherBrowserCapabilities (same as VS Code) to launch a real Chrome
+    // instance via chrome-launcher + chrome-remote-interface for CDP automation.
+    // This avoids the Electron BrowserWindow approach which confusingly opens
+    // another Ptah Desktop window instead of a separate browser.
     {
       const workspaceProvider = container.resolve<IWorkspaceProvider>(
         PLATFORM_TOKENS.WORKSPACE_PROVIDER,
       );
       container.register(BROWSER_CAPABILITIES_TOKEN, {
-        useValue: new ElectronBrowserCapabilities(
+        useValue: new ChromeLauncherBrowserCapabilities(
           // getRecordingDir
           () =>
             workspaceProvider.getConfiguration<string>(

--- a/apps/ptah-electron/src/services/git-info.service.ts
+++ b/apps/ptah-electron/src/services/git-info.service.ts
@@ -16,6 +16,11 @@ import {
   type GitFileStatus,
   type GitInfoResult,
   type GitWorktreeInfo,
+  type GitStageResult,
+  type GitUnstageResult,
+  type GitDiscardResult,
+  type GitCommitResult,
+  type GitShowFileResult,
 } from '@ptah-extension/shared';
 
 const GIT_TIMEOUT_MS = 10_000;
@@ -157,6 +162,286 @@ export class GitInfoService {
       return { success: false, error: message };
     }
   }
+
+  // ==========================================================================
+  // Source Control Operations (TASK_2025_273)
+  // ==========================================================================
+
+  /**
+   * Stage files in the git index.
+   * Runs: git add -- <paths...>
+   */
+  async stageFiles(
+    workspacePath: string,
+    paths: string[],
+  ): Promise<GitStageResult> {
+    try {
+      this.validatePaths(paths);
+
+      const { exitCode, stderr } = await this.execGit(
+        ['add', '--', ...paths],
+        workspacePath,
+      );
+
+      if (exitCode !== 0) {
+        return {
+          success: false,
+          error: stderr.trim() || 'Failed to stage files',
+        };
+      }
+
+      return { success: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error('[GitInfoService] stageFiles failed', {
+        workspacePath,
+        paths,
+        error: message,
+      } as unknown as Error);
+      return { success: false, error: message };
+    }
+  }
+
+  /**
+   * Unstage files from the git index.
+   * Runs: git reset HEAD -- <paths...>
+   */
+  async unstageFiles(
+    workspacePath: string,
+    paths: string[],
+  ): Promise<GitUnstageResult> {
+    try {
+      this.validatePaths(paths);
+
+      const { exitCode, stderr } = await this.execGit(
+        ['reset', 'HEAD', '--', ...paths],
+        workspacePath,
+      );
+
+      if (exitCode !== 0) {
+        return {
+          success: false,
+          error: stderr.trim() || 'Failed to unstage files',
+        };
+      }
+
+      return { success: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error('[GitInfoService] unstageFiles failed', {
+        workspacePath,
+        paths,
+        error: message,
+      } as unknown as Error);
+      return { success: false, error: message };
+    }
+  }
+
+  /**
+   * Discard working tree changes for files.
+   * For tracked files: git checkout -- <paths...>
+   * For untracked files: git clean -f -- <paths...>
+   *
+   * WARNING: This is a destructive operation that cannot be undone.
+   */
+  async discardChanges(
+    workspacePath: string,
+    paths: string[],
+  ): Promise<GitDiscardResult> {
+    try {
+      this.validatePaths(paths);
+
+      // Separate tracked from untracked files by checking git status
+      const { stdout: statusOutput } = await this.execGit(
+        ['status', '--porcelain', '--', ...paths],
+        workspacePath,
+      );
+
+      const untrackedPaths: string[] = [];
+      const trackedPaths: string[] = [];
+
+      for (const line of statusOutput.split('\n')) {
+        if (!line.trim()) continue;
+        // Untracked files start with '?? '
+        if (line.startsWith('?? ')) {
+          untrackedPaths.push(line.substring(3).trim());
+        } else {
+          // Extract the file path from the status line (skip 3-char status prefix)
+          trackedPaths.push(line.substring(3).trim());
+        }
+      }
+
+      // Discard tracked file changes
+      if (trackedPaths.length > 0) {
+        const { exitCode, stderr } = await this.execGit(
+          ['checkout', '--', ...trackedPaths],
+          workspacePath,
+        );
+
+        if (exitCode !== 0) {
+          return {
+            success: false,
+            error: stderr.trim() || 'Failed to discard tracked file changes',
+          };
+        }
+      }
+
+      // Remove untracked files
+      if (untrackedPaths.length > 0) {
+        this.logger.warn(
+          '[GitInfoService] Removing untracked files via git clean (irreversible)',
+          {
+            workspacePath,
+            paths: untrackedPaths,
+          } as unknown as Error,
+        );
+
+        const { exitCode, stderr } = await this.execGit(
+          ['clean', '-f', '--', ...untrackedPaths],
+          workspacePath,
+        );
+
+        if (exitCode !== 0) {
+          return {
+            success: false,
+            error: stderr.trim() || 'Failed to remove untracked files',
+          };
+        }
+      }
+
+      return { success: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error('[GitInfoService] discardChanges failed', {
+        workspacePath,
+        paths,
+        error: message,
+      } as unknown as Error);
+      return { success: false, error: message };
+    }
+  }
+
+  /**
+   * Create a commit with the given message.
+   * Runs: git commit -m "<message>"
+   * Parses the commit hash from the output.
+   */
+  async commit(
+    workspacePath: string,
+    message: string,
+  ): Promise<GitCommitResult> {
+    try {
+      const trimmedMessage = message.trim();
+      if (!trimmedMessage) {
+        return { success: false, error: 'Commit message cannot be empty' };
+      }
+
+      const { stdout, exitCode, stderr } = await this.execGit(
+        ['commit', '-m', trimmedMessage],
+        workspacePath,
+      );
+
+      if (exitCode !== 0) {
+        return {
+          success: false,
+          error: stderr.trim() || 'Failed to create commit',
+        };
+      }
+
+      // Parse commit hash from output like "[branch abc1234] commit message"
+      const hashMatch = stdout.match(/\[[\w/.-]+ ([0-9a-f]+)\]/);
+      const commitHash = hashMatch?.[1];
+
+      return { success: true, commitHash };
+    } catch (error) {
+      const message_ = error instanceof Error ? error.message : String(error);
+      this.logger.error('[GitInfoService] commit failed', {
+        workspacePath,
+        error: message_,
+      } as unknown as Error);
+      return { success: false, error: message_ };
+    }
+  }
+
+  /**
+   * Show file content from HEAD.
+   * Runs: git show HEAD:<relativePath>
+   * Returns empty content for new/untracked files.
+   */
+  async showFile(
+    workspacePath: string,
+    relativePath: string,
+  ): Promise<GitShowFileResult> {
+    try {
+      if (!relativePath || !relativePath.trim()) {
+        return { content: '' };
+      }
+
+      this.validatePathSegment(relativePath);
+
+      const { stdout, exitCode } = await this.execGit(
+        ['show', `HEAD:${relativePath}`],
+        workspacePath,
+      );
+
+      if (exitCode !== 0) {
+        // File doesn't exist in HEAD (new/untracked file) — return empty content
+        return { content: '' };
+      }
+
+      return { content: stdout };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error('[GitInfoService] showFile failed', {
+        workspacePath,
+        relativePath,
+        error: message,
+      } as unknown as Error);
+      // Gracefully return empty content on any failure
+      return { content: '' };
+    }
+  }
+
+  // ==========================================================================
+  // PATH VALIDATION
+  // ==========================================================================
+
+  /**
+   * Validate an array of paths: must be non-empty, no path traversal.
+   * Throws on invalid input.
+   */
+  private validatePaths(paths: string[]): void {
+    if (!paths || paths.length === 0) {
+      throw new Error('paths must be a non-empty array');
+    }
+
+    for (const p of paths) {
+      this.validatePathSegment(p);
+    }
+  }
+
+  /**
+   * Validate a single path: must be non-empty, no '..' segments.
+   * Throws on invalid input.
+   */
+  private validatePathSegment(filePath: string): void {
+    if (!filePath || !filePath.trim()) {
+      throw new Error('path must be a non-empty string');
+    }
+
+    // Prevent path traversal: reject paths containing '..' segments
+    const normalized = filePath.replace(/\\/g, '/');
+    const segments = normalized.split('/');
+    if (segments.some((s) => s === '..')) {
+      throw new Error(
+        `Path traversal detected: "${filePath}" contains '..' segments`,
+      );
+    }
+  }
+
+  // ==========================================================================
+  // REPOSITORY CHECKS
+  // ==========================================================================
 
   async isGitRepo(workspacePath: string): Promise<boolean> {
     try {

--- a/apps/ptah-electron/src/services/rpc/handlers/electron-git-rpc.handlers.ts
+++ b/apps/ptah-electron/src/services/rpc/handlers/electron-git-rpc.handlers.ts
@@ -22,6 +22,16 @@ import type {
   GitAddWorktreeResult,
   GitRemoveWorktreeParams,
   GitRemoveWorktreeResult,
+  GitStageParams,
+  GitStageResult,
+  GitUnstageParams,
+  GitUnstageResult,
+  GitDiscardParams,
+  GitDiscardResult,
+  GitCommitParams,
+  GitCommitResult,
+  GitShowFileParams,
+  GitShowFileResult,
 } from '@ptah-extension/shared';
 import type { GitInfoService } from '../../git-info.service';
 import { ELECTRON_TOKENS } from '../../../di/electron-tokens';
@@ -42,6 +52,12 @@ export class ElectronGitRpcHandlers {
     this.registerGitWorktrees();
     this.registerAddWorktree();
     this.registerRemoveWorktree();
+    // Source control methods (TASK_2025_273)
+    this.registerGitStage();
+    this.registerGitUnstage();
+    this.registerGitDiscard();
+    this.registerGitCommit();
+    this.registerGitShowFile();
   }
 
   /**
@@ -157,5 +173,119 @@ export class ElectronGitRpcHandlers {
 
       return this.gitInfo.removeWorktree(wsRoot, params.path, params.force);
     });
+  }
+
+  // ==========================================================================
+  // Source Control Handlers (TASK_2025_273)
+  // ==========================================================================
+
+  /**
+   * git:stage - Stage files in the git index.
+   */
+  private registerGitStage(): void {
+    this.rpcHandler.registerMethod<GitStageParams, GitStageResult>(
+      'git:stage',
+      async (params) => {
+        const wsRoot = this.workspace.getWorkspaceRoot();
+        if (!wsRoot) {
+          return { success: false, error: 'No workspace folder open' };
+        }
+
+        if (!params?.paths || params.paths.length === 0) {
+          return { success: false, error: 'paths must be a non-empty array' };
+        }
+
+        return this.gitInfo.stageFiles(wsRoot, params.paths);
+      },
+    );
+  }
+
+  /**
+   * git:unstage - Unstage files from the git index.
+   */
+  private registerGitUnstage(): void {
+    this.rpcHandler.registerMethod<GitUnstageParams, GitUnstageResult>(
+      'git:unstage',
+      async (params) => {
+        const wsRoot = this.workspace.getWorkspaceRoot();
+        if (!wsRoot) {
+          return { success: false, error: 'No workspace folder open' };
+        }
+
+        if (!params?.paths || params.paths.length === 0) {
+          return { success: false, error: 'paths must be a non-empty array' };
+        }
+
+        return this.gitInfo.unstageFiles(wsRoot, params.paths);
+      },
+    );
+  }
+
+  /**
+   * git:discard - Discard working tree changes (destructive).
+   */
+  private registerGitDiscard(): void {
+    this.rpcHandler.registerMethod<GitDiscardParams, GitDiscardResult>(
+      'git:discard',
+      async (params) => {
+        const wsRoot = this.workspace.getWorkspaceRoot();
+        if (!wsRoot) {
+          return { success: false, error: 'No workspace folder open' };
+        }
+
+        if (!params?.paths || params.paths.length === 0) {
+          return { success: false, error: 'paths must be a non-empty array' };
+        }
+
+        this.logger.warn(
+          '[ElectronGitRpc] git:discard called — this is a destructive operation',
+          { paths: params.paths } as unknown as Error,
+        );
+
+        return this.gitInfo.discardChanges(wsRoot, params.paths);
+      },
+    );
+  }
+
+  /**
+   * git:commit - Create a commit with the provided message.
+   */
+  private registerGitCommit(): void {
+    this.rpcHandler.registerMethod<GitCommitParams, GitCommitResult>(
+      'git:commit',
+      async (params) => {
+        const wsRoot = this.workspace.getWorkspaceRoot();
+        if (!wsRoot) {
+          return { success: false, error: 'No workspace folder open' };
+        }
+
+        if (!params?.message || !params.message.trim()) {
+          return { success: false, error: 'Commit message cannot be empty' };
+        }
+
+        return this.gitInfo.commit(wsRoot, params.message);
+      },
+    );
+  }
+
+  /**
+   * git:showFile - Show file content from HEAD revision.
+   */
+  private registerGitShowFile(): void {
+    this.rpcHandler.registerMethod<GitShowFileParams, GitShowFileResult>(
+      'git:showFile',
+      async (params) => {
+        const wsRoot = this.workspace.getWorkspaceRoot();
+        if (!wsRoot) {
+          return { content: '' };
+        }
+
+        if (!params?.path || !params.path.trim()) {
+          return { content: '' };
+        }
+
+        return this.gitInfo.showFile(wsRoot, params.path);
+      },
+    );
   }
 }

--- a/apps/ptah-extension-vscode/src/services/rpc/rpc-method-registration.service.ts
+++ b/apps/ptah-extension-vscode/src/services/rpc/rpc-method-registration.service.ts
@@ -213,6 +213,12 @@ export class RpcMethodRegistrationService {
       'git:worktrees',
       'git:addWorktree',
       'git:removeWorktree',
+      // Source control methods (TASK_2025_273)
+      'git:stage',
+      'git:unstage',
+      'git:discard',
+      'git:commit',
+      'git:showFile',
       // Electron terminal methods (TASK_2025_227)
       'terminal:create',
       'terminal:kill',

--- a/apps/ptah-landing-page/src/app/app.routes.ts
+++ b/apps/ptah-landing-page/src/app/app.routes.ts
@@ -7,6 +7,7 @@ import { TrialEndedPageComponent } from './pages/trial-ended/trial-ended-page.co
 import { AuthGuard } from './guards/auth.guard';
 import { GuestGuard } from './guards/guest.guard';
 import { DocsPageComponent } from './pages/docs/docs-page.component';
+import { DownloadPageComponent } from './pages/download/download-page.component';
 import { TermsPageComponent } from './pages/legal/terms-page.component';
 import { PrivacyPageComponent } from './pages/legal/privacy-page.component';
 import { RefundPageComponent } from './pages/legal/refund-page.component';
@@ -53,6 +54,10 @@ export const routes: Routes = [
   {
     path: 'docs',
     component: DocsPageComponent,
+  },
+  {
+    path: 'download',
+    component: DownloadPageComponent,
   },
   {
     path: 'pricing',

--- a/apps/ptah-landing-page/src/app/components/navigation.component.ts
+++ b/apps/ptah-landing-page/src/app/components/navigation.component.ts
@@ -98,6 +98,15 @@ import { AuthService } from '../services/auth.service';
           Docs
         </a>
 
+        <!-- Download Link -->
+        <a
+          routerLink="/download"
+          class="text-white/80 hover:text-amber-400 transition-colors text-sm font-medium focus-visible:outline focus-visible:outline-2 focus-visible:outline-amber-400 focus-visible:outline-offset-2 rounded-md px-2 py-1"
+          aria-label="Download desktop app"
+        >
+          Download
+        </a>
+
         @if (isAuthenticated()) {
           <!-- Profile Link (Authenticated) -->
           <a
@@ -278,6 +287,16 @@ import { AuthService } from '../services/auth.service';
             (click)="closeMobileMenu()"
           >
             Docs
+          </a>
+
+          <!-- Download Link -->
+          <a
+            routerLink="/download"
+            class="flex items-center px-4 py-3 text-white/80 hover:text-amber-400 hover:bg-white/5 rounded-lg transition-colors text-base font-medium"
+            role="menuitem"
+            (click)="closeMobileMenu()"
+          >
+            Download
           </a>
 
           @if (isAuthenticated()) {

--- a/apps/ptah-landing-page/src/app/pages/download/download-page.component.ts
+++ b/apps/ptah-landing-page/src/app/pages/download/download-page.component.ts
@@ -1,0 +1,466 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  OnInit,
+  signal,
+} from '@angular/core';
+import {
+  ViewportAnimationConfig,
+  ViewportAnimationDirective,
+} from '@hive-academy/angular-gsap';
+import {
+  ChevronDown,
+  ChevronUp,
+  Download,
+  ExternalLink,
+  LucideAngularModule,
+} from 'lucide-angular';
+import { NavigationComponent } from '../../components/navigation.component';
+import { FooterComponent } from '../../components/footer.component';
+import { GitHubReleaseService } from '../../services/github-release.service';
+
+@Component({
+  selector: 'ptah-download-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    NavigationComponent,
+    FooterComponent,
+    ViewportAnimationDirective,
+    LucideAngularModule,
+  ],
+  template: `
+    <div class="min-h-screen bg-base-100 text-base-content">
+      <ptah-navigation />
+
+      <!-- Hero Header -->
+      <div class="relative pt-32 pb-16 sm:pt-40 sm:pb-20 overflow-hidden">
+        <!-- Background layers -->
+        <div
+          class="absolute inset-0 opacity-40"
+          style="
+            background-image: url('/assets/backgrounds/hieroglyph-circuit-pattern.png');
+            background-repeat: repeat;
+            background-size: 400px 400px;
+          "
+          aria-hidden="true"
+        ></div>
+        <div
+          class="absolute inset-0 bg-gradient-to-b from-base-100/30 via-base-100/60 to-base-100"
+          aria-hidden="true"
+        ></div>
+
+        <div class="relative z-10 max-w-5xl mx-auto px-6 sm:px-10">
+          <h1
+            viewportAnimation
+            [viewportConfig]="headlineConfig"
+            class="text-4xl sm:text-5xl lg:text-6xl font-display font-bold leading-tight mb-4"
+          >
+            <span class="gradient-text-gold">Downloads</span>
+          </h1>
+          <p
+            viewportAnimation
+            [viewportConfig]="subheadlineConfig"
+            class="text-lg sm:text-xl text-neutral-content max-w-2xl leading-relaxed"
+          >
+            Download the Ptah Desktop app for Windows, macOS, or Linux.
+            Auto-updates keep you on the latest version.
+          </p>
+        </div>
+      </div>
+
+      <!-- Main Content -->
+      <div class="max-w-5xl mx-auto px-6 sm:px-10 pb-24">
+        @if (loading()) {
+          <!-- Loading State -->
+          <div class="flex flex-col items-center justify-center py-24 gap-4">
+            <div
+              class="w-10 h-10 border-2 border-secondary/30 border-t-secondary rounded-full animate-spin"
+            ></div>
+            <p class="text-neutral-content text-sm">Loading releases...</p>
+          </div>
+        } @else if (error()) {
+          <!-- Error State -->
+          <div
+            class="rounded-2xl border border-error/20 bg-error/5 p-8 text-center"
+          >
+            <p class="text-error mb-4">{{ error() }}</p>
+            <button
+              (click)="retry()"
+              class="btn btn-sm btn-outline border-secondary/30 text-secondary hover:bg-secondary hover:text-base-100"
+            >
+              Try Again
+            </button>
+          </div>
+        } @else {
+          <!-- Releases -->
+          @for (release of releases(); track release.tagName; let i = $index) {
+            <div
+              viewportAnimation
+              [viewportConfig]="getReleaseConfig(i)"
+              class="mb-4"
+            >
+              <!-- Version Header (clickable) -->
+              <button
+                (click)="toggleRelease(release.tagName)"
+                class="w-full group"
+                [attr.aria-expanded]="isExpanded(release.tagName)"
+              >
+                <div
+                  class="flex items-center justify-between px-6 py-5 rounded-2xl border transition-all duration-300"
+                  [class]="
+                    i === 0
+                      ? 'border-secondary/30 bg-base-200/80 hover:border-secondary/50'
+                      : 'border-secondary/10 bg-base-200/40 hover:border-secondary/30'
+                  "
+                >
+                  <div class="flex items-center gap-4">
+                    <span class="text-sm text-neutral-content font-medium"
+                      >Version</span
+                    >
+                    <span
+                      class="text-lg font-display font-bold"
+                      [class]="i === 0 ? 'text-secondary' : 'text-base-content'"
+                    >
+                      {{ release.version }}
+                    </span>
+                    @if (i === 0) {
+                      <span
+                        class="px-2.5 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wider bg-secondary/15 text-secondary border border-secondary/20"
+                      >
+                        Latest
+                      </span>
+                    }
+                    <span
+                      class="text-xs text-neutral-content/60 hidden sm:inline"
+                    >
+                      {{ formatDate(release.publishedAt) }}
+                    </span>
+                  </div>
+                  <lucide-angular
+                    [img]="
+                      isExpanded(release.tagName)
+                        ? ChevronUpIcon
+                        : ChevronDownIcon
+                    "
+                    class="w-5 h-5 text-neutral-content/50 group-hover:text-secondary transition-colors"
+                    aria-hidden="true"
+                  />
+                </div>
+              </button>
+
+              <!-- Expanded Platform Grid -->
+              @if (isExpanded(release.tagName)) {
+                <div
+                  class="mt-2 rounded-2xl border border-secondary/10 bg-base-200/30 overflow-hidden"
+                >
+                  <div
+                    class="grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x divide-secondary/10"
+                  >
+                    <!-- macOS -->
+                    <div class="p-6">
+                      <div class="flex items-center gap-2.5 mb-5">
+                        <svg
+                          class="w-5 h-5 text-neutral-content"
+                          viewBox="0 0 24 24"
+                          fill="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path
+                            d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"
+                          />
+                        </svg>
+                        <h3 class="font-display font-bold text-base-content">
+                          macOS
+                        </h3>
+                      </div>
+                      @for (asset of release.macos; track asset.fileName) {
+                        <a
+                          [href]="asset.downloadUrl"
+                          class="download-link group/dl flex items-center gap-3 px-4 py-3 -mx-2 rounded-xl hover:bg-secondary/5 transition-colors"
+                        >
+                          <lucide-angular
+                            [img]="DownloadIcon"
+                            class="w-4 h-4 text-secondary/60 group-hover/dl:text-secondary transition-colors shrink-0"
+                            aria-hidden="true"
+                          />
+                          <div class="flex-1 min-w-0">
+                            <p
+                              class="text-sm text-neutral-content group-hover/dl:text-secondary transition-colors"
+                            >
+                              {{ asset.label }}
+                            </p>
+                            <p class="text-xs text-neutral-content/40">
+                              {{ asset.size }}
+                            </p>
+                          </div>
+                        </a>
+                      } @empty {
+                        <p class="text-sm text-neutral-content/40 italic px-2">
+                          No macOS builds
+                        </p>
+                      }
+                    </div>
+
+                    <!-- Windows -->
+                    <div class="p-6">
+                      <div class="flex items-center gap-2.5 mb-5">
+                        <svg
+                          class="w-5 h-5 text-neutral-content"
+                          viewBox="0 0 24 24"
+                          fill="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path
+                            d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"
+                          />
+                        </svg>
+                        <h3 class="font-display font-bold text-base-content">
+                          Windows
+                        </h3>
+                      </div>
+                      @for (asset of release.windows; track asset.fileName) {
+                        <a
+                          [href]="asset.downloadUrl"
+                          class="download-link group/dl flex items-center gap-3 px-4 py-3 -mx-2 rounded-xl hover:bg-secondary/5 transition-colors"
+                        >
+                          <lucide-angular
+                            [img]="DownloadIcon"
+                            class="w-4 h-4 text-secondary/60 group-hover/dl:text-secondary transition-colors shrink-0"
+                            aria-hidden="true"
+                          />
+                          <div class="flex-1 min-w-0">
+                            <p
+                              class="text-sm text-neutral-content group-hover/dl:text-secondary transition-colors"
+                            >
+                              {{ asset.label }}
+                            </p>
+                            <p class="text-xs text-neutral-content/40">
+                              {{ asset.size }}
+                            </p>
+                          </div>
+                        </a>
+                      } @empty {
+                        <p class="text-sm text-neutral-content/40 italic px-2">
+                          No Windows builds
+                        </p>
+                      }
+                    </div>
+
+                    <!-- Linux -->
+                    <div class="p-6">
+                      <div class="flex items-center gap-2.5 mb-5">
+                        <svg
+                          class="w-5 h-5 text-neutral-content"
+                          viewBox="0 0 24 24"
+                          fill="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path
+                            d="M20.581 19.049c-.55-.446-.336-1.431-.907-1.917.553-3.365-.997-6.331-2.845-8.232-1.551-1.595-1.958-3.321-1.881-4.243.039-.467-.084-.986-.222-1.385-.869-.266-1.727-.312-2.712-.074-.105.378-.233.93-.198 1.459.077.922-.33 2.648-1.881 4.243-1.848 1.901-3.398 4.867-2.845 8.232-.571.486-.357 1.471-.907 1.917-1.37 1.112-.086 3.447 2.581 2.449 1.598-.597 2.21-2.18 2.258-3.256.175.015.354.024.536.024h.822c.182 0 .361-.009.536-.024.048 1.076.66 2.659 2.258 3.256 2.667.998 3.951-1.337 2.581-2.449zm-8.548-5.381c-.272 0-.492-.22-.492-.492s.22-.493.492-.493.493.221.493.493-.221.492-.493.492zm3.934 0c-.272 0-.492-.22-.492-.492s.22-.493.492-.493.493.221.493.493-.221.492-.493.492z"
+                          />
+                        </svg>
+                        <h3 class="font-display font-bold text-base-content">
+                          Linux
+                        </h3>
+                      </div>
+                      @for (asset of release.linux; track asset.fileName) {
+                        <a
+                          [href]="asset.downloadUrl"
+                          class="download-link group/dl flex items-center gap-3 px-4 py-3 -mx-2 rounded-xl hover:bg-secondary/5 transition-colors"
+                        >
+                          <lucide-angular
+                            [img]="DownloadIcon"
+                            class="w-4 h-4 text-secondary/60 group-hover/dl:text-secondary transition-colors shrink-0"
+                            aria-hidden="true"
+                          />
+                          <div class="flex-1 min-w-0">
+                            <p
+                              class="text-sm text-neutral-content group-hover/dl:text-secondary transition-colors"
+                            >
+                              {{ asset.label }}
+                            </p>
+                            <p class="text-xs text-neutral-content/40">
+                              {{ asset.size }}
+                            </p>
+                          </div>
+                        </a>
+                      } @empty {
+                        <p class="text-sm text-neutral-content/40 italic px-2">
+                          No Linux builds
+                        </p>
+                      }
+                    </div>
+                  </div>
+
+                  <!-- Release link -->
+                  <div
+                    class="px-6 py-3 border-t border-secondary/5 flex items-center justify-end"
+                  >
+                    <a
+                      [href]="release.releaseUrl"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="inline-flex items-center gap-1.5 text-xs text-neutral-content/40 hover:text-secondary transition-colors"
+                    >
+                      View release notes
+                      <lucide-angular
+                        [img]="ExternalLinkIcon"
+                        class="w-3 h-3"
+                        aria-hidden="true"
+                      />
+                    </a>
+                  </div>
+                </div>
+              }
+            </div>
+          }
+
+          <!-- VS Code Extension Callout -->
+          <div
+            viewportAnimation
+            [viewportConfig]="calloutConfig"
+            class="mt-12 rounded-2xl border border-secondary/15 bg-base-200/50 p-8 flex flex-col sm:flex-row items-center gap-6"
+          >
+            <div
+              class="w-14 h-14 rounded-2xl bg-secondary/10 border border-secondary/20 flex items-center justify-center shrink-0"
+            >
+              <svg
+                class="w-7 h-7 text-secondary"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  d="M23.15 2.587L18.21.21a1.494 1.494 0 0 0-1.705.29l-9.46 8.63-4.12-3.128a.999.999 0 0 0-1.276.057L.327 7.261A1 1 0 0 0 .326 8.74L3.899 12 .326 15.26a1 1 0 0 0 .001 1.479L1.65 17.94a.999.999 0 0 0 1.276.057l4.12-3.128 9.46 8.63a1.492 1.492 0 0 0 1.704.29l4.942-2.377A1.5 1.5 0 0 0 24 20.06V3.939a1.5 1.5 0 0 0-.85-1.352zm-5.146 14.861L10.826 12l7.178-5.448v10.896z"
+                />
+              </svg>
+            </div>
+            <div class="flex-1 text-center sm:text-left">
+              <h3 class="font-display font-bold text-base-content text-lg mb-1">
+                Looking for the VS Code Extension?
+              </h3>
+              <p class="text-neutral-content text-sm">
+                Install directly from the VS Code Marketplace for seamless IDE
+                integration with automatic updates.
+              </p>
+            </div>
+            <a
+              href="https://marketplace.visualstudio.com/items?itemName=ptah-extensions.ptah-coding-orchestra"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="btn bg-gradient-to-r from-secondary to-accent text-base-100 border-0 font-semibold shadow-lg shadow-secondary/20 hover:shadow-secondary/40 hover:scale-105 transition-all shrink-0"
+            >
+              VS Code Marketplace
+            </a>
+          </div>
+        }
+      </div>
+
+      <ptah-footer />
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        display: block;
+      }
+    `,
+  ],
+})
+export class DownloadPageComponent implements OnInit {
+  private readonly releaseService = inject(GitHubReleaseService);
+
+  readonly DownloadIcon = Download;
+  readonly ChevronDownIcon = ChevronDown;
+  readonly ChevronUpIcon = ChevronUp;
+  readonly ExternalLinkIcon = ExternalLink;
+
+  readonly releases = this.releaseService.releases;
+  readonly loading = this.releaseService.loading;
+  readonly error = this.releaseService.error;
+
+  /** Track which versions are expanded */
+  private readonly expandedSet = signal<Set<string>>(new Set());
+
+  /** Auto-expand the latest release */
+  readonly autoExpandApplied = signal(false);
+
+  // Animation configs
+  readonly headlineConfig: ViewportAnimationConfig = {
+    animation: 'slideUp',
+    duration: 0.7,
+    threshold: 0.1,
+    ease: 'power2.out',
+  };
+
+  readonly subheadlineConfig: ViewportAnimationConfig = {
+    animation: 'fadeIn',
+    duration: 0.7,
+    delay: 0.15,
+    threshold: 0.1,
+  };
+
+  readonly calloutConfig: ViewportAnimationConfig = {
+    animation: 'fadeIn',
+    duration: 0.6,
+    delay: 0.2,
+    threshold: 0.2,
+  };
+
+  ngOnInit(): void {
+    this.releaseService.fetchReleases(3);
+
+    // Auto-expand the latest release once data loads
+    const checkExpand = setInterval(() => {
+      const r = this.releases();
+      if (r.length > 0 && !this.autoExpandApplied()) {
+        this.expandedSet.update((s) => new Set(s).add(r[0].tagName));
+        this.autoExpandApplied.set(true);
+        clearInterval(checkExpand);
+      }
+      if (!this.loading()) {
+        clearInterval(checkExpand);
+      }
+    }, 100);
+  }
+
+  toggleRelease(tagName: string): void {
+    this.expandedSet.update((current) => {
+      const next = new Set(current);
+      if (next.has(tagName)) {
+        next.delete(tagName);
+      } else {
+        next.add(tagName);
+      }
+      return next;
+    });
+  }
+
+  isExpanded(tagName: string): boolean {
+    return this.expandedSet().has(tagName);
+  }
+
+  getReleaseConfig(index: number): ViewportAnimationConfig {
+    return {
+      animation: 'slideUp',
+      duration: 0.5,
+      delay: 0.1 * index,
+      threshold: 0.1,
+      ease: 'power2.out',
+    };
+  }
+
+  formatDate(isoDate: string): string {
+    return new Date(isoDate).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  retry(): void {
+    this.releaseService.fetchReleases(3);
+  }
+}

--- a/apps/ptah-landing-page/src/app/sections/hero/hero-content-overlay.component.ts
+++ b/apps/ptah-landing-page/src/app/sections/hero/hero-content-overlay.component.ts
@@ -1,4 +1,5 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import {
   ViewportAnimationDirective,
   ViewportAnimationConfig,
@@ -18,7 +19,7 @@ import {
 @Component({
   selector: 'ptah-hero-content-overlay',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ViewportAnimationDirective, ScrollAnimationDirective],
+  imports: [ViewportAnimationDirective, ScrollAnimationDirective, RouterLink],
   template: `
     <!-- Scroll-linked fade-out container for cinematic exit -->
     <div
@@ -89,9 +90,7 @@ import {
             30 DAYS TRIAL
           </span>
           <a
-            href="https://github.com/Hive-Academy/ptah-extension/releases/latest"
-            target="_blank"
-            rel="noopener"
+            routerLink="/download"
             class="cta-glow-button block relative overflow-hidden px-5 sm:px-8 py-3.5 sm:py-4 text-sm sm:text-base font-semibold text-white rounded-xl text-center"
           >
             <span class="relative z-[1]">Download Desktop App</span>

--- a/apps/ptah-landing-page/src/app/sections/open-source/open-source-section.component.ts
+++ b/apps/ptah-landing-page/src/app/sections/open-source/open-source-section.component.ts
@@ -196,9 +196,7 @@ import {
                 </li>
               </ul>
               <a
-                href="https://github.com/Hive-Academy/ptah-extension/releases/latest"
-                target="_blank"
-                rel="noopener noreferrer"
+                routerLink="/download"
                 class="inline-flex items-center gap-2 text-[#f4d47c] hover:text-[#d4af37] font-medium text-sm transition-colors group/link"
               >
                 <div

--- a/apps/ptah-landing-page/src/app/services/github-release.service.ts
+++ b/apps/ptah-landing-page/src/app/services/github-release.service.ts
@@ -1,0 +1,137 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable, signal } from '@angular/core';
+
+export interface ReleaseAsset {
+  name: string;
+  size: number;
+  browser_download_url: string;
+}
+
+export interface GitHubRelease {
+  tag_name: string;
+  name: string;
+  published_at: string;
+  html_url: string;
+  assets: ReleaseAsset[];
+}
+
+export interface PlatformAsset {
+  label: string;
+  fileName: string;
+  downloadUrl: string;
+  size: string;
+}
+
+export interface ParsedRelease {
+  version: string;
+  tagName: string;
+  name: string;
+  publishedAt: string;
+  releaseUrl: string;
+  windows: PlatformAsset[];
+  macos: PlatformAsset[];
+  linux: PlatformAsset[];
+}
+
+const GITHUB_API =
+  'https://api.github.com/repos/Hive-Academy/ptah-extension/releases';
+
+@Injectable({ providedIn: 'root' })
+export class GitHubReleaseService {
+  private readonly http = inject(HttpClient);
+
+  readonly releases = signal<ParsedRelease[]>([]);
+  readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
+
+  fetchReleases(count = 3): void {
+    this.loading.set(true);
+    this.error.set(null);
+
+    this.http
+      .get<GitHubRelease[]>(GITHUB_API, {
+        params: { per_page: count.toString() },
+      })
+      .subscribe({
+        next: (data) => {
+          this.releases.set(data.map((r) => this.parseRelease(r)));
+          this.loading.set(false);
+        },
+        error: (err) => {
+          this.error.set(
+            err.status === 403
+              ? 'GitHub API rate limit reached. Please try again later.'
+              : 'Failed to load releases. Please try again.',
+          );
+          this.loading.set(false);
+        },
+      });
+  }
+
+  private parseRelease(release: GitHubRelease): ParsedRelease {
+    const version = release.tag_name.replace('electron-v', '');
+    const installAssets = release.assets.filter(
+      (a) => !a.name.endsWith('.yml') && !a.name.endsWith('.yaml'),
+    );
+
+    return {
+      version,
+      tagName: release.tag_name,
+      name: release.name,
+      publishedAt: release.published_at,
+      releaseUrl: release.html_url,
+      windows: this.filterPlatform(installAssets, 'windows'),
+      macos: this.filterPlatform(installAssets, 'macos'),
+      linux: this.filterPlatform(installAssets, 'linux'),
+    };
+  }
+
+  private filterPlatform(
+    assets: ReleaseAsset[],
+    platform: 'windows' | 'macos' | 'linux',
+  ): PlatformAsset[] {
+    return assets
+      .filter((a) => this.matchesPlatform(a.name, platform))
+      .map((a) => ({
+        label: this.getAssetLabel(a.name, platform),
+        fileName: a.name,
+        downloadUrl: a.browser_download_url,
+        size: this.formatSize(a.size),
+      }));
+  }
+
+  private matchesPlatform(
+    name: string,
+    platform: 'windows' | 'macos' | 'linux',
+  ): boolean {
+    const lower = name.toLowerCase();
+    switch (platform) {
+      case 'windows':
+        return lower.endsWith('.exe');
+      case 'macos':
+        return lower.endsWith('.dmg') || lower.includes('-mac.zip');
+      case 'linux':
+        return lower.endsWith('.appimage') || lower.endsWith('.deb');
+    }
+  }
+
+  private getAssetLabel(
+    name: string,
+    platform: 'windows' | 'macos' | 'linux',
+  ): string {
+    const lower = name.toLowerCase();
+    if (platform === 'windows') return 'Windows Installer (.exe)';
+    if (platform === 'macos') {
+      if (lower.endsWith('.dmg')) return 'macOS Apple Silicon (.dmg)';
+      return 'macOS Apple Silicon (.zip)';
+    }
+    if (lower.endsWith('.appimage')) return 'Linux AppImage';
+    if (lower.endsWith('.deb')) return 'Debian / Ubuntu (.deb)';
+    return name;
+  }
+
+  private formatSize(bytes: number): string {
+    const mb = bytes / (1024 * 1024);
+    return mb >= 1000 ? `${(mb / 1024).toFixed(1)} GB` : `${Math.round(mb)} MB`;
+  }
+}

--- a/libs/backend/agent-sdk/src/index.ts
+++ b/libs/backend/agent-sdk/src/index.ts
@@ -58,8 +58,14 @@ export { registerSdkServices } from './lib/di/register';
 export { SDK_TOKENS } from './lib/di/tokens';
 export type { SdkDIToken } from './lib/di/tokens';
 
-// Model ID constants (single source of truth for tier → model ID mapping)
-export { TIER_TO_MODEL_ID, DEFAULT_FALLBACK_MODEL_ID } from './lib/helpers';
+// Model ID constants and tier resolution (single source of truth)
+export {
+  TIER_TO_MODEL_ID,
+  TIER_ENV_VAR_MAP,
+  DEFAULT_FALLBACK_MODEL_ID,
+  buildTierEnvDefaults,
+  resolveModelIdStatic,
+} from './lib/helpers';
 
 // Anthropic-compatible provider registry (TASK_2025_129 Batch 3)
 // Re-exported via helpers barrel (canonical source: helpers/anthropic-provider-registry.ts)

--- a/libs/backend/agent-sdk/src/lib/copilot-provider/copilot-provider-entry.ts
+++ b/libs/backend/agent-sdk/src/lib/copilot-provider/copilot-provider-entry.ts
@@ -186,11 +186,19 @@ const COPILOT_STATIC_MODELS: ProviderStaticModel[] = [
 /**
  * Default model tier mappings for GitHub Copilot.
  * Auto-applied on first login so users get the best models mapped immediately.
+ *
+ * IMPORTANT: These default to GPT models, NOT Claude. Claude models via Copilot
+ * consume 5-10x more premium requests than GPT equivalents. Since the Claude
+ * Agent SDK spawns subagents using tier aliases (sonnet/opus/haiku), every
+ * subagent would silently use Claude at inflated rates if these defaulted
+ * to Claude models — even when the user selected a GPT model for the main session.
+ *
+ * Users who prefer Claude through Copilot can manually configure tiers in the UI.
  */
 export const COPILOT_DEFAULT_TIERS = {
-  sonnet: 'claude-sonnet-4.6',
-  opus: 'claude-opus-4.6',
-  haiku: 'claude-haiku-4.5',
+  sonnet: 'gpt-5.4',
+  opus: 'gpt-5.4',
+  haiku: 'gpt-5-mini',
 } as const;
 
 export const COPILOT_PROVIDER_ENTRY: AnthropicProvider = {

--- a/libs/backend/agent-sdk/src/lib/copilot-provider/copilot-translation-proxy.ts
+++ b/libs/backend/agent-sdk/src/lib/copilot-provider/copilot-translation-proxy.ts
@@ -83,11 +83,13 @@ export class CopilotTranslationProxy extends TranslationProxyBase {
       return modelId;
     }
 
-    // Match: claude-{family}-{major}-{minor}[-{date}]
-    // e.g., 'claude-opus-4-6' → ['claude-opus-4', '6']
-    // e.g., 'claude-haiku-4-5-20251001' → ['claude-haiku-4', '5']
+    // Match: claude-{family}-{major}-{minor}[-{anything}]
+    // e.g., 'claude-opus-4-6' → 'claude-opus-4.6'
+    // e.g., 'claude-haiku-4-5-20251001' → 'claude-haiku-4.5'
+    // e.g., 'claude-sonnet-5-0-preview-20261001' → 'claude-sonnet-5.0'
+    // Strips everything after major.minor — Copilot uses short model names.
     const match = modelId.match(
-      /^(claude-(?:opus|sonnet|haiku)-\d+)-(\d+)(?:-\d+)?$/,
+      /^(claude-(?:opus|sonnet|haiku)-\d+)-(\d+)(?:-.+)?$/,
     );
     if (match) {
       return `${match[1]}.${match[2]}`;

--- a/libs/backend/agent-sdk/src/lib/helpers/anthropic-provider-registry.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/anthropic-provider-registry.ts
@@ -22,6 +22,7 @@ import {
   type ModelPricing,
   type AuthEnv,
 } from '@ptah-extension/shared';
+import { TIER_ENV_VAR_MAP } from './sdk-model-service';
 import { COPILOT_PROVIDER_ENTRY } from '../copilot-provider';
 import { CODEX_PROVIDER_ENTRY } from '../codex-provider';
 import {
@@ -448,23 +449,16 @@ export function resolveActualModelForPricing(
   }
 
   // Third-party provider detected — check if modelId looks like an Anthropic model
+  // and resolve to the actual provider model via tier env var overrides.
+  // Uses TIER_ENV_VAR_MAP (canonical source) instead of fragile substring matching.
   const lower = modelId.toLowerCase();
 
-  if (lower.includes('opus')) {
-    const override =
-      authEnv?.ANTHROPIC_DEFAULT_OPUS_MODEL ??
-      process.env['ANTHROPIC_DEFAULT_OPUS_MODEL'];
-    if (override) return override;
-  } else if (lower.includes('sonnet')) {
-    const override =
-      authEnv?.ANTHROPIC_DEFAULT_SONNET_MODEL ??
-      process.env['ANTHROPIC_DEFAULT_SONNET_MODEL'];
-    if (override) return override;
-  } else if (lower.includes('haiku')) {
-    const override =
-      authEnv?.ANTHROPIC_DEFAULT_HAIKU_MODEL ??
-      process.env['ANTHROPIC_DEFAULT_HAIKU_MODEL'];
-    if (override) return override;
+  for (const [tier, envKey] of Object.entries(TIER_ENV_VAR_MAP)) {
+    if (lower.includes(tier)) {
+      const override = authEnv?.[envKey] ?? process.env[envKey];
+      if (override) return override;
+      break; // Only match the first tier — 'opus', 'sonnet', 'haiku' are mutually exclusive
+    }
   }
 
   // Not an Anthropic model alias, or no tier override set — return as-is

--- a/libs/backend/agent-sdk/src/lib/helpers/build-safe-env.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/build-safe-env.ts
@@ -13,6 +13,7 @@
  * @returns Minimal env safe for custom agent processes
  */
 import type { AuthEnv } from '@ptah-extension/shared';
+import { buildTierEnvDefaults } from './sdk-model-service';
 
 export function buildSafeEnv(
   authEnv: AuthEnv,
@@ -59,7 +60,10 @@ export function buildSafeEnv(
     // Terminal
     TERM: process.env['TERM'],
     SHELL: process.env['SHELL'],
+    // Guarantee tier env vars so subprocesses can resolve bare tier names
+    ...buildTierEnvDefaults(authEnv),
     // Provider-specific auth and config (e.g., ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL)
+    // Spread AFTER tier defaults so explicit authEnv overrides take precedence
     ...authEnv,
     // Disable experimental betas for any non-Anthropic base URL — prevents the SDK
     // from enabling context-management-2025-06-27 which third-party endpoints don't support

--- a/libs/backend/agent-sdk/src/lib/helpers/index.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/index.ts
@@ -65,7 +65,12 @@ export { SdkModuleLoader } from './sdk-module-loader';
 export {
   SdkModelService,
   TIER_TO_MODEL_ID,
+  TIER_ENV_VAR_MAP,
   DEFAULT_FALLBACK_MODEL_ID,
+  buildTierEnvDefaults,
+  resolveModelIdStatic,
+  type ModelTier,
+  type EnvMappedTier,
   type ApiModelEntry,
 } from './sdk-model-service';
 // Slash command interceptor (TASK_2025_184)

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-model-service.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-model-service.ts
@@ -32,6 +32,12 @@ export interface ApiModelEntry {
   createdAt: string;
 }
 
+/** Valid tier names for model resolution */
+export type ModelTier = 'opus' | 'sonnet' | 'haiku' | 'default';
+
+/** Tier names that have corresponding ANTHROPIC_DEFAULT_*_MODEL env vars */
+export type EnvMappedTier = Exclude<ModelTier, 'default'>;
+
 /**
  * Canonical mapping from bare tier names to full model IDs.
  * Exported as the single source of truth — all consumers must import this
@@ -44,7 +50,7 @@ export interface ApiModelEntry {
  *
  * MAINTENANCE: Update these when new Claude model versions are released.
  */
-export const TIER_TO_MODEL_ID: Record<string, string> = {
+export const TIER_TO_MODEL_ID: Record<ModelTier, string> = {
   opus: 'claude-opus-4-6',
   sonnet: 'claude-sonnet-4-6',
   haiku: 'claude-haiku-4-5-20251001',
@@ -52,17 +58,90 @@ export const TIER_TO_MODEL_ID: Record<string, string> = {
 };
 
 /** Default fallback model ID — Sonnet as the best cost/capability balance */
-export const DEFAULT_FALLBACK_MODEL_ID = 'claude-sonnet-4-6';
+export const DEFAULT_FALLBACK_MODEL_ID = TIER_TO_MODEL_ID['default'];
+
+/** Type guard: check if a string is a valid ModelTier key */
+function isModelTier(value: string): value is ModelTier {
+  return value in TIER_TO_MODEL_ID;
+}
+
+/** Type guard: check if a string is an EnvMappedTier key */
+function isEnvMappedTier(value: string): value is EnvMappedTier {
+  return value in TIER_ENV_VAR_MAP;
+}
 
 /**
- * Known tier names that have corresponding ANTHROPIC_DEFAULT_*_MODEL env vars.
- * Used to safely construct env var keys without unsound `as keyof AuthEnv` casts.
+ * Canonical mapping from tier names to their ANTHROPIC_DEFAULT_*_MODEL env var keys.
+ * Single source of truth — all consumers must import this rather than defining their own.
+ *
+ * Used by:
+ * - SdkModelService.resolveModelId() — to check env var overrides
+ * - ProviderModelsService.setModelTier() — to set env vars for proxy providers
+ * - buildTierEnvDefaults() — to guarantee env vars for SDK subagent spawning
+ * - clearAllTierEnvVars() / applyPersistedTiers() — to manage tier env lifecycle
  */
-const TIER_ENV_VAR_MAP: Record<string, keyof AuthEnv> = {
+export const TIER_ENV_VAR_MAP: Record<EnvMappedTier, keyof AuthEnv> = {
   opus: 'ANTHROPIC_DEFAULT_OPUS_MODEL',
   sonnet: 'ANTHROPIC_DEFAULT_SONNET_MODEL',
   haiku: 'ANTHROPIC_DEFAULT_HAIKU_MODEL',
 };
+
+/**
+ * Build tier env var defaults for SDK subprocess environments.
+ *
+ * The Claude Agent SDK resolves bare tier names ('haiku', 'sonnet', 'opus') in
+ * subagent subprocesses by reading ANTHROPIC_DEFAULT_*_MODEL env vars. When using
+ * direct Anthropic auth (API key / OAuth), these vars are never set because
+ * ProviderModelsService.setModelTier() is only called for third-party providers.
+ *
+ * This function returns a Record that guarantees all three tier env vars are
+ * present — using existing authEnv values when set (proxy provider), falling
+ * back to TIER_TO_MODEL_ID defaults (direct Anthropic).
+ *
+ * @param authEnv - Current AuthEnv (may have overrides from proxy provider)
+ * @returns Record with guaranteed ANTHROPIC_DEFAULT_*_MODEL values
+ */
+export function buildTierEnvDefaults(authEnv: AuthEnv): Record<string, string> {
+  const defaults: Record<string, string> = {};
+  for (const [tier, envKey] of Object.entries(TIER_ENV_VAR_MAP)) {
+    defaults[envKey] =
+      authEnv[envKey] || TIER_TO_MODEL_ID[tier as EnvMappedTier];
+  }
+  return defaults;
+}
+
+/**
+ * Resolve a model identifier to a full model ID (static version).
+ *
+ * Standalone function for contexts where SdkModelService is not injectable
+ * (e.g., RPC handlers). Uses the same resolution priority as the instance
+ * method:
+ *
+ * 1. Already a full ID (starts with 'claude-') → return as-is
+ * 2. Env var override (if authEnv provided) → use provider-specific mapping
+ * 3. Known tier in TIER_TO_MODEL_ID → return default mapping
+ * 4. Unknown → return as-is
+ *
+ * @param model - Model string (could be full ID or bare tier name)
+ * @param authEnv - Optional AuthEnv for env var override checks (proxy providers)
+ */
+export function resolveModelIdStatic(model: string, authEnv?: AuthEnv): string {
+  if (model.startsWith('claude-')) {
+    return model;
+  }
+  const tierLower = model.toLowerCase();
+
+  // Check env var overrides (set by ProviderModelsService for proxy providers)
+  if (authEnv && isEnvMappedTier(tierLower)) {
+    const envKey = TIER_ENV_VAR_MAP[tierLower];
+    const override = authEnv[envKey];
+    if (override) {
+      return override;
+    }
+  }
+
+  return isModelTier(tierLower) ? TIER_TO_MODEL_ID[tierLower] : model;
+}
 
 /**
  * Fallback models using full model IDs.
@@ -549,8 +628,8 @@ export class SdkModelService {
     // Check env var overrides first (set by ProviderModelsService.setModelTier).
     // Only check known tiers that have corresponding env vars — avoids
     // constructing invalid env key names from arbitrary input.
-    const envVarKey = TIER_ENV_VAR_MAP[tierLower];
-    if (envVarKey) {
+    if (isEnvMappedTier(tierLower)) {
+      const envVarKey = TIER_ENV_VAR_MAP[tierLower];
       const envOverride = this.authEnv[envVarKey];
       if (envOverride) {
         this.logger.debug(
@@ -561,8 +640,8 @@ export class SdkModelService {
     }
 
     // Fall back to known tier-to-model-ID mapping
-    const knownId = TIER_TO_MODEL_ID[tierLower];
-    if (knownId) {
+    if (isModelTier(tierLower)) {
+      const knownId = TIER_TO_MODEL_ID[tierLower];
       this.logger.debug(
         `[SdkModelService] Resolved bare tier name '${model}' to '${knownId}'`,
       );

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.ts
@@ -48,7 +48,7 @@ import {
   getAnthropicProvider,
   ANTHROPIC_PROVIDERS,
 } from './anthropic-provider-registry';
-import { SdkModelService } from './sdk-model-service';
+import { SdkModelService, buildTierEnvDefaults } from './sdk-model-service';
 import { COPILOT_PROXY_TOKEN_PLACEHOLDER } from '../copilot-provider/copilot-provider.types';
 import { CODEX_PROXY_TOKEN_PLACEHOLDER } from '../codex-provider/codex-provider.types';
 import { PTAH_CORE_SYSTEM_PROMPT } from '../prompt-harness';
@@ -462,13 +462,31 @@ export class SdkQueryOptionsBuilder {
     }
 
     // Log resolved model and tier env vars for debugging (TASK_2025_132, TASK_2025_164: reads from AuthEnv)
+    const envSonnet = this.authEnv.ANTHROPIC_DEFAULT_SONNET_MODEL || 'default';
+    const envOpus = this.authEnv.ANTHROPIC_DEFAULT_OPUS_MODEL || 'default';
+    const envHaiku = this.authEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL || 'default';
     this.logger.info(`[SdkQueryOptionsBuilder] SDK call with model: ${model}`, {
       model,
-      envSonnet: this.authEnv.ANTHROPIC_DEFAULT_SONNET_MODEL || 'default',
-      envOpus: this.authEnv.ANTHROPIC_DEFAULT_OPUS_MODEL || 'default',
-      envHaiku: this.authEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL || 'default',
+      envSonnet,
+      envOpus,
+      envHaiku,
       baseUrl: this.authEnv.ANTHROPIC_BASE_URL || 'default',
     });
+
+    // Warn when main model is non-Claude but tier env vars still point to Claude.
+    // This means subagents will silently use Claude models at higher premium rates.
+    if (!model.startsWith('claude-')) {
+      const claudeTiers = [envSonnet, envOpus, envHaiku].filter(
+        (t) => t !== 'default' && t.startsWith('claude-'),
+      );
+      if (claudeTiers.length > 0) {
+        this.logger.warn(
+          `[SdkQueryOptionsBuilder] Model mismatch: main model is '${model}' but ${claudeTiers.length} tier(s) still point to Claude models (${claudeTiers.join(', ')}). ` +
+            'Subagents spawned by the SDK will use these Claude models, potentially consuming premium requests at a higher rate. ' +
+            'Update tier mappings in the model selector to match your preferred provider.',
+        );
+      }
+    }
 
     // Build system prompt configuration
     const systemPrompt = this.buildSystemPrompt(
@@ -549,6 +567,10 @@ export class SdkQueryOptionsBuilder {
           ? ['project', 'local']
           : ['user', 'project', 'local'],
         // Merge AuthEnv with process.env — AuthEnv values override process.env (TASK_2025_164)
+        // Guarantee tier env vars (ANTHROPIC_DEFAULT_*_MODEL) are always present so the
+        // SDK can resolve bare tier names ('haiku', 'sonnet', 'opus') in subagent
+        // subprocesses. Without these, direct Anthropic users get "model not found" errors
+        // when subagents specify a tier name instead of a full model ID.
         // Set NO_PROXY to prevent corporate proxy interception of localhost requests
         // Disable experimental betas for any non-Anthropic base URL — the SDK
         // enables context-management-2025-06-27 for "firstParty" providers, which
@@ -557,6 +579,7 @@ export class SdkQueryOptionsBuilder {
         // relying on provider registry detection, which misses unknown providers.
         env: {
           ...process.env,
+          ...buildTierEnvDefaults(this.authEnv),
           ...this.authEnv,
           NO_PROXY: '127.0.0.1,localhost',
           ...(() => {
@@ -756,7 +779,16 @@ export class SdkQueryOptionsBuilder {
   }
 
   /**
-   * Calculate max turns from session config
+   * Calculate max turns from session config.
+   *
+   * Safety limit: returns a default cap when no explicit maxTokens is set.
+   * Without this, the SDK runs unlimited agentic turns — each turn is an
+   * API round-trip that consumes provider quota. On metered providers like
+   * Copilot (premium requests) or pay-per-token APIs, runaway sessions can
+   * exhaust budgets quickly.
+   *
+   * Default: 200 turns — generous enough for complex multi-step tasks,
+   * but prevents infinite loops from burning through quota.
    */
   private calculateMaxTurns(
     sessionConfig?: AISessionConfig,
@@ -764,7 +796,8 @@ export class SdkQueryOptionsBuilder {
     if (sessionConfig?.maxTokens) {
       return Math.floor(sessionConfig.maxTokens / 1000);
     }
-    return undefined;
+    // Safety cap: prevent unlimited agentic turns on metered providers
+    return 200;
   }
 
   /**

--- a/libs/backend/agent-sdk/src/lib/internal-query/internal-query.service.ts
+++ b/libs/backend/agent-sdk/src/lib/internal-query/internal-query.service.ts
@@ -41,7 +41,10 @@ import { Logger, TOKENS } from '@ptah-extension/vscode-core';
 import type { AuthEnv } from '@ptah-extension/shared';
 import { SDK_TOKENS } from '../di/tokens';
 import { SdkModuleLoader } from '../helpers/sdk-module-loader';
-import { SdkModelService } from '../helpers/sdk-model-service';
+import {
+  SdkModelService,
+  buildTierEnvDefaults,
+} from '../helpers/sdk-model-service';
 import { SdkAgentAdapter } from '../sdk-agent-adapter';
 import { SubagentHookHandler } from '../helpers/subagent-hook-handler';
 import { CompactionConfigProvider } from '../helpers/compaction-config-provider';
@@ -307,11 +310,23 @@ export class InternalQueryService {
       pathToClaudeCodeExecutable: cliJsPath || undefined,
 
       // Merge AuthEnv with process.env — AuthEnv values override process.env (TASK_2025_164)
+      // Guarantee tier env vars so SDK subagents can resolve bare tier names
       // Set NO_PROXY to prevent corporate proxy interception of localhost requests
+      // Disable experimental betas for non-Anthropic base URLs (parity with
+      // SdkQueryOptionsBuilder and buildSafeEnv — third-party endpoints don't
+      // support context-management-2025-06-27, causing 400 errors)
       env: {
         ...process.env,
+        ...buildTierEnvDefaults(this.authEnv),
         ...this.authEnv,
         NO_PROXY: '127.0.0.1,localhost',
+        ...(() => {
+          const baseUrl = this.authEnv.ANTHROPIC_BASE_URL?.trim();
+          return baseUrl &&
+            !/^https?:\/\/api\.anthropic\.com\/?$/i.test(baseUrl)
+            ? { CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: '1' }
+            : {};
+        })(),
       } as Record<string, string | undefined>,
 
       // Load settings from project and local directories.

--- a/libs/backend/agent-sdk/src/lib/openai-translation/translation-proxy-base.ts
+++ b/libs/backend/agent-sdk/src/lib/openai-translation/translation-proxy-base.ts
@@ -599,6 +599,13 @@ export abstract class TranslationProxyBase implements ITranslationProxy {
           }
 
           // Handle 429 -- rate limit
+          // IMPORTANT: Return 429 rate_limit_error (NOT 529 overloaded_error).
+          // The Claude Agent SDK retries 529 aggressively with backoff, which
+          // creates a retry amplification loop: each retry sends a new request
+          // to the upstream API, consuming another premium request, which gets
+          // rate-limited again → another 529 → another retry. This burns through
+          // Copilot premium requests until max_retries is exhausted.
+          // Returning 429 with retry-after lets the SDK handle rate limits properly.
           if (statusCode === 429) {
             const retryAfter = proxyRes.headers['retry-after'];
             const retryMsg = retryAfter
@@ -608,11 +615,19 @@ export abstract class TranslationProxyBase implements ITranslationProxy {
               `${this.logPrefix} [${requestId}] Rate limited by ${this.config.name} ${apiLabel}${retryMsg}`,
             );
             proxyRes.resume();
+
+            // Pass through retry-after header so the SDK can respect it
+            const headers: Record<string, string> = {};
+            if (retryAfter) {
+              headers['retry-after'] = retryAfter;
+            }
+
             this.sendErrorResponse(
               res,
-              529,
-              'overloaded_error',
+              429,
+              'rate_limit_error',
               `${this.config.name} API rate limit exceeded.${retryMsg} Please wait and try again.`,
+              headers,
             );
             resolve();
             return;
@@ -1062,37 +1077,45 @@ export abstract class TranslationProxyBase implements ITranslationProxy {
   }
 
   /**
-   * Send a JSON response.
+   * Send a JSON response with optional extra headers.
    */
   private sendJson(
     res: http.ServerResponse,
     statusCode: number,
     body: Record<string, unknown>,
+    extraHeaders?: Record<string, string>,
   ): void {
     const json = JSON.stringify(body);
     res.writeHead(statusCode, {
       'Content-Type': 'application/json',
       'Content-Length': Buffer.byteLength(json).toString(),
+      ...extraHeaders,
     });
     res.end(json);
   }
 
   /**
-   * Send an Anthropic-format error response.
+   * Send an Anthropic-format error response with optional extra headers.
    */
   private sendErrorResponse(
     res: http.ServerResponse,
     statusCode: number,
     errorType: string,
     message: string,
+    extraHeaders?: Record<string, string>,
   ): void {
-    this.sendJson(res, statusCode, {
-      type: 'error',
-      error: {
-        type: errorType,
-        message,
+    this.sendJson(
+      res,
+      statusCode,
+      {
+        type: 'error',
+        error: {
+          type: errorType,
+          message,
+        },
       },
-    });
+      extraHeaders,
+    );
   }
 
   /**

--- a/libs/backend/agent-sdk/src/lib/provider-models.service.ts
+++ b/libs/backend/agent-sdk/src/lib/provider-models.service.ts
@@ -29,6 +29,7 @@ import {
   getAnthropicProvider,
   type AnthropicProvider,
 } from './helpers/anthropic-provider-registry';
+import { TIER_ENV_VAR_MAP } from './helpers/sdk-model-service';
 import { SDK_TOKENS } from './di/tokens';
 
 /**
@@ -57,13 +58,6 @@ interface ModelsApiModel {
 interface ModelsApiResponse {
   data: ModelsApiModel[];
 }
-
-/** Environment variable names for tier overrides */
-const TIER_ENV_VARS = {
-  sonnet: 'ANTHROPIC_DEFAULT_SONNET_MODEL',
-  opus: 'ANTHROPIC_DEFAULT_OPUS_MODEL',
-  haiku: 'ANTHROPIC_DEFAULT_HAIKU_MODEL',
-} as const;
 
 /** Per-provider cache entry */
 interface ProviderCache {
@@ -410,7 +404,7 @@ export class ProviderModelsService {
     tier: ProviderModelTier,
     modelId: string,
   ): Promise<void> {
-    const envVar = TIER_ENV_VARS[tier];
+    const envVar = TIER_ENV_VAR_MAP[tier];
     const configKey = this.getTierConfigKey(providerId, tier);
 
     // Set AuthEnv variable for immediate use
@@ -456,7 +450,7 @@ export class ProviderModelsService {
     providerId: string,
     tier: ProviderModelTier,
   ): Promise<void> {
-    const envVar = TIER_ENV_VARS[tier];
+    const envVar = TIER_ENV_VAR_MAP[tier];
     const configKey = this.getTierConfigKey(providerId, tier);
 
     // Clear AuthEnv variable
@@ -478,17 +472,14 @@ export class ProviderModelsService {
   applyPersistedTiers(providerId: string): void {
     const tiers = this.getModelTiers(providerId);
 
-    if (tiers.sonnet) {
-      this.authEnv.ANTHROPIC_DEFAULT_SONNET_MODEL = tiers.sonnet;
-      process.env['ANTHROPIC_DEFAULT_SONNET_MODEL'] = tiers.sonnet;
-    }
-    if (tiers.opus) {
-      this.authEnv.ANTHROPIC_DEFAULT_OPUS_MODEL = tiers.opus;
-      process.env['ANTHROPIC_DEFAULT_OPUS_MODEL'] = tiers.opus;
-    }
-    if (tiers.haiku) {
-      this.authEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL = tiers.haiku;
-      process.env['ANTHROPIC_DEFAULT_HAIKU_MODEL'] = tiers.haiku;
+    // Iterate the canonical TIER_ENV_VAR_MAP to ensure all tiers are covered
+    // if new tiers are added in the future
+    for (const [tier, envKey] of Object.entries(TIER_ENV_VAR_MAP)) {
+      const value = tiers[tier as keyof typeof tiers];
+      if (value) {
+        this.authEnv[envKey as keyof AuthEnv] = value;
+        process.env[envKey] = value;
+      }
     }
 
     this.logger.debug(
@@ -502,12 +493,11 @@ export class ProviderModelsService {
    * Call this when switching providers or switching to OAuth/API key auth
    */
   clearAllTierEnvVars(): void {
-    delete this.authEnv.ANTHROPIC_DEFAULT_SONNET_MODEL;
-    delete this.authEnv.ANTHROPIC_DEFAULT_OPUS_MODEL;
-    delete this.authEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL;
-    delete process.env['ANTHROPIC_DEFAULT_SONNET_MODEL'];
-    delete process.env['ANTHROPIC_DEFAULT_OPUS_MODEL'];
-    delete process.env['ANTHROPIC_DEFAULT_HAIKU_MODEL'];
+    // Iterate the canonical TIER_ENV_VAR_MAP to ensure all tiers are covered
+    for (const envKey of Object.values(TIER_ENV_VAR_MAP)) {
+      delete this.authEnv[envKey as keyof AuthEnv];
+      delete process.env[envKey];
+    }
 
     this.logger.debug(
       '[ProviderModelsService] Cleared all tier environment variables',

--- a/libs/backend/rpc-handlers/src/lib/handlers/config-rpc.handlers.ts
+++ b/libs/backend/rpc-handlers/src/lib/handlers/config-rpc.handlers.ts
@@ -23,6 +23,7 @@ import {
   DEFAULT_PROVIDER_ID,
   ANTHROPIC_DIRECT_PROVIDER_ID,
   TIER_TO_MODEL_ID,
+  resolveModelIdStatic,
 } from '@ptah-extension/agent-sdk';
 import {
   PermissionLevel,
@@ -37,6 +38,7 @@ import {
   ConfigEffortSetResult,
   ConfigEffortGetResult,
   getModelPricingDescription,
+  type AuthEnv,
   type EffortLevel,
 } from '@ptah-extension/shared';
 
@@ -56,6 +58,8 @@ export class ConfigRpcHandlers {
     private readonly providerModels: ProviderModelsService,
     @inject(SDK_TOKENS.SDK_PERMISSION_HANDLER)
     private readonly permissionHandler: SdkPermissionHandler,
+    @inject(SDK_TOKENS.SDK_AUTH_ENV)
+    private readonly authEnv: AuthEnv,
   ) {}
 
   /**
@@ -158,9 +162,9 @@ export class ConfigRpcHandlers {
         try {
           this.logger.debug('RPC: config:model-get called');
 
-          const raw = this.configManager.get<string>('model.selected') || '';
-          const model =
-            raw === 'default' || raw === '' ? TIER_TO_MODEL_ID['sonnet'] : raw;
+          const raw =
+            this.configManager.get<string>('model.selected') || 'default';
+          const model = resolveModelIdStatic(raw, this.authEnv);
 
           return { model };
         } catch (error) {
@@ -316,15 +320,11 @@ export class ConfigRpcHandlers {
         try {
           this.logger.debug('RPC: config:models-list called');
 
-          // Get saved model preference. Resolve legacy 'default' to
-          // the canonical sonnet model ID so selection matching works
-          // now that we no longer include a 'default' entry.
+          // Get saved model preference. Resolve bare tier names and 'default'
+          // to full model IDs via the canonical resolver.
           const rawSaved =
-            this.configManager.get<string>('model.selected') || '';
-          const savedModel =
-            rawSaved === 'default' || rawSaved === ''
-              ? TIER_TO_MODEL_ID['sonnet']
-              : rawSaved;
+            this.configManager.get<string>('model.selected') || 'default';
+          const savedModel = resolveModelIdStatic(rawSaved, this.authEnv);
 
           // Fetch SDK tier models (always available, 3 slots)
           const sdkModels = await this.sdkAdapter.getSupportedModels();
@@ -372,16 +372,23 @@ export class ConfigRpcHandlers {
           }
 
           // --- Phase 1: Build SDK tier models (recommended shortcuts) ---
-          // Filter out the SDK's 'default' model — it always resolves to
-          // the same ID as one of the tier models (usually sonnet), creating
-          // a confusing duplicate entry in the dropdown. The tier models
-          // themselves are the authoritative entries.
-          const filteredSdkModels = sdkModels.filter(
-            (m) => m.value.toLowerCase() !== 'default',
-          );
-
+          // The SDK may return 'default' as a model value (which maps to sonnet).
+          // Instead of filtering it out (which loses sonnet entirely when the SDK
+          // doesn't return a separate 'sonnet' entry), resolve it to the actual
+          // tier model ID. De-duplicate by resolved ID to avoid duplicate entries.
           const sdkModelIds = new Set<string>();
-          const models = filteredSdkModels.map((m) => {
+          const models: Array<{
+            id: string;
+            name: string;
+            description: string;
+            apiName: string;
+            isSelected: boolean;
+            isRecommended: boolean;
+            providerModelId: string | null;
+            tier: 'opus' | 'sonnet' | 'haiku' | undefined;
+          }> = [];
+
+          for (const m of sdkModels) {
             const valueLower = m.value.toLowerCase();
             const displayLower = (m.displayName || '').toLowerCase();
             const descLower = (m.description || '').toLowerCase();
@@ -392,15 +399,23 @@ export class ConfigRpcHandlers {
               descLower,
             );
 
-            // Resolve bare tier names to full model IDs.
-            // Uses the canonical TIER_TO_MODEL_ID mapping from sdk-model-service
-            // (single source of truth for tier → model ID mapping).
-            let resolvedValue = m.value;
-            if (TIER_TO_MODEL_ID[valueLower]) {
-              resolvedValue = TIER_TO_MODEL_ID[valueLower];
+            // Resolve bare tier names AND 'default' to full model IDs via the
+            // canonical resolver (single source of truth in sdk-model-service).
+            const resolvedValue = resolveModelIdStatic(m.value, this.authEnv);
+            if (resolvedValue !== m.value) {
               this.logger.info(
-                `Resolved bare tier name '${m.value}' to '${resolvedValue}'`,
+                `Resolved SDK model '${m.value}' to '${resolvedValue}'`,
+                { displayName: m.displayName },
               );
+            }
+
+            // De-duplicate by resolved ID — 'default' and an explicit tier
+            // may resolve to the same model ID
+            if (sdkModelIds.has(resolvedValue)) {
+              this.logger.debug(
+                `Skipping duplicate SDK model '${m.value}' (resolved to '${resolvedValue}')`,
+              );
+              continue;
             }
 
             sdkModelIds.add(resolvedValue);
@@ -415,7 +430,9 @@ export class ConfigRpcHandlers {
               ? getModelPricingDescription(providerModelId)
               : m.description;
 
-            return {
+            // Also check resolved value for sonnet (e.g. 'default' resolved to sonnet tier)
+            const resolvedLower = resolvedValue.toLowerCase();
+            models.push({
               id: resolvedValue,
               name: m.displayName,
               description,
@@ -423,11 +440,12 @@ export class ConfigRpcHandlers {
               isSelected: resolvedValue === savedModel,
               isRecommended:
                 valueLower.includes('sonnet') ||
-                displayLower.includes('sonnet'),
+                displayLower.includes('sonnet') ||
+                resolvedLower.includes('sonnet'),
               providerModelId,
               tier,
-            };
-          });
+            });
+          }
 
           // --- Phase 2: Add API models not already covered by SDK tiers ---
           for (const apiModel of apiModels) {

--- a/libs/frontend/chat/src/lib/components/atoms/file-path-link.component.ts
+++ b/libs/frontend/chat/src/lib/components/atoms/file-path-link.component.ts
@@ -1,23 +1,26 @@
 import {
   Component,
+  Injector,
   input,
   inject,
   output,
   ChangeDetectionStrategy,
 } from '@angular/core';
 import { LucideAngularModule, ExternalLink } from 'lucide-angular';
-import { ClaudeRpcService } from '@ptah-extension/core';
+import { ClaudeRpcService, VSCodeService } from '@ptah-extension/core';
 
 /**
- * FilePathLinkComponent - Clickable file path that opens file in VS Code editor
+ * FilePathLinkComponent - Clickable file path that opens file in editor
  *
  * Complexity Level: 1 (Simple atom)
- * Patterns: RPC integration, path shortening
+ * Patterns: RPC integration, path shortening, platform-aware routing
  *
  * Features:
  * - Shorten paths > 2 segments to ".../last/two"
  * - Show full path on hover (title attribute)
- * - Open file in VS Code on click via ClaudeRpcService
+ * - Platform-aware file opening:
+ *   - VS Code: opens via file:open RPC → vscode.window.showTextDocument()
+ *   - Electron: opens in Monaco editor tab via EditorService (dynamic import)
  * - Emit click event for parent to handle event propagation
  */
 @Component({
@@ -42,6 +45,8 @@ import { ClaudeRpcService } from '@ptah-extension/core';
 })
 export class FilePathLinkComponent {
   private readonly rpcService = inject(ClaudeRpcService);
+  private readonly vscodeService = inject(VSCodeService);
+  private readonly injector = inject(Injector);
 
   readonly fullPath = input.required<string>();
   readonly clicked = output<Event>(); // For parent to handle stopPropagation
@@ -50,7 +55,6 @@ export class FilePathLinkComponent {
 
   /**
    * Shorten file path for display
-   * Extracted from tool-call-item.component.ts:654-660
    * Shows just the filename or last 2 path segments
    */
   protected getShortPath(): string {
@@ -63,16 +67,36 @@ export class FilePathLinkComponent {
   }
 
   /**
-   * Open file in VS Code editor
-   * Extracted from tool-call-item.component.ts:351-358
-   * Uses RPC to open file in VS Code
+   * Open file in the editor (platform-aware).
+   * VS Code: sends file:open RPC which opens the file natively.
+   * Electron: dynamically imports EditorService to open in Monaco editor tab.
    */
   protected openFile(event: Event): void {
     this.clicked.emit(event); // Let parent handle stopPropagation
     const filePath = this.fullPath();
-    if (filePath) {
-      // Use RPC to open file in VS Code
-      this.rpcService.call('file:open', { path: filePath });
+    if (!filePath) return;
+
+    if (this.vscodeService.isElectron) {
+      void this.openFileInElectron(filePath);
+    } else {
+      void this.rpcService.openFile(filePath);
+    }
+  }
+
+  /**
+   * Open file in Electron's Monaco editor via dynamically-imported EditorService.
+   * Uses the same dynamic-import pattern as WorkspaceCoordinatorService.
+   */
+  private async openFileInElectron(filePath: string): Promise<void> {
+    try {
+      const editorModule = await import('@ptah-extension/editor');
+      const editorService = this.injector.get(editorModule.EditorService);
+      await editorService.openFile(filePath);
+    } catch (error) {
+      console.error(
+        '[FilePathLink] Electron openFile failed:',
+        error instanceof Error ? error.message : String(error),
+      );
     }
   }
 }

--- a/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.ts
+++ b/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.ts
@@ -109,7 +109,7 @@ interface PastedImage {
       (drop)="handleDrop($event)"
     >
       <!-- Compaction overlay on input area -->
-      @if (chatStore.isCompacting()) {
+      @if (resolvedIsCompacting()) {
         <div
           class="absolute inset-0 z-10 flex items-center justify-center bg-base-100/60 backdrop-blur-[1px] rounded-lg"
         >
@@ -338,6 +338,23 @@ export class ChatInputComponent implements OnInit {
     return tabId ? this.tabManager.isTabStreaming(tabId) : false;
   });
 
+  /**
+   * Per-tab compaction state. In canvas mode, scoped to this tile's tab.
+   * Prevents compaction overlay from showing on ALL tiles.
+   */
+  readonly resolvedIsCompacting = computed(() => {
+    const ctx = this._sessionContext;
+    if (ctx) {
+      const tabId = ctx();
+      if (!tabId) return false;
+      return (
+        this.tabManager.tabs().find((t) => t.id === tabId)?.isCompacting ??
+        false
+      );
+    }
+    return this.chatStore.isCompacting();
+  });
+
   // Signal-based viewChild references (Angular 20+ pattern)
   private readonly textareaRef =
     viewChild<ElementRef<HTMLTextAreaElement>>('inputElement');
@@ -418,8 +435,17 @@ export class ChatInputComponent implements OnInit {
     this.fetchAuthMethodLabel();
   }
 
-  // Check if there's queued content waiting to be sent
+  // Check if there's queued content waiting to be sent (session-context-aware)
   readonly hasQueuedContent = computed(() => {
+    const ctx = this._sessionContext;
+    if (ctx) {
+      // Canvas tile: read from this tile's specific tab
+      const tabId = ctx();
+      if (!tabId) return false;
+      const tab = this.tabManager.tabs().find((t) => t.id === tabId);
+      return !!tab?.queuedContent?.trim();
+    }
+    // Single mode: read from active tab
     const queued = this.tabManager.activeTabQueuedContent();
     return !!queued?.trim();
   });

--- a/libs/frontend/chat/src/lib/components/templates/chat-view.component.css
+++ b/libs/frontend/chat/src/lib/components/templates/chat-view.component.css
@@ -36,3 +36,20 @@
     oklch(var(--s) / 0.5)
   );
 }
+
+/* Collapsible input area animation */
+.input-collapse-wrapper {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows 200ms ease-out;
+  overflow: hidden;
+}
+
+.input-collapse-wrapper.input-collapsed {
+  grid-template-rows: 0fr;
+}
+
+.input-collapse-wrapper > :first-child {
+  min-height: 0;
+  overflow: hidden;
+}

--- a/libs/frontend/chat/src/lib/components/templates/chat-view.component.html
+++ b/libs/frontend/chat/src/lib/components/templates/chat-view.component.html
@@ -18,7 +18,7 @@
 
     <!-- TASK_2025_098: Compaction Notification Banner -->
     <div class="px-4">
-      <ptah-compaction-notification [isCompacting]="chatStore.isCompacting()" />
+      <ptah-compaction-notification [isCompacting]="resolvedIsCompacting()" />
     </div>
 
     <!-- Message List -->
@@ -146,8 +146,29 @@
       </div>
     }
 
-    <!-- Input Area (sticky at bottom, never shrinks) -->
-    <ptah-chat-input class="flex-shrink-0 border-t border-base-300" />
+    <!-- Input Area Collapse Toggle (full-width bar above input) -->
+    <button
+      class="w-full flex items-center justify-center gap-1 py-0.5 bg-base-200/50 hover:bg-base-200 border-t border-base-300 cursor-pointer transition-colors text-base-content/40 hover:text-base-content/70 flex-shrink-0"
+      (click)="toggleInputCollapse()"
+      [title]="inputCollapsed() ? 'Show input area' : 'Hide input area'"
+      type="button"
+    >
+      <lucide-angular
+        [img]="inputCollapsed() ? ChevronUpIcon : ChevronDownIcon"
+        class="w-3.5 h-3.5"
+      />
+      <span class="text-[10px] font-medium uppercase tracking-wider">{{
+        inputCollapsed() ? 'Show Input' : 'Hide Input'
+      }}</span>
+    </button>
+
+    <!-- Input Area (sticky at bottom, never shrinks) — collapsible with animation -->
+    <div
+      class="flex-shrink-0 input-collapse-wrapper"
+      [class.input-collapsed]="inputCollapsed()"
+    >
+      <ptah-chat-input class="border-t border-base-300" />
+    </div>
   </div>
 
   <!-- Agents vertical toggle tab (per-session) -->

--- a/libs/frontend/chat/src/lib/components/templates/chat-view.component.ts
+++ b/libs/frontend/chat/src/lib/components/templates/chat-view.component.ts
@@ -12,7 +12,12 @@ import {
   Injector,
   DestroyRef,
 } from '@angular/core';
-import { LucideAngularModule, Bell } from 'lucide-angular';
+import {
+  LucideAngularModule,
+  Bell,
+  ChevronUp,
+  ChevronDown,
+} from 'lucide-angular';
 import { MessageBubbleComponent } from '../organisms/message-bubble.component';
 import { AgentMonitorPanelComponent } from '../organisms/agent-monitor-panel.component';
 import { ChatInputComponent } from '../molecules/chat-input/chat-input.component';
@@ -94,8 +99,18 @@ export class ChatViewComponent {
   private readonly _tabManager = inject(TabManagerService);
   private readonly _treeBuilder = inject(ExecutionTreeBuilderService);
 
-  /** Lucide icon reference for template binding */
+  /** Lucide icon references for template binding */
   protected readonly BellIcon = Bell;
+  protected readonly ChevronUpIcon = ChevronUp;
+  protected readonly ChevronDownIcon = ChevronDown;
+
+  /** Whether the input area is collapsed to give more room to chat */
+  readonly inputCollapsed = signal(false);
+
+  /** Toggle the input area collapse state */
+  toggleInputCollapse(): void {
+    this.inputCollapsed.update((v) => !v);
+  }
 
   // ============================================================================
   // AGENT PANEL (per-session, embedded)
@@ -198,6 +213,23 @@ export class ChatViewComponent {
   /** Track message count to detect new user messages */
   private lastMessageCount = 0;
 
+  /**
+   * Tracks previous streaming state to detect the streaming→idle transition.
+   * When streaming ends (agent finishes), we force scroll-to-bottom regardless
+   * of userScrolledUp — the dramatic DOM change during finalization (streaming
+   * DOM replaced with finalized DOM) can trigger layout-driven scroll events
+   * that falsely set userScrolledUp=true.
+   */
+  private wasStreaming = false;
+
+  /**
+   * Flag to suppress onScroll during programmatic scrollToBottom().
+   * Smooth scroll animations generate intermediate scroll events at positions
+   * that aren't near the bottom, which falsely set userScrolledUp=true.
+   * This guard prevents that race condition.
+   */
+  private isProgrammaticScrolling = false;
+
   private readonly scrollPositionCache = new Map<string, number>();
   private previousTabId: string | null = null;
   private isRestoringScroll = false;
@@ -295,6 +327,17 @@ export class ChatViewComponent {
     return tab !== null
       ? (tab.compactionCount ?? 0)
       : this.chatStore.compactionCount();
+  });
+
+  /**
+   * Resolved isCompacting: tile-scoped when SESSION_CONTEXT is provided, otherwise global.
+   * Prevents compaction banner from showing on ALL canvas tiles when only one session compacts.
+   */
+  readonly resolvedIsCompacting = computed(() => {
+    const tab = this.resolvedTab();
+    return tab !== null
+      ? (tab.isCompacting ?? false)
+      : this.chatStore.isCompacting();
   });
 
   readonly resolvedQueuedContent = computed(() => {
@@ -438,6 +481,25 @@ export class ChatViewComponent {
       }
     });
 
+    // Force scroll to bottom when streaming ends (agent finished work).
+    // During finalization, streaming DOM is destroyed and finalized DOM is created.
+    // This dramatic DOM change can trigger layout-driven scroll events that falsely
+    // set userScrolledUp=true via onScroll(). The MutationObserver's scheduleScroll
+    // then sees userScrolledUp=true and skips scrolling, leaving the user stuck
+    // at an old position. This effect bypasses that by directly calling scrollToBottom.
+    effect(() => {
+      const isStreaming = this.resolvedIsStreaming();
+      if (this.wasStreaming && !isStreaming) {
+        untracked(() => {
+          this.userScrolledUp.set(false);
+          // setTimeout(0) runs after Angular CD completes and DOM is updated,
+          // ensuring scrollHeight reflects the finalized content.
+          setTimeout(() => this.scrollToBottom('instant'), 0);
+        });
+      }
+      this.wasStreaming = isStreaming;
+    });
+
     // Setup MutationObserver after initial render to watch for DOM changes
     // This replaces the effect-based approach for more reliable scroll timing
     afterNextRender(
@@ -454,10 +516,14 @@ export class ChatViewComponent {
   }
 
   /**
-   * Handle scroll events on message container
-   * Detects if user has scrolled up to disable auto-scroll
+   * Handle scroll events on message container.
+   * Detects if user has scrolled up to disable auto-scroll.
+   * Ignores scroll events fired during programmatic scrollToBottom() to prevent
+   * smooth scroll animation intermediates from falsely setting userScrolledUp.
    */
   onScroll(event: Event): void {
+    if (this.isProgrammaticScrolling) return;
+
     const container = event.target as HTMLElement;
     if (!container) return;
 
@@ -485,10 +551,12 @@ export class ChatViewComponent {
   }
 
   /**
-   * Cancel queued message (user-requested cancellation)
+   * Cancel queued message (user-requested cancellation).
+   * Uses resolvedTabId to target the correct tab in both single and canvas modes.
    */
   cancelQueue(): void {
-    this.chatStore.clearQueuedContent();
+    const tabId = this.resolvedTabId() ?? undefined;
+    this.chatStore.clearQueuedContent(tabId);
     console.log('[ChatViewComponent] Queued content cancelled by user');
   }
 
@@ -537,10 +605,29 @@ export class ChatViewComponent {
     if (!containerRef) return;
 
     const container = containerRef.nativeElement;
+
+    // Guard: suppress onScroll during programmatic scrolling.
+    // Smooth scroll generates intermediate scroll events at positions that
+    // aren't near the bottom, which would falsely set userScrolledUp=true.
+    this.isProgrammaticScrolling = true;
     container.scrollTo({
       top: container.scrollHeight,
       behavior,
     });
+
+    if (behavior === 'instant') {
+      // Instant scroll completes synchronously; clear after next frame
+      // to catch any same-frame scroll events the browser fires.
+      requestAnimationFrame(() => {
+        this.isProgrammaticScrolling = false;
+      });
+    } else {
+      // Smooth scroll animation takes multiple frames.
+      // Clear after a generous window to cover the animation duration.
+      setTimeout(() => {
+        this.isProgrammaticScrolling = false;
+      }, 400);
+    }
   }
 
   /**

--- a/libs/frontend/chat/src/lib/services/chat-message-handler.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-message-handler.service.ts
@@ -30,7 +30,7 @@ export class ChatMessageHandler implements MessageHandler {
 
   readonly handledMessageTypes = [
     MESSAGE_TYPES.CHAT_CHUNK,
-    // CHAT_COMPLETE intentionally not registered — SESSION_STATS is authoritative (TASK_2025_101)
+    MESSAGE_TYPES.CHAT_COMPLETE,
     MESSAGE_TYPES.CHAT_ERROR,
     MESSAGE_TYPES.PERMISSION_REQUEST,
     MESSAGE_TYPES.AGENT_SUMMARY_CHUNK,
@@ -45,6 +45,9 @@ export class ChatMessageHandler implements MessageHandler {
     switch (message.type) {
       case MESSAGE_TYPES.CHAT_CHUNK:
         this.handleChatChunk(message.payload);
+        break;
+      case MESSAGE_TYPES.CHAT_COMPLETE:
+        this.handleChatComplete(message.payload);
         break;
       case MESSAGE_TYPES.CHAT_ERROR:
         this.handleChatError(message.payload);
@@ -89,6 +92,32 @@ export class ChatMessageHandler implements MessageHandler {
     };
 
     this.chatStore.processStreamEvent(event, tabId, sessionId);
+  }
+
+  // CHAT_COMPLETE: Mark tab idle as safety net
+  // SESSION_STATS remains the authoritative completion signal (TASK_2025_101),
+  // but slash commands (/compact, /context, /cost) may not produce a result
+  // message, so SESSION_STATS never fires. CHAT_COMPLETE is the fallback
+  // that ensures the tab exits "streaming" state. markTabIdle is idempotent,
+  // so calling it twice (from both SESSION_STATS and CHAT_COMPLETE) is safe.
+  private handleChatComplete(payload: unknown): void {
+    const { tabId, sessionId } =
+      (payload as { tabId?: string; sessionId?: string }) ?? {};
+
+    // Route by tabId (primary) then sessionId fallback
+    let targetTabId = tabId;
+    if (!targetTabId && sessionId) {
+      const tab = this.chatStore.findTabBySessionId(sessionId);
+      targetTabId = tab?.id ?? undefined;
+    }
+    if (!targetTabId) {
+      targetTabId = this.chatStore.getActiveTabId() ?? undefined;
+    }
+    if (targetTabId) {
+      this.chatStore.markTabIdle(targetTabId);
+      // Also clear compaction state in case this was a /compact command
+      this.chatStore.clearCompactionStateForTab(targetTabId);
+    }
   }
 
   // CHAT_ERROR: Chat error signal

--- a/libs/frontend/chat/src/lib/services/chat-store/conversation.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/conversation.service.ts
@@ -143,8 +143,9 @@ export class ConversationService {
     content: string,
     options?: SendMessageOptions,
   ): void {
-    const activeTabId = this.tabManager.activeTabId();
-    if (!activeTabId) return;
+    // Use explicit tabId from options (canvas tile isolation) or fall back to active tab
+    const targetTabId = options?.tabId ?? this.tabManager.activeTabId();
+    if (!targetTabId) return;
 
     // Validate content using centralized validation service
     const validation = this.validator.validate(content);
@@ -158,8 +159,8 @@ export class ConversationService {
     // Sanitize content (trim whitespace)
     const sanitized = this.validator.sanitize(content);
 
-    const activeTab = this.tabManager.activeTab();
-    const existingQueue = activeTab?.queuedContent?.trim() ?? '';
+    const targetTab = this.tabManager.tabs().find((t) => t.id === targetTabId);
+    const existingQueue = targetTab?.queuedContent?.trim() ?? '';
 
     let newQueuedContent: string;
     const tabUpdate: Record<string, unknown> = {};
@@ -176,17 +177,18 @@ export class ConversationService {
     }
 
     tabUpdate['queuedContent'] = newQueuedContent;
-    this.tabManager.updateTab(activeTabId, tabUpdate);
+    this.tabManager.updateTab(targetTabId, tabUpdate);
   }
 
   /**
-   * Clear queued content and options for active tab
+   * Clear queued content and options for a specific tab or the active tab.
+   * @param tabId - Optional tab ID. Falls back to active tab if not provided.
    */
-  public clearQueuedContent(): void {
-    const activeTabId = this.tabManager.activeTabId();
-    if (!activeTabId) return;
+  public clearQueuedContent(tabId?: string): void {
+    const targetTabId = tabId ?? this.tabManager.activeTabId();
+    if (!targetTabId) return;
 
-    this.tabManager.updateTab(activeTabId, {
+    this.tabManager.updateTab(targetTabId, {
       queuedContent: '',
       queuedOptions: null,
     });
@@ -377,8 +379,18 @@ export class ConversationService {
   /**
    * Continue an existing conversation with Claude
    * Uses the real session ID (SDK UUID) for resume, tabId for event routing
+   *
+   * @param content - Message content to send
+   * @param files - Optional file paths to include
+   * @param explicitTabId - Optional tab ID to target. When provided (e.g., from sendQueuedMessage),
+   *   uses this tab instead of activeTab. Prevents user message being added to the wrong tab
+   *   if the user switched tabs before the queued message fires.
    */
-  async continueConversation(content: string, files?: string[]): Promise<void> {
+  async continueConversation(
+    content: string,
+    files?: string[],
+    explicitTabId?: string,
+  ): Promise<void> {
     try {
       // Wait for services to be ready (with timeout)
       const ready = await this.waitForServices(5000);
@@ -402,22 +414,25 @@ export class ConversationService {
         return;
       }
 
-      // Get REAL Claude session ID from the ACTIVE TAB (not global SessionManager)
+      // Use explicit tab if provided (queued message), otherwise fall back to active tab
+      const targetTabId = explicitTabId ?? this.tabManager.activeTabId();
+      const targetTab = explicitTabId
+        ? this.tabManager.tabs().find((t) => t.id === explicitTabId)
+        : this.tabManager.activeTab();
+
+      // Get REAL Claude session ID from the TARGET TAB (not global SessionManager)
       // This is critical for multi-tab support - each tab has its own session
-      const activeTab = this.tabManager.activeTab();
-      const sessionId = activeTab?.claudeSessionId;
+      const sessionId = targetTab?.claudeSessionId;
       if (!sessionId) {
         console.warn(
-          '[ConversationService] No Claude session ID on active tab - starting new conversation',
+          '[ConversationService] No Claude session ID on target tab - starting new conversation',
         );
         return this.startNewConversation(content, files);
       }
 
-      // Get active tab ID for event routing
-      const activeTabId = this.tabManager.activeTabId();
-      if (!activeTabId) {
+      if (!targetTabId) {
         console.warn(
-          '[ConversationService] No active tab for continuing conversation',
+          '[ConversationService] No target tab for continuing conversation',
         );
         return this.startNewConversation(content, files);
       }
@@ -426,14 +441,14 @@ export class ConversationService {
       this.sessionManager.setStatus('resuming');
 
       // Update tab status
-      this.tabManager.updateTab(activeTabId, { status: 'resuming' });
+      this.tabManager.updateTab(targetTabId, { status: 'resuming' });
 
       // TASK_2025_093 FIX: Finalize any existing streaming state before starting new turn.
       // This converts the streaming content into a proper message in tab.messages.
       // Without this, the streaming message would persist alongside new messages.
-      if (activeTab?.streamingState) {
+      if (targetTab?.streamingState) {
         const streamingHandler = this.injector.get(StreamingHandlerService);
-        streamingHandler.finalizeCurrentMessage(activeTabId);
+        streamingHandler.finalizeCurrentMessage(targetTabId);
         // Re-fetch the tab after finalization to get updated messages
         // Note: The tab's messages array now includes the finalized assistant message
       }
@@ -441,7 +456,7 @@ export class ConversationService {
       // Re-fetch tab after potential finalization to get updated messages
       const currentTab = this.tabManager
         .tabs()
-        .find((t) => t.id === activeTabId);
+        .find((t) => t.id === targetTabId);
 
       // Add user message immediately
       const userMessage = createExecutionChatMessage({
@@ -453,7 +468,7 @@ export class ConversationService {
       });
 
       // Update tab with user message (use currentTab to include finalized messages)
-      this.tabManager.updateTab(activeTabId, {
+      this.tabManager.updateTab(targetTabId, {
         messages: [...(currentTab?.messages ?? []), userMessage],
       });
 
@@ -463,9 +478,9 @@ export class ConversationService {
       const result = await this.claudeRpcService.call('chat:continue', {
         prompt: content,
         sessionId: sessionId as SessionId,
-        tabId: activeTabId, // For event routing
+        tabId: targetTabId, // For event routing
         workspacePath,
-        model: activeTab?.sessionModel ?? undefined,
+        model: targetTab?.sessionModel ?? undefined,
       });
 
       if (!result.success) {
@@ -473,19 +488,19 @@ export class ConversationService {
           '[ConversationService] Failed to continue chat:',
           result.error,
         );
-        this.tabManager.updateTab(activeTabId, { status: 'loaded' });
+        this.tabManager.updateTab(targetTabId, { status: 'loaded' });
       } else {
         this.sessionManager.setStatus('streaming');
-        this.tabManager.updateTab(activeTabId, { status: 'streaming' });
+        this.tabManager.updateTab(targetTabId, { status: 'streaming' });
       }
     } catch (error) {
       console.error(
         '[ConversationService] Failed to continue conversation:',
         error,
       );
-      const activeTabId = this.tabManager.activeTabId();
-      if (activeTabId) {
-        this.tabManager.updateTab(activeTabId, { status: 'loaded' });
+      const fallbackTabId = explicitTabId ?? this.tabManager.activeTabId();
+      if (fallbackTabId) {
+        this.tabManager.updateTab(fallbackTabId, { status: 'loaded' });
       }
     }
   }

--- a/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts
@@ -62,6 +62,12 @@ export class SessionLoaderService {
   private readonly _resumableSubagents = signal<SubagentRecord[]>([]);
 
   /**
+   * Tracks which session ID the current _resumableSubagents belong to.
+   * Used to clear stale subagents when the active tab changes to a different session.
+   */
+  private _resumableSubagentsSessionId: string | null = null;
+
+  /**
    * Set of sessionIds currently being loaded via switchSession() or
    * refreshResumableSubagentsForSession(). Prevents duplicate chat:resume
    * calls when the same session is requested while a load is already in
@@ -153,6 +159,19 @@ export class SessionLoaderService {
           this.refreshResumableSubagentsForSession(sessionId, tabId),
         );
       }
+    });
+
+    // Clear stale resumable subagents when the active tab switches to a different session.
+    // Without this, interrupted agents from session A leak into session B's banner
+    // because _resumableSubagents is a global signal, not tab-scoped.
+    effect(() => {
+      const activeSessionId = this.tabManager.activeTabSessionId();
+      untracked(() => {
+        if (activeSessionId !== this._resumableSubagentsSessionId) {
+          this._resumableSubagents.set([]);
+          this._resumableSubagentsSessionId = activeSessionId ?? null;
+        }
+      });
     });
   }
 
@@ -650,6 +669,7 @@ export class SessionLoaderService {
 
         // TASK_2025_213: Populate resumableSubagents signal for the banner UI
         this._resumableSubagents.set(resumableSubagents ?? []);
+        this._resumableSubagentsSessionId = sessionId;
 
         // TASK_2025_168: Load CLI sessions into agent monitor panel
         if (cliSessions && cliSessions.length > 0) {
@@ -677,6 +697,7 @@ export class SessionLoaderService {
 
         // TASK_2025_213: Set resumableSubagents from chat:resume response (empty for simple-message sessions)
         this._resumableSubagents.set(resumableSubagents ?? []);
+        this._resumableSubagentsSessionId = sessionId;
 
         // TASK_2025_168: Also load CLI sessions in fallback branch
         if (cliSessions && cliSessions.length > 0) {
@@ -696,11 +717,13 @@ export class SessionLoaderService {
 
         // TASK_2025_213: No resumable subagents on error/empty session
         this._resumableSubagents.set([]);
+        this._resumableSubagentsSessionId = sessionId;
       }
     } catch (error) {
       console.error('[SessionLoaderService] Failed to switch session:', error);
       // Clear stale resumable subagents from previous session on switch failure
       this._resumableSubagents.set([]);
+      this._resumableSubagentsSessionId = null;
     } finally {
       this._inFlightSessions.delete(sessionId);
     }
@@ -794,6 +817,7 @@ export class SessionLoaderService {
       const resumableSubagents = result.data?.resumableSubagents;
       if (resumableSubagents && resumableSubagents.length > 0) {
         this._resumableSubagents.set(resumableSubagents);
+        this._resumableSubagentsSessionId = sessionId;
         console.log(
           '[SessionLoaderService] Populated resumableSubagents for restored session',
           { sessionId, count: resumableSubagents.length },

--- a/libs/frontend/chat/src/lib/services/chat.store.ts
+++ b/libs/frontend/chat/src/lib/services/chat.store.ts
@@ -170,9 +170,10 @@ export class ChatStore {
   );
   readonly licenseStatus = this._licenseStatus.asReadonly();
 
-  // Compaction state signals (TASK_2025_098)
-  private readonly _isCompacting = signal<boolean>(false);
-  readonly isCompacting = this._isCompacting.asReadonly();
+  // Compaction state — per-tab via TabManagerService (TASK_2025_098)
+  // Previously a global signal that caused ALL canvas tiles to show the
+  // compaction banner when any single session was compacting.
+  readonly isCompacting = this.tabManager.activeTabIsCompacting;
 
   /**
    * Timeout ID for compaction safety fallback.
@@ -183,7 +184,7 @@ export class ChatStore {
    * 2. setTimeout returns a number/NodeJS.Timeout, not a serializable value
    * 3. We only need to clear it, never read it in templates
    *
-   * The associated `_isCompacting` signal IS the UI state that components observe.
+   * The associated `isCompacting` per-tab field IS the UI state that components observe.
    * @see TASK_2025_098
    */
   private compactionTimeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -544,10 +545,13 @@ export class ChatStore {
    * @param sessionId - The session ID where compaction is occurring
    */
   handleCompactionStart(sessionId: string): void {
-    const activeSessionId = this.currentSessionId();
-
-    // Only show compaction for the active session
-    if (sessionId !== activeSessionId) {
+    // Find the tab for this session — compaction state is per-tab, not global
+    const tab = this.tabManager.findTabBySessionId(sessionId);
+    if (!tab) {
+      console.warn(
+        '[ChatStore] handleCompactionStart: no tab found for sessionId',
+        { sessionId },
+      );
       return;
     }
 
@@ -557,12 +561,13 @@ export class ChatStore {
       this.compactionTimeoutId = null;
     }
 
-    // Set compacting state — stays visible until compaction_complete event arrives
-    this._isCompacting.set(true);
+    // Set compacting state on the specific tab
+    this.tabManager.updateTab(tab.id, { isCompacting: true });
 
     // Safety fallback: dismiss if compaction_complete event is never received
+    const compactingTabId = tab.id;
     this.compactionTimeoutId = setTimeout(() => {
-      this._isCompacting.set(false);
+      this.tabManager.updateTab(compactingTabId, { isCompacting: false });
       this.compactionTimeoutId = null;
       console.warn(
         '[ChatStore] Compaction safety timeout reached — compaction_complete event may have been lost',
@@ -571,15 +576,57 @@ export class ChatStore {
   }
 
   /**
-   * Clear compaction state (called when new message is received)
+   * Public accessor for marking a tab idle from external handlers.
+   * Used by ChatMessageHandler to handle CHAT_COMPLETE fallback.
+   */
+  markTabIdle(tabId: string): void {
+    this.tabManager.markTabIdle(tabId);
+  }
+
+  /**
+   * Public accessor to find a tab by its session ID.
+   * Used by ChatMessageHandler for CHAT_COMPLETE routing.
+   */
+  findTabBySessionId(sessionId: string): TabState | null {
+    return this.tabManager.findTabBySessionId(sessionId);
+  }
+
+  /**
+   * Public accessor to get the active tab ID.
+   * Used by ChatMessageHandler for CHAT_COMPLETE fallback routing.
+   */
+  getActiveTabId(): string | null {
+    return this.tabManager.activeTabId();
+  }
+
+  /**
+   * Clear compaction state for a specific tab.
+   * Public for use by ChatMessageHandler on CHAT_COMPLETE.
+   */
+  clearCompactionStateForTab(tabId: string): void {
+    this.tabManager.updateTab(tabId, { isCompacting: false });
+  }
+
+  /**
+   * Clear compaction state for a specific tab, or all compacting tabs if no tabId given.
    * TASK_2025_098: SDK Session Compaction
    */
-  private clearCompactionState(): void {
+  private clearCompactionState(tabId?: string): void {
     if (this.compactionTimeoutId) {
       clearTimeout(this.compactionTimeoutId);
       this.compactionTimeoutId = null;
     }
-    this._isCompacting.set(false);
+    // Clear on the specific tab if provided, otherwise clear on all compacting tabs
+    if (tabId) {
+      this.tabManager.updateTab(tabId, { isCompacting: false });
+    } else {
+      // Fallback: clear isCompacting on any tab that has it set
+      for (const tab of this.tabManager.tabs()) {
+        if (tab.isCompacting) {
+          this.tabManager.updateTab(tab.id, { isCompacting: false });
+        }
+      }
+    }
   }
 
   /**
@@ -670,13 +717,13 @@ export class ChatStore {
   }
 
   /**
-   * Clear queued content for active tab
-   * Delegates to TabManagerService (simple facade)
+   * Clear queued content for a specific tab or the active tab.
+   * @param tabId - Optional tab ID. Falls back to active tab if not provided.
    */
-  clearQueuedContent(): void {
-    const activeTabId = this.tabManager.activeTabId();
-    if (!activeTabId) return;
-    this.tabManager.updateTab(activeTabId, { queuedContent: null });
+  clearQueuedContent(tabId?: string): void {
+    const targetTabId = tabId ?? this.tabManager.activeTabId();
+    if (!targetTabId) return;
+    this.tabManager.updateTab(targetTabId, { queuedContent: null });
   }
 
   /**
@@ -717,9 +764,12 @@ export class ChatStore {
       // messageSender.send() checks tab.status === 'loaded' which is false during streaming,
       // causing it to incorrectly start a NEW conversation instead of continuing the existing one.
       // Pass files from stored options (effort is set at session config level, not per-message for continue).
+      // Pass explicit tabId so the user message is added to the correct tab even if the user
+      // switched tabs before the queued message fires.
       await this.conversation.continueConversation(
         content,
         queuedOptions?.files,
+        tabId,
       );
     } catch (error) {
       console.error('[ChatStore] sendQueuedMessage failed:', error);
@@ -753,7 +803,7 @@ export class ChatStore {
 
     // Handle compaction complete: dismiss banner, reset tree, clear finalized messages
     if (result && result.compactionComplete && result.compactionSessionId) {
-      this.clearCompactionState();
+      this.clearCompactionState(result.tabId);
       this.treeBuilder.clearCache();
 
       // Clear finalized messages for the tab - stale pre-compaction messages
@@ -787,6 +837,11 @@ export class ChatStore {
           preloadedStats,
           compactionCount: (compactionTab.compactionCount ?? 0) + 1,
         });
+
+        // Mark tab idle — /compact doesn't produce a result message with
+        // SESSION_STATS, so the normal completion path never fires.
+        // Without this, the tab stays in "streaming" state forever.
+        this.tabManager.markTabIdle(result.tabId);
       }
       return;
     }
@@ -931,14 +986,14 @@ export class ChatStore {
       lastTurnContextTokens?: number;
     }>;
   }): void {
-    // TASK_2025_098: Clear compaction state when new message finishes
-    // This indicates compaction (if any) has completed successfully
-    this.clearCompactionState();
-
     // Resolve the target tab by sessionId first.
     // Fallback to activeTab() only as safety net — stats can't be dropped since
     // they're the only opportunity to record cost/token data for the turn.
     let targetTab = this.tabManager.findTabBySessionId(stats.sessionId);
+
+    // TASK_2025_098: Clear compaction state when new message finishes
+    // This indicates compaction (if any) has completed successfully
+    this.clearCompactionState(targetTab?.id);
     if (!targetTab) {
       targetTab = this.tabManager.activeTab();
       if (targetTab) {

--- a/libs/frontend/chat/src/lib/services/chat.types.ts
+++ b/libs/frontend/chat/src/lib/services/chat.types.ts
@@ -286,6 +286,12 @@ export interface TabState {
   preset?: 'claude_code' | 'enhanced';
 
   /**
+   * Whether context compaction is currently in progress for this tab.
+   * Set to true on compaction_start, cleared on compaction_complete or error.
+   */
+  isCompacting?: boolean;
+
+  /**
    * Number of context compactions that occurred during this session.
    * Incremented on each compaction_complete event.
    */

--- a/libs/frontend/chat/src/lib/services/tab-manager.service.ts
+++ b/libs/frontend/chat/src/lib/services/tab-manager.service.ts
@@ -168,6 +168,14 @@ export class TabManagerService {
     { equal: (a, b) => a === b },
   );
 
+  /** Whether compaction is in progress for the active tab. */
+  readonly activeTabIsCompacting = computed(
+    () =>
+      this._tabs().find((t) => t.id === this._activeTabId())?.isCompacting ??
+      false,
+    { equal: (a, b) => a === b },
+  );
+
   /** Compaction count. Rarely changes. */
   readonly activeTabCompactionCount = computed(
     () =>

--- a/libs/frontend/editor/src/index.ts
+++ b/libs/frontend/editor/src/index.ts
@@ -36,12 +36,16 @@ export type { FileTreeNode } from './lib/models/file-tree.model';
 export { FileTreeComponent } from './lib/file-tree/file-tree.component';
 export { FileTreeNodeComponent } from './lib/file-tree/file-tree-node.component';
 export { CodeEditorComponent } from './lib/code-editor/code-editor.component';
+export { DiffViewComponent } from './lib/diff-view/diff-view.component';
 export { EditorPanelComponent } from './lib/editor-panel/editor-panel.component';
 export { GitStatusBarComponent } from './lib/git-status-bar/git-status-bar.component';
 export { TerminalComponent } from './lib/terminal/terminal.component';
 export { TerminalTabBarComponent } from './lib/terminal/terminal-tab-bar.component';
 export { TerminalPanelComponent } from './lib/terminal/terminal-panel.component';
 export { AddWorktreeDialogComponent } from './lib/worktree/add-worktree-dialog.component';
+export { SidebarComponent } from './lib/sidebar/sidebar.component';
+export { SourceControlPanelComponent } from './lib/source-control/source-control-panel.component';
+export { SourceControlFileComponent } from './lib/source-control/source-control-file.component';
 
 // Services
 export { EditorService } from './lib/services/editor.service';
@@ -49,6 +53,7 @@ export type { EditorTab } from './lib/services/editor.service';
 export { GitStatusService } from './lib/services/git-status.service';
 export { TerminalService } from './lib/services/terminal.service';
 export { WorktreeService } from './lib/services/worktree.service';
+export { SourceControlService } from './lib/services/source-control.service';
 
 // Utilities
 export { rpcCall } from './lib/services/rpc-call.util';

--- a/libs/frontend/editor/src/lib/diff-view/diff-view.component.ts
+++ b/libs/frontend/editor/src/lib/diff-view/diff-view.component.ts
@@ -1,0 +1,125 @@
+import {
+  Component,
+  input,
+  computed,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+import {
+  DiffEditorComponent,
+  type DiffEditorModel,
+} from 'ngx-monaco-editor-v2';
+
+/**
+ * DiffViewComponent - Monaco diff editor wrapper for side-by-side file comparison.
+ *
+ * Complexity Level: 1 (Simple - thin wrapper around ngx-monaco-diff-editor)
+ * Patterns: Standalone component, signal-based inputs, computed language detection
+ *
+ * Displays a read-only side-by-side diff of the original (HEAD) content versus
+ * the current (working tree) content using Monaco's built-in diff editor.
+ */
+@Component({
+  selector: 'ptah-diff-view',
+  standalone: true,
+  imports: [DiffEditorComponent],
+  template: `
+    <ngx-monaco-diff-editor
+      class="h-full"
+      [options]="diffOptions"
+      [originalModel]="originalModel()"
+      [modifiedModel]="modifiedModel()"
+    />
+  `,
+  styles: `
+    :host {
+      display: block;
+      height: 100%;
+      width: 100%;
+    }
+    ngx-monaco-diff-editor {
+      display: block;
+      height: 100%;
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DiffViewComponent {
+  readonly filePath = input.required<string>();
+  readonly originalContent = input.required<string>();
+  readonly modifiedContent = input.required<string>();
+
+  readonly diffOptions = {
+    theme: 'vs-dark',
+    automaticLayout: true,
+    readOnly: true,
+    renderSideBySide: true,
+    scrollBeyondLastLine: false,
+  };
+
+  readonly originalModel = computed(
+    (): DiffEditorModel => ({
+      code: this.originalContent(),
+      language: this.detectLanguage(this.filePath()),
+    }),
+  );
+
+  readonly modifiedModel = computed(
+    (): DiffEditorModel => ({
+      code: this.modifiedContent(),
+      language: this.detectLanguage(this.filePath()),
+    }),
+  );
+
+  private detectLanguage(filePath: string): string {
+    if (!filePath) return 'plaintext';
+    const ext = filePath.split('.').pop()?.toLowerCase();
+    const languageMap: Record<string, string> = {
+      ts: 'typescript',
+      tsx: 'typescript',
+      js: 'javascript',
+      jsx: 'javascript',
+      json: 'json',
+      html: 'html',
+      htm: 'html',
+      css: 'css',
+      scss: 'scss',
+      less: 'less',
+      py: 'python',
+      rb: 'ruby',
+      rs: 'rust',
+      go: 'go',
+      java: 'java',
+      kt: 'kotlin',
+      swift: 'swift',
+      c: 'c',
+      cpp: 'cpp',
+      h: 'c',
+      hpp: 'cpp',
+      cs: 'csharp',
+      php: 'php',
+      md: 'markdown',
+      yaml: 'yaml',
+      yml: 'yaml',
+      xml: 'xml',
+      svg: 'xml',
+      sql: 'sql',
+      sh: 'shell',
+      bash: 'shell',
+      zsh: 'shell',
+      ps1: 'powershell',
+      dockerfile: 'dockerfile',
+      toml: 'toml',
+      ini: 'ini',
+      cfg: 'ini',
+      env: 'dotenv',
+      graphql: 'graphql',
+      gql: 'graphql',
+      r: 'r',
+      lua: 'lua',
+      dart: 'dart',
+      vue: 'html',
+      svelte: 'html',
+    };
+    return languageMap[ext ?? ''] ?? 'plaintext';
+  }
+}

--- a/libs/frontend/editor/src/lib/editor-panel/editor-panel.component.ts
+++ b/libs/frontend/editor/src/lib/editor-panel/editor-panel.component.ts
@@ -16,12 +16,13 @@ import {
   Terminal as TermIcon,
 } from 'lucide-angular';
 import { VSCodeService } from '@ptah-extension/core';
-import { FileTreeComponent } from '../file-tree/file-tree.component';
 import { CodeEditorComponent } from '../code-editor/code-editor.component';
+import { DiffViewComponent } from '../diff-view/diff-view.component';
 import { EditorService } from '../services/editor.service';
 import { GitStatusService } from '../services/git-status.service';
 import { GitStatusBarComponent } from '../git-status-bar/git-status-bar.component';
 import { TerminalPanelComponent } from '../terminal/terminal-panel.component';
+import { SidebarComponent } from '../sidebar/sidebar.component';
 
 /**
  * EditorPanelComponent - Main container combining file tree sidebar, code editor,
@@ -50,11 +51,12 @@ import { TerminalPanelComponent } from '../terminal/terminal-panel.component';
   standalone: true,
   imports: [
     NgClass,
-    FileTreeComponent,
     CodeEditorComponent,
+    DiffViewComponent,
     LucideAngularModule,
     GitStatusBarComponent,
     TerminalPanelComponent,
+    SidebarComponent,
   ],
   template: `
     <div
@@ -68,12 +70,12 @@ import { TerminalPanelComponent } from '../terminal/terminal-panel.component';
       >
         <button
           class="btn btn-square btn-ghost btn-xs"
-          [title]="explorerVisible() ? 'Hide explorer' : 'Show explorer'"
-          aria-label="Toggle explorer"
-          (click)="toggleExplorer()"
+          [title]="sidebarVisible() ? 'Hide sidebar' : 'Show sidebar'"
+          aria-label="Toggle sidebar"
+          (click)="toggleSidebar()"
         >
           <lucide-angular
-            [img]="explorerVisible() ? PanelLeftCloseIcon : PanelLeftIcon"
+            [img]="sidebarVisible() ? PanelLeftCloseIcon : PanelLeftIcon"
             class="w-3.5 h-3.5"
           />
         </button>
@@ -104,11 +106,14 @@ import { TerminalPanelComponent } from '../terminal/terminal-panel.component';
           class="flex min-h-0"
           [style.flex]="terminalVisible() ? '1 1 0' : '1 1 auto'"
         >
-          @if (explorerVisible()) {
-            <ptah-file-tree
+          @if (sidebarVisible()) {
+            <ptah-sidebar
               [files]="editorService.fileTree()"
               [activeFilePath]="editorService.activeFilePath()"
+              [changedFiles]="gitStatus.files()"
+              [branchName]="gitStatus.branchName()"
               (fileSelected)="onFileSelected($event)"
+              (diffRequested)="onDiffRequested($event)"
             />
           }
           <div class="flex-1 min-w-0 flex flex-col">
@@ -159,12 +164,24 @@ import { TerminalPanelComponent } from '../terminal/terminal-panel.component';
               </div>
             } @else {
               <div class="flex-1 min-h-0">
-                <ptah-code-editor
-                  [filePath]="editorService.activeFilePath()"
-                  [content]="editorService.activeFileContent()"
-                  (contentChanged)="onContentChanged($event)"
-                  (fileSaved)="onFileSaved($event)"
-                />
+                @if (editorService.activeDiffTab()) {
+                  <ptah-diff-view
+                    [filePath]="
+                      editorService.activeDiffTab()!.diffRelativePath!
+                    "
+                    [originalContent]="
+                      editorService.activeDiffTab()!.originalContent!
+                    "
+                    [modifiedContent]="editorService.activeDiffTab()!.content"
+                  />
+                } @else {
+                  <ptah-code-editor
+                    [filePath]="editorService.activeFilePath()"
+                    [content]="editorService.activeFileContent()"
+                    (contentChanged)="onContentChanged($event)"
+                    (fileSaved)="onFileSaved($event)"
+                  />
+                }
               </div>
             }
           </div>
@@ -215,10 +232,10 @@ import { TerminalPanelComponent } from '../terminal/terminal-panel.component';
 })
 export class EditorPanelComponent implements OnInit, OnDestroy {
   protected readonly editorService = inject(EditorService);
-  private readonly gitStatus = inject(GitStatusService);
+  protected readonly gitStatus = inject(GitStatusService);
   private readonly vscodeService = inject(VSCodeService);
   private readonly ngZone = inject(NgZone);
-  protected readonly explorerVisible = signal(true);
+  protected readonly sidebarVisible = signal(true);
 
   /** Whether the terminal panel is visible. */
   protected readonly terminalVisible = signal(false);
@@ -253,8 +270,8 @@ export class EditorPanelComponent implements OnInit, OnDestroy {
     this.cleanupResizeListeners();
   }
 
-  protected toggleExplorer(): void {
-    this.explorerVisible.update((v) => !v);
+  protected toggleSidebar(): void {
+    this.sidebarVisible.update((v) => !v);
   }
 
   protected toggleTerminal(): void {
@@ -263,6 +280,17 @@ export class EditorPanelComponent implements OnInit, OnDestroy {
 
   protected onFileSelected(filePath: string): void {
     void this.editorService.openFile(filePath);
+  }
+
+  protected onDiffRequested(relativePath: string): void {
+    const workspaceRoot = this.gitStatus.activeWorkspacePath;
+    if (!workspaceRoot) return;
+    const normalizedRoot = workspaceRoot.replace(/\\/g, '/');
+    const root = normalizedRoot.endsWith('/')
+      ? normalizedRoot
+      : normalizedRoot + '/';
+    const absolutePath = root + relativePath.replace(/\\/g, '/');
+    void this.editorService.openDiff(relativePath, absolutePath);
   }
 
   protected onContentChanged(content: string): void {

--- a/libs/frontend/editor/src/lib/file-tree/file-tree-node.component.ts
+++ b/libs/frontend/editor/src/lib/file-tree/file-tree-node.component.ts
@@ -71,7 +71,7 @@ import type { GitFileStatus } from '@ptah-extension/shared';
           aria-hidden="true"
         />
       }
-      <span class="truncate">{{ node().name }}</span>
+      <span class="truncate" [class]="fileNameColor()">{{ node().name }}</span>
       @if (nodeGitStatus()) {
         <span
           class="ml-auto text-[10px] font-mono flex-shrink-0"
@@ -80,6 +80,12 @@ import type { GitFileStatus } from '@ptah-extension/shared';
           aria-hidden="true"
           >{{ nodeGitStatus()!.status }}</span
         >
+      }
+      @if (hasChangedChildren()) {
+        <span
+          class="w-1.5 h-1.5 rounded-full bg-warning ml-auto flex-shrink-0"
+          title="Contains changes"
+        ></span>
       }
       @if (isLoadingChildren()) {
         <span class="loading loading-spinner loading-xs ml-auto"></span>
@@ -172,6 +178,55 @@ export class FileTreeNodeComponent {
       default:
         return 'text-base-content/50';
     }
+  });
+
+  /**
+   * CSS class for coloring the entire filename based on git status.
+   * Applied to files only (directories use hasChangedChildren dot instead).
+   * Deleted files also get a line-through decoration.
+   */
+  readonly fileNameColor = computed((): string => {
+    const status = this.nodeGitStatus();
+    if (!status) return '';
+    switch (status.status) {
+      case 'M':
+        return 'text-warning';
+      case 'A':
+        return 'text-success';
+      case 'D':
+        return 'text-error line-through';
+      case '??':
+        return 'text-success';
+      default:
+        return '';
+    }
+  });
+
+  /**
+   * Whether this directory contains any files with git changes.
+   * Used to show a small dot indicator on directories that have modified children.
+   * Only applies to directory nodes.
+   */
+  readonly hasChangedChildren = computed((): boolean => {
+    if (this.node().type !== 'directory') return false;
+    const nodePath = this.node().path.replace(/\\/g, '/');
+    const workspaceRoot = this.gitStatus.activeWorkspacePath;
+    if (!workspaceRoot) return false;
+
+    const normalizedRoot = workspaceRoot.replace(/\\/g, '/');
+    const rootWithSlash = normalizedRoot.endsWith('/')
+      ? normalizedRoot
+      : normalizedRoot + '/';
+    const relativeDirPath = nodePath.startsWith(rootWithSlash)
+      ? nodePath.slice(rootWithSlash.length)
+      : '';
+    if (!relativeDirPath) return false;
+
+    const dirPrefix = relativeDirPath + '/';
+    for (const key of this.gitStatus.fileStatusMap().keys()) {
+      if (key.startsWith(dirPrefix)) return true;
+    }
+    return false;
   });
 
   // Lucide icons

--- a/libs/frontend/editor/src/lib/services/editor.service.ts
+++ b/libs/frontend/editor/src/lib/services/editor.service.ts
@@ -9,6 +9,12 @@ export interface EditorTab {
   fileName: string;
   content: string;
   isDirty: boolean;
+  /** Whether this tab shows a diff view instead of a regular editor */
+  isDiff?: boolean;
+  /** Original (HEAD) content for diff tabs */
+  originalContent?: string;
+  /** Relative path within the workspace for diff tabs */
+  diffRelativePath?: string;
 }
 
 /**
@@ -106,6 +112,14 @@ export class EditorService {
 
   /** Whether a file is currently open */
   readonly hasActiveFile = computed(() => this._activeFilePath() !== undefined);
+
+  /** The active diff tab, or null if the active tab is not a diff view */
+  readonly activeDiffTab = computed(() => {
+    const tabs = this._openTabs();
+    const activePath = this._activeFilePath();
+    const tab = tabs.find((t) => t.filePath === activePath);
+    return tab?.isDiff ? tab : null;
+  });
 
   // ============================================================================
   // WORKSPACE OPERATIONS (TASK_2025_208)
@@ -286,6 +300,70 @@ export class EditorService {
       this.showError(result.error ?? 'Failed to open file');
     }
     this._isLoading.set(false);
+  }
+
+  /**
+   * Open a diff view for a file, showing the HEAD version alongside the working tree version.
+   * Creates a special diff tab with a `diff:` prefixed key to distinguish from regular file tabs.
+   *
+   * Fetches the original (HEAD) content via git:showFile RPC and the current content
+   * via editor:openFile RPC in parallel.
+   *
+   * @param relativePath - The git-relative path of the file (e.g., "src/app/foo.ts")
+   * @param absolutePath - The absolute file system path for reading current content
+   */
+  async openDiff(relativePath: string, absolutePath: string): Promise<void> {
+    const diffKey = `diff:${relativePath}`;
+
+    // If diff tab already open, switch to it
+    const existingTab = this._openTabs().find((t) => t.filePath === diffKey);
+    if (existingTab) {
+      this._activeFilePath.set(diffKey);
+      this._activeFileContent.set(existingTab.content);
+      return;
+    }
+
+    this._isLoading.set(true);
+    this.clearError();
+
+    // Fetch original content from HEAD and current content in parallel
+    const [originalResult, currentResult] = await Promise.all([
+      rpcCall<{ content: string }>(this.vscodeService, 'git:showFile', {
+        path: relativePath,
+      }),
+      rpcCall<{ content: string; filePath: string }>(
+        this.vscodeService,
+        'editor:openFile',
+        { filePath: absolutePath },
+      ),
+    ]);
+
+    const originalContent = originalResult.success
+      ? (originalResult.data?.content ?? '')
+      : '';
+    const currentContent = currentResult.success
+      ? (currentResult.data?.content ?? '')
+      : '';
+
+    const fileName = this._extractFileName(relativePath);
+
+    this._openTabs.update((tabs) => [
+      ...tabs,
+      {
+        filePath: diffKey,
+        fileName: `${fileName} (diff)`,
+        content: currentContent,
+        isDirty: false,
+        isDiff: true,
+        originalContent,
+        diffRelativePath: relativePath,
+      },
+    ]);
+
+    this._activeFilePath.set(diffKey);
+    this._activeFileContent.set(currentContent);
+    this._isLoading.set(false);
+    this._syncTabsToCache();
   }
 
   /**

--- a/libs/frontend/editor/src/lib/services/git-status.service.ts
+++ b/libs/frontend/editor/src/lib/services/git-status.service.ts
@@ -111,6 +111,20 @@ export class GitStatusService {
   /** Current branch name string shortcut. */
   readonly branchName = computed(() => this._branch().branch);
 
+  /** Files that are staged in the git index. */
+  readonly stagedFiles = computed(() => this._files().filter((f) => f.staged));
+
+  /** Files that are unstaged (working tree changes). */
+  readonly unstagedFiles = computed(() =>
+    this._files().filter((f) => !f.staged),
+  );
+
+  /** Count of staged files. */
+  readonly stagedCount = computed(() => this.stagedFiles().length);
+
+  /** Count of unstaged files. */
+  readonly unstagedCount = computed(() => this.unstagedFiles().length);
+
   /**
    * Map<relativePath, GitFileStatus[]> for O(1) lookup by FileTreeNodeComponent.
    * Keys are relative paths from workspace root (as reported by git status --porcelain=v2).

--- a/libs/frontend/editor/src/lib/services/source-control.service.ts
+++ b/libs/frontend/editor/src/lib/services/source-control.service.ts
@@ -1,0 +1,103 @@
+import { Injectable, inject } from '@angular/core';
+import { VSCodeService } from '@ptah-extension/core';
+import type {
+  GitStageResult,
+  GitUnstageResult,
+  GitDiscardResult,
+  GitCommitResult,
+  GitShowFileResult,
+} from '@ptah-extension/shared';
+import { rpcCall, type RpcCallResult } from './rpc-call.util';
+
+/**
+ * SourceControlService - Frontend RPC wrapper for git source control operations.
+ *
+ * Complexity Level: 1 (Simple RPC delegation, no internal state)
+ * Patterns: Injectable service, RPC delegation
+ *
+ * Responsibilities:
+ * - Stage/unstage individual files and all files
+ * - Discard working tree changes
+ * - Create commits
+ * - Retrieve original file content from HEAD for diff views
+ *
+ * Communication: Uses rpcCall utility for MESSAGE_TYPES.RPC_CALL / RPC_RESPONSE with correlationId.
+ *
+ * TASK_2025_273
+ */
+@Injectable({ providedIn: 'root' })
+export class SourceControlService {
+  private readonly vscodeService = inject(VSCodeService);
+
+  /**
+   * Stage a single file.
+   * @param path - Relative path from workspace root
+   */
+  async stageFile(path: string): Promise<RpcCallResult<GitStageResult>> {
+    return rpcCall<GitStageResult>(this.vscodeService, 'git:stage', {
+      paths: [path],
+    });
+  }
+
+  /**
+   * Unstage a single file.
+   * @param path - Relative path from workspace root
+   */
+  async unstageFile(path: string): Promise<RpcCallResult<GitUnstageResult>> {
+    return rpcCall<GitUnstageResult>(this.vscodeService, 'git:unstage', {
+      paths: [path],
+    });
+  }
+
+  /**
+   * Stage all changed files in the workspace.
+   */
+  async stageAll(): Promise<RpcCallResult<GitStageResult>> {
+    return rpcCall<GitStageResult>(this.vscodeService, 'git:stage', {
+      paths: ['.'],
+    });
+  }
+
+  /**
+   * Unstage all staged files in the workspace.
+   */
+  async unstageAll(): Promise<RpcCallResult<GitUnstageResult>> {
+    return rpcCall<GitUnstageResult>(this.vscodeService, 'git:unstage', {
+      paths: ['.'],
+    });
+  }
+
+  /**
+   * Discard working tree changes for a file.
+   * WARNING: This is a destructive operation that cannot be undone.
+   * @param path - Relative path from workspace root
+   */
+  async discardChanges(path: string): Promise<RpcCallResult<GitDiscardResult>> {
+    return rpcCall<GitDiscardResult>(this.vscodeService, 'git:discard', {
+      paths: [path],
+    });
+  }
+
+  /**
+   * Create a commit with the given message.
+   * @param message - Commit message
+   */
+  async commit(message: string): Promise<RpcCallResult<GitCommitResult>> {
+    return rpcCall<GitCommitResult>(this.vscodeService, 'git:commit', {
+      message,
+    });
+  }
+
+  /**
+   * Get the original content of a file from HEAD revision.
+   * Returns empty content for new/untracked files.
+   * @param relativePath - Relative path from workspace root
+   */
+  async getOriginalContent(
+    relativePath: string,
+  ): Promise<RpcCallResult<GitShowFileResult>> {
+    return rpcCall<GitShowFileResult>(this.vscodeService, 'git:showFile', {
+      path: relativePath,
+    });
+  }
+}

--- a/libs/frontend/editor/src/lib/sidebar/sidebar.component.ts
+++ b/libs/frontend/editor/src/lib/sidebar/sidebar.component.ts
@@ -1,0 +1,132 @@
+import {
+  Component,
+  input,
+  output,
+  signal,
+  computed,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+import { LucideAngularModule, FolderOpen, GitBranch } from 'lucide-angular';
+import type { FileTreeNode } from '../models/file-tree.model';
+import type { GitFileStatus } from '@ptah-extension/shared';
+import { FileTreeComponent } from '../file-tree/file-tree.component';
+import { SourceControlPanelComponent } from '../source-control/source-control-panel.component';
+
+/**
+ * SidebarComponent - Tabbed container switching between Explorer and Source Control panels.
+ *
+ * Complexity Level: 1 (Simple tab container, delegates rendering to child components)
+ * Patterns: Standalone, OnPush, signal-based tab state, composition
+ *
+ * Replaces the direct <ptah-file-tree> in the editor panel with a tabbed sidebar
+ * that can switch between file explorer and source control views.
+ *
+ * TASK_2025_273
+ */
+@Component({
+  selector: 'ptah-sidebar',
+  standalone: true,
+  imports: [
+    LucideAngularModule,
+    FileTreeComponent,
+    SourceControlPanelComponent,
+  ],
+  template: `
+    <aside
+      class="w-64 h-full flex flex-col flex-shrink-0 bg-base-200 border-r border-base-300"
+      role="complementary"
+      aria-label="Sidebar"
+    >
+      <!-- Tab bar -->
+      <div
+        class="flex items-center border-b border-base-300 flex-shrink-0"
+        role="tablist"
+        aria-label="Sidebar tabs"
+      >
+        <button
+          class="flex items-center gap-1 px-3 py-1.5 text-xs transition-colors"
+          role="tab"
+          [attr.aria-selected]="activeTab() === 'explorer'"
+          [class]="
+            activeTab() === 'explorer'
+              ? 'border-b-2 border-primary text-base-content'
+              : 'text-base-content/50 hover:text-base-content/80'
+          "
+          (click)="activeTab.set('explorer')"
+        >
+          <lucide-angular [img]="FolderOpenIcon" class="w-3.5 h-3.5" />
+          <span>Explorer</span>
+        </button>
+
+        <button
+          class="flex items-center gap-1 px-3 py-1.5 text-xs transition-colors"
+          role="tab"
+          [attr.aria-selected]="activeTab() === 'source-control'"
+          [class]="
+            activeTab() === 'source-control'
+              ? 'border-b-2 border-primary text-base-content'
+              : 'text-base-content/50 hover:text-base-content/80'
+          "
+          (click)="activeTab.set('source-control')"
+        >
+          <lucide-angular [img]="GitBranchIcon" class="w-3.5 h-3.5" />
+          <span>Source Control</span>
+          @if (changeCount() > 0) {
+            <span class="badge badge-xs badge-primary ml-0.5">{{
+              changeCount()
+            }}</span>
+          }
+        </button>
+      </div>
+
+      <!-- Tab content -->
+      <div class="flex-1 min-h-0">
+        @switch (activeTab()) {
+          @case ('explorer') {
+            <ptah-file-tree
+              [files]="files()"
+              [activeFilePath]="activeFilePath()"
+              (fileSelected)="fileSelected.emit($event)"
+            />
+          }
+          @case ('source-control') {
+            <ptah-source-control-panel
+              [files]="changedFiles()"
+              (fileClicked)="fileSelected.emit($event)"
+              (diffRequested)="diffRequested.emit($event)"
+            />
+          }
+        }
+      </div>
+    </aside>
+  `,
+  styles: `
+    :host ptah-file-tree {
+      display: contents;
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SidebarComponent {
+  // Inputs
+  readonly files = input<FileTreeNode[]>([]);
+  readonly activeFilePath = input<string | undefined>(undefined);
+  readonly changedFiles = input<GitFileStatus[]>([]);
+  readonly branchName = input<string>('');
+
+  // Outputs
+  readonly fileSelected = output<string>();
+  readonly diffRequested = output<string>();
+
+  // Tab state
+  protected readonly activeTab = signal<'explorer' | 'source-control'>(
+    'explorer',
+  );
+
+  // Icons
+  readonly FolderOpenIcon = FolderOpen;
+  readonly GitBranchIcon = GitBranch;
+
+  // Computed
+  protected readonly changeCount = computed(() => this.changedFiles().length);
+}

--- a/libs/frontend/editor/src/lib/source-control/source-control-file.component.ts
+++ b/libs/frontend/editor/src/lib/source-control/source-control-file.component.ts
@@ -1,0 +1,188 @@
+import {
+  Component,
+  input,
+  output,
+  computed,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+import {
+  LucideAngularModule,
+  Plus,
+  Minus,
+  Undo2,
+  FileEdit,
+  FilePlus,
+  FileMinus,
+  FileQuestion,
+  FileCode,
+} from 'lucide-angular';
+import type { GitFileStatus } from '@ptah-extension/shared';
+
+/**
+ * SourceControlFileComponent - Single file row in the source control panel.
+ *
+ * Complexity Level: 1 (Simple presentational component)
+ * Patterns: Standalone, OnPush, signal-based inputs/outputs
+ *
+ * Displays a file with:
+ * - Status icon with semantic color (M=warning, A=success, D=error, ??=info)
+ * - File name (bold) + parent directory (subdued)
+ * - Inline hover actions: stage/unstage, discard
+ * - Row click opens diff view
+ *
+ * TASK_2025_273
+ */
+@Component({
+  selector: 'ptah-source-control-file',
+  standalone: true,
+  imports: [LucideAngularModule],
+  template: `
+    <button
+      type="button"
+      class="group flex items-center gap-1.5 w-full px-2 py-0.5 text-left text-xs
+             hover:bg-base-content/10 transition-colors cursor-pointer"
+      role="listitem"
+      [title]="file().path"
+      (click)="openDiff.emit(file().path)"
+    >
+      <!-- Status icon -->
+      <lucide-angular
+        [img]="statusIcon()"
+        [class]="'w-3.5 h-3.5 flex-shrink-0 ' + statusColor()"
+        aria-hidden="true"
+      />
+
+      <!-- File name + parent dir -->
+      <span class="flex items-center gap-1 min-w-0 flex-1">
+        <span class="font-medium truncate">{{ fileName() }}</span>
+        @if (parentDir()) {
+          <span class="opacity-40 text-[10px] truncate">{{ parentDir() }}</span>
+        }
+      </span>
+
+      <!-- Inline actions (visible on hover) -->
+      <span
+        class="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+      >
+        @if (staged()) {
+          <!-- Unstage button -->
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs p-0.5 h-auto min-h-0"
+            title="Unstage"
+            aria-label="Unstage file"
+            (click)="onAction($event, 'unstage')"
+          >
+            <lucide-angular [img]="MinusIcon" class="w-3.5 h-3.5" />
+          </button>
+        } @else {
+          <!-- Stage button -->
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs p-0.5 h-auto min-h-0"
+            title="Stage"
+            aria-label="Stage file"
+            (click)="onAction($event, 'stage')"
+          >
+            <lucide-angular [img]="PlusIcon" class="w-3.5 h-3.5" />
+          </button>
+        }
+
+        <!-- Discard button -->
+        <button
+          type="button"
+          class="btn btn-ghost btn-xs p-0.5 h-auto min-h-0"
+          title="Discard changes"
+          aria-label="Discard changes"
+          (click)="onAction($event, 'discard')"
+        >
+          <lucide-angular [img]="Undo2Icon" class="w-3.5 h-3.5" />
+        </button>
+      </span>
+
+      <!-- Status badge -->
+      <span class="text-[10px] font-mono opacity-40 flex-shrink-0">{{
+        file().status
+      }}</span>
+    </button>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SourceControlFileComponent {
+  readonly file = input.required<GitFileStatus>();
+  readonly staged = input.required<boolean>();
+
+  readonly stage = output<string>();
+  readonly unstage = output<string>();
+  readonly discard = output<string>();
+  readonly openDiff = output<string>();
+  readonly openFile = output<string>();
+
+  // Icons
+  readonly PlusIcon = Plus;
+  readonly MinusIcon = Minus;
+  readonly Undo2Icon = Undo2;
+
+  protected readonly fileName = computed(() => {
+    const parts = this.file().path.replace(/\\/g, '/').split('/');
+    return parts.pop() ?? this.file().path;
+  });
+
+  protected readonly parentDir = computed(() => {
+    const parts = this.file().path.replace(/\\/g, '/').split('/');
+    if (parts.length > 1) {
+      parts.pop();
+      return parts.join('/');
+    }
+    return '';
+  });
+
+  protected readonly statusIcon = computed(() => {
+    switch (this.file().status) {
+      case 'M':
+        return FileEdit;
+      case 'A':
+        return FilePlus;
+      case 'D':
+        return FileMinus;
+      case '??':
+        return FileQuestion;
+      default:
+        return FileCode;
+    }
+  });
+
+  protected readonly statusColor = computed(() => {
+    switch (this.file().status) {
+      case 'M':
+        return 'text-warning';
+      case 'A':
+        return 'text-success';
+      case 'D':
+        return 'text-error';
+      case '??':
+        return 'text-info';
+      default:
+        return 'opacity-60';
+    }
+  });
+
+  protected onAction(
+    event: MouseEvent,
+    action: 'stage' | 'unstage' | 'discard',
+  ): void {
+    event.stopPropagation();
+    const path = this.file().path;
+    switch (action) {
+      case 'stage':
+        this.stage.emit(path);
+        break;
+      case 'unstage':
+        this.unstage.emit(path);
+        break;
+      case 'discard':
+        this.discard.emit(path);
+        break;
+    }
+  }
+}

--- a/libs/frontend/editor/src/lib/source-control/source-control-panel.component.ts
+++ b/libs/frontend/editor/src/lib/source-control/source-control-panel.component.ts
@@ -1,0 +1,250 @@
+import {
+  Component,
+  input,
+  output,
+  inject,
+  signal,
+  computed,
+  ChangeDetectionStrategy,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  LucideAngularModule,
+  Plus,
+  Minus,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-angular';
+import type { GitFileStatus } from '@ptah-extension/shared';
+import { SourceControlService } from '../services/source-control.service';
+import { SourceControlFileComponent } from './source-control-file.component';
+
+/**
+ * SourceControlPanelComponent - Main source control panel with commit UI and file groups.
+ *
+ * Complexity Level: 2 (Medium - service injection, computed signals, commit workflow)
+ * Patterns: Standalone, OnPush, signal-based, facade service delegation
+ *
+ * Layout (top to bottom):
+ * 1. Commit message textarea + commit button
+ * 2. Collapsible "Staged Changes (N)" section
+ * 3. Collapsible "Changes (N)" section
+ *
+ * After stage/unstage/discard/commit, the GitStatusService auto-refreshes
+ * via push events from the backend watcher (no manual refresh needed).
+ *
+ * TASK_2025_273
+ */
+@Component({
+  selector: 'ptah-source-control-panel',
+  standalone: true,
+  imports: [FormsModule, LucideAngularModule, SourceControlFileComponent],
+  template: `
+    <div
+      class="flex flex-col h-full overflow-y-auto scrollbar-thin"
+      role="region"
+      aria-label="Source Control"
+    >
+      <!-- Commit area -->
+      <div class="p-2 border-b border-base-300 flex-shrink-0">
+        <textarea
+          class="textarea textarea-bordered textarea-xs w-full resize-none"
+          rows="3"
+          placeholder="Commit message"
+          aria-label="Commit message"
+          [(ngModel)]="commitMessage"
+          [disabled]="isCommitting()"
+        ></textarea>
+        <button
+          class="btn btn-primary btn-xs w-full mt-1"
+          [disabled]="!canCommit"
+          (click)="onCommit()"
+        >
+          @if (isCommitting()) {
+            <span class="loading loading-spinner loading-xs"></span>
+            Committing...
+          } @else {
+            Commit ({{ stagedFiles().length }})
+          }
+        </button>
+      </div>
+
+      <!-- Staged Changes section -->
+      <div class="flex-shrink-0">
+        <button
+          type="button"
+          class="flex items-center gap-1 w-full px-2 py-1 text-[10px] font-semibold
+                 uppercase tracking-wider opacity-70 hover:opacity-100
+                 bg-base-200 transition-opacity cursor-pointer"
+          (click)="stagedExpanded.set(!stagedExpanded())"
+          aria-label="Toggle staged changes section"
+        >
+          <lucide-angular
+            [img]="stagedExpanded() ? ChevronDownIcon : ChevronRightIcon"
+            class="w-3 h-3 flex-shrink-0"
+          />
+          <span>Staged Changes ({{ stagedFiles().length }})</span>
+          @if (stagedFiles().length > 0) {
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs p-0.5 h-auto min-h-0 ml-auto"
+              title="Unstage all"
+              aria-label="Unstage all files"
+              (click)="onUnstageAll($event)"
+            >
+              <lucide-angular [img]="MinusIcon" class="w-3.5 h-3.5" />
+            </button>
+          }
+        </button>
+        @if (stagedExpanded()) {
+          <div role="list" aria-label="Staged files">
+            @for (file of stagedFiles(); track file.path) {
+              <ptah-source-control-file
+                [file]="file"
+                [staged]="true"
+                (unstage)="onUnstageFile($event)"
+                (discard)="onDiscardFile($event)"
+                (openDiff)="diffRequested.emit($event)"
+                (openFile)="fileClicked.emit($event)"
+              />
+            }
+            @if (stagedFiles().length === 0) {
+              <div class="px-3 py-2 text-[10px] opacity-40 text-center">
+                No staged changes
+              </div>
+            }
+          </div>
+        }
+      </div>
+
+      <!-- Unstaged Changes section -->
+      <div class="flex-shrink-0">
+        <button
+          type="button"
+          class="flex items-center gap-1 w-full px-2 py-1 text-[10px] font-semibold
+                 uppercase tracking-wider opacity-70 hover:opacity-100
+                 bg-base-200 transition-opacity cursor-pointer"
+          (click)="unstagedExpanded.set(!unstagedExpanded())"
+          aria-label="Toggle changes section"
+        >
+          <lucide-angular
+            [img]="unstagedExpanded() ? ChevronDownIcon : ChevronRightIcon"
+            class="w-3 h-3 flex-shrink-0"
+          />
+          <span>Changes ({{ unstagedFiles().length }})</span>
+          @if (unstagedFiles().length > 0) {
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs p-0.5 h-auto min-h-0 ml-auto"
+              title="Stage all"
+              aria-label="Stage all files"
+              (click)="onStageAll($event)"
+            >
+              <lucide-angular [img]="PlusIcon" class="w-3.5 h-3.5" />
+            </button>
+          }
+        </button>
+        @if (unstagedExpanded()) {
+          <div role="list" aria-label="Changed files">
+            @for (file of unstagedFiles(); track file.path) {
+              <ptah-source-control-file
+                [file]="file"
+                [staged]="false"
+                (stage)="onStageFile($event)"
+                (discard)="onDiscardFile($event)"
+                (openDiff)="diffRequested.emit($event)"
+                (openFile)="fileClicked.emit($event)"
+              />
+            }
+            @if (unstagedFiles().length === 0) {
+              <div class="px-3 py-2 text-[10px] opacity-40 text-center">
+                No changes
+              </div>
+            }
+          </div>
+        }
+      </div>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SourceControlPanelComponent {
+  private readonly sourceControl = inject(SourceControlService);
+
+  readonly files = input.required<GitFileStatus[]>();
+
+  readonly fileClicked = output<string>();
+  readonly diffRequested = output<string>();
+
+  // UI state
+  protected commitMessage = '';
+  protected readonly isCommitting = signal(false);
+  protected readonly stagedExpanded = signal(true);
+  protected readonly unstagedExpanded = signal(true);
+
+  // Icons
+  readonly PlusIcon = Plus;
+  readonly MinusIcon = Minus;
+  readonly ChevronDownIcon = ChevronDown;
+  readonly ChevronRightIcon = ChevronRight;
+
+  // Computed file groups
+  protected readonly stagedFiles = computed(() =>
+    this.files().filter((f) => f.staged),
+  );
+
+  protected readonly unstagedFiles = computed(() =>
+    this.files().filter((f) => !f.staged),
+  );
+
+  /**
+   * Whether the commit button should be enabled.
+   * Uses a getter instead of computed() because commitMessage is a plain string
+   * bound via ngModel (not a signal). The getter re-evaluates on each change
+   * detection cycle triggered by user input events.
+   */
+  protected get canCommit(): boolean {
+    return (
+      this.stagedFiles().length > 0 &&
+      this.commitMessage.trim().length > 0 &&
+      !this.isCommitting()
+    );
+  }
+
+  protected async onStageFile(path: string): Promise<void> {
+    await this.sourceControl.stageFile(path);
+  }
+
+  protected async onUnstageFile(path: string): Promise<void> {
+    await this.sourceControl.unstageFile(path);
+  }
+
+  protected async onDiscardFile(path: string): Promise<void> {
+    await this.sourceControl.discardChanges(path);
+  }
+
+  protected onStageAll(event: MouseEvent): void {
+    event.stopPropagation();
+    void this.sourceControl.stageAll();
+  }
+
+  protected onUnstageAll(event: MouseEvent): void {
+    event.stopPropagation();
+    void this.sourceControl.unstageAll();
+  }
+
+  protected async onCommit(): Promise<void> {
+    const message = this.commitMessage.trim();
+    if (!message || this.stagedFiles().length === 0) return;
+
+    this.isCommitting.set(true);
+
+    const result = await this.sourceControl.commit(message);
+
+    if (result.success) {
+      this.commitMessage = '';
+    }
+
+    this.isCommitting.set(false);
+  }
+}

--- a/libs/frontend/ui/src/lib/native/shared/floating-ui.service.ts
+++ b/libs/frontend/ui/src/lib/native/shared/floating-ui.service.ts
@@ -119,7 +119,7 @@ export class FloatingUIService {
   async position(
     referenceEl: HTMLElement,
     floatingEl: HTMLElement,
-    options: FloatingUIOptions = {}
+    options: FloatingUIOptions = {},
   ): Promise<void> {
     // Cleanup any existing auto-update listener
     this.cleanup();
@@ -169,7 +169,7 @@ export class FloatingUIService {
    */
   private applyPosition(floatingEl: HTMLElement, x: number, y: number): void {
     Object.assign(floatingEl.style, {
-      position: 'absolute',
+      position: 'fixed',
       left: `${x}px`,
       top: `${y}px`,
       // Ensure visibility after positioning to prevent flash at 0,0

--- a/libs/shared/src/lib/types/rpc.types.ts
+++ b/libs/shared/src/lib/types/rpc.types.ts
@@ -199,6 +199,16 @@ import type {
   GitAddWorktreeResult,
   GitRemoveWorktreeParams,
   GitRemoveWorktreeResult,
+  GitStageParams,
+  GitStageResult,
+  GitUnstageParams,
+  GitUnstageResult,
+  GitDiscardParams,
+  GitDiscardResult,
+  GitCommitParams,
+  GitCommitResult,
+  GitShowFileParams,
+  GitShowFileResult,
 } from './rpc/rpc-git.types';
 
 import type {
@@ -894,6 +904,12 @@ export interface RpcMethodRegistry {
     params: GitRemoveWorktreeParams;
     result: GitRemoveWorktreeResult;
   };
+  // Source control methods (TASK_2025_273)
+  'git:stage': { params: GitStageParams; result: GitStageResult };
+  'git:unstage': { params: GitUnstageParams; result: GitUnstageResult };
+  'git:discard': { params: GitDiscardParams; result: GitDiscardResult };
+  'git:commit': { params: GitCommitParams; result: GitCommitResult };
+  'git:showFile': { params: GitShowFileParams; result: GitShowFileResult };
 
   // ---- Terminal Methods (TASK_2025_227) ----
   'terminal:create': {
@@ -1110,6 +1126,12 @@ export const RPC_METHOD_NAMES: RpcMethodName[] = [
   'git:worktrees',
   'git:addWorktree',
   'git:removeWorktree',
+  // Source control methods (TASK_2025_273)
+  'git:stage',
+  'git:unstage',
+  'git:discard',
+  'git:commit',
+  'git:showFile',
 
   // Terminal Methods (TASK_2025_227)
   'terminal:create',

--- a/libs/shared/src/lib/types/rpc/rpc-git.types.ts
+++ b/libs/shared/src/lib/types/rpc/rpc-git.types.ts
@@ -112,3 +112,71 @@ export interface GitWorktreeChangedNotification {
   /** Worktree path (for removed, or the created path if available) */
   path?: string;
 }
+
+// ============================================================================
+// Source Control RPC Types (TASK_2025_273)
+// ============================================================================
+
+/** Parameters for git:stage RPC method */
+export interface GitStageParams {
+  /** File paths to stage (relative to workspace root) */
+  paths: string[];
+}
+
+/** Result from git:stage RPC method */
+export interface GitStageResult {
+  success: boolean;
+  error?: string;
+}
+
+/** Parameters for git:unstage RPC method */
+export interface GitUnstageParams {
+  /** File paths to unstage (relative to workspace root) */
+  paths: string[];
+}
+
+/** Result from git:unstage RPC method */
+export interface GitUnstageResult {
+  success: boolean;
+  error?: string;
+}
+
+/** Parameters for git:discard RPC method */
+export interface GitDiscardParams {
+  /** File paths to discard changes for (relative to workspace root) */
+  paths: string[];
+}
+
+/** Result from git:discard RPC method */
+export interface GitDiscardResult {
+  success: boolean;
+  error?: string;
+}
+
+/** Parameters for git:commit RPC method */
+export interface GitCommitParams {
+  /** Commit message */
+  message: string;
+}
+
+/** Result from git:commit RPC method */
+export interface GitCommitResult {
+  success: boolean;
+  /** Abbreviated commit hash on success */
+  commitHash?: string;
+  error?: string;
+}
+
+/** Parameters for git:showFile RPC method */
+export interface GitShowFileParams {
+  /** Relative file path from workspace root */
+  path: string;
+}
+
+/** Result from git:showFile RPC method */
+export interface GitShowFileResult {
+  /** File content from HEAD (empty string for new/untracked files) */
+  content: string;
+  /** Whether the file is binary */
+  isBinary?: boolean;
+}


### PR DESCRIPTION
- Fix subagent model proxy and translation issues in agent-sdk
- Make file path links platform-aware: Electron opens files in Monaco editor via EditorService instead of broken file:open RPC
- Add git info service and git RPC handlers for Electron
- Add diff view, source control panel, and sidebar to editor library
- Add download page and GitHub release service to landing page
- Fix unused import lint error in download-page component
- Enhance chat view, input, session loader, and conversation services