### PR TITLE
chore(release): extension v0.2.28

### DIFF
--- a/apps/ptah-extension-vscode/package.json
+++ b/apps/ptah-extension-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ptah-coding-orchestra",
   "displayName": "Ptah - The Coding Orchestra",
   "description": "The AI coding orchestra for VS Code. Provider-agnostic AI orchestration with intelligent workspace analysis, Code Execution MCP server, and project-adaptive multi-agent workflows.",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "publisher": "ptah-extensions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Auto-generated version bump after publishing extension v0.2.28 to VS Code Marketplace.