### PR TITLE
fix(ci): preserve esbuild outExtension and banner in prod config

### DIFF
--- a/apps/ptah-electron/project.json
+++ b/apps/ptah-electron/project.json
@@ -102,6 +102,12 @@
           "sourcemap": false,
           "minify": true,
           "esbuildOptions": {
+            "outExtension": {
+              ".js": ".mjs"
+            },
+            "banner": {
+              "js": "import { createRequire } from 'module'; const require = createRequire(import.meta.url);"
+            },
             "define": {
               "__SENTRY_DSN__": "\"https://f443ca20f86dff7c57cbf370e0f790e6@o4511123313393664.ingest.de.sentry.io/4511142057738320\""
             }
@@ -111,6 +117,12 @@
           "sourcemap": true,
           "minify": false,
           "esbuildOptions": {
+            "outExtension": {
+              ".js": ".mjs"
+            },
+            "banner": {
+              "js": "import { createRequire } from 'module'; const require = createRequire(import.meta.url);"
+            },
             "define": {
               "__SENTRY_DSN__": "\"\""
             }

--- a/apps/ptah-extension-vscode/project.json
+++ b/apps/ptah-extension-vscode/project.json
@@ -51,6 +51,12 @@
           "sourcemap": true,
           "minify": false,
           "esbuildOptions": {
+            "outExtension": {
+              ".js": ".mjs"
+            },
+            "banner": {
+              "js": "import { createRequire } from 'module'; const require = createRequire(import.meta.url);"
+            },
             "define": {
               "__SENTRY_DSN__": "\"\""
             }
@@ -60,6 +66,12 @@
           "sourcemap": false,
           "minify": true,
           "esbuildOptions": {
+            "outExtension": {
+              ".js": ".mjs"
+            },
+            "banner": {
+              "js": "import { createRequire } from 'module'; const require = createRequire(import.meta.url);"
+            },
             "define": {
               "__SENTRY_DSN__": "\"https://f443ca20f86dff7c57cbf370e0f790e6@o4511123313393664.ingest.de.sentry.io/4511142057738320\""
             }


### PR DESCRIPTION
Nx shallow-merges configuration options on top of base options. When f7b143b4 added esbuildOptions.define to each configuration to inject the Sentry DSN, the nested esbuildOptions object fully replaced the base esbuildOptions — dropping outExtension {.js:.mjs} and the createRequire banner. esbuild fell back to writing main.js with no ESM banner, so vsce could not find extension/main.mjs and electron-builder could not find main.mjs in the asar. Inline outExtension and banner alongside define in each configuration for both apps.