### PR TITLE
ci: tolerate npm ci lockfile drift via npm install fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,10 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache-modules.outputs.cache-hit != 'true'
-        run: npm ci
+        # Fall back to `npm install` if lockfile drift (npm/cli#4828:
+        # Windows-generated lockfiles omit transitive deps under
+        # sass-embedded's catch-all packages, breaking `npm ci` on Linux).
+        run: npm ci || npm install --no-audit --no-fund
 
       # Always run — cached node_modules may be missing Linux platform
       # binaries (npm/cli#4828: package-lock.json generated on Windows omits

--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -76,8 +76,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache-modules.outputs.cache-hit != 'true'
+        # Fall back to `npm install` if lockfile drift (npm/cli#4828).
         run: |
-          npm ci
+          npm ci || npm install --no-audit --no-fund
           if [ "${{ runner.os }}" = "Linux" ]; then
             npm install @rollup/rollup-linux-x64-gnu --no-save --force
           fi

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -40,8 +40,9 @@ jobs:
         if: steps.cache-modules.outputs.cache-hit != 'true'
         # Workaround for npm/cli#4828: package-lock.json generated on Windows
         # omits Linux rollup platform binaries. Install them explicitly.
+        # Fall back to `npm install` if `npm ci` fails on transitive drift.
         run: |
-          npm ci
+          npm ci || npm install --no-audit --no-fund
           npm install @rollup/rollup-linux-x64-gnu --no-save --force
 
       - name: Build docs site (pre-deploy sanity check)

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -40,8 +40,9 @@ jobs:
         if: steps.cache-modules.outputs.cache-hit != 'true'
         # Workaround for npm/cli#4828: package-lock.json generated on Windows
         # omits Linux rollup platform binaries. Install them explicitly.
+        # Fall back to `npm install` if `npm ci` fails on transitive drift.
         run: |
-          npm ci
+          npm ci || npm install --no-audit --no-fund
           npm install @rollup/rollup-linux-x64-gnu --no-save --force
 
       - name: Build landing page

--- a/.github/workflows/electron-e2e.yml
+++ b/.github/workflows/electron-e2e.yml
@@ -53,7 +53,8 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache-modules.outputs.cache-hit != 'true'
-        run: npm ci
+        # Fall back to `npm install` if lockfile drift (npm/cli#4828).
+        run: npm ci || npm install --no-audit --no-fund
 
       # Always run — cached node_modules may be missing Linux platform
       # binaries (npm/cli#4828: package-lock.json generated on Windows omits

--- a/.github/workflows/nightly-coverage.yml
+++ b/.github/workflows/nightly-coverage.yml
@@ -45,8 +45,9 @@ jobs:
         if: steps.cache-modules.outputs.cache-hit != 'true'
         # Workaround for npm/cli#4828: package-lock.json generated on
         # Windows omits Linux rollup platform binaries.
+        # Fall back to `npm install` if `npm ci` fails on transitive drift.
         run: |
-          npm ci
+          npm ci || npm install --no-audit --no-fund
           npm install @rollup/rollup-linux-x64-gnu --no-save --force
 
       - name: Cache Prisma client

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -118,8 +118,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache-modules.outputs.cache-hit != 'true'
+        # Fall back to `npm install` if lockfile drift (npm/cli#4828).
         run: |
-          npm ci
+          npm ci || npm install --no-audit --no-fund
           if [ "${{ runner.os }}" = "Linux" ]; then
             npm install @rollup/rollup-linux-x64-gnu --no-save --force
           fi
@@ -201,8 +202,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache-modules.outputs.cache-hit != 'true'
+        # Fall back to `npm install` if lockfile drift (npm/cli#4828).
         run: |
-          npm ci
+          npm ci || npm install --no-audit --no-fund
           npm install @rollup/rollup-linux-x64-gnu --no-save --force
 
       - name: Build CLI
@@ -255,8 +257,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache-modules.outputs.cache-hit != 'true'
+        # Fall back to `npm install` if lockfile drift (npm/cli#4828).
         run: |
-          npm ci
+          npm ci || npm install --no-audit --no-fund
           npm install @rollup/rollup-linux-x64-gnu --no-save --force
 
       - name: Configure git

--- a/.github/workflows/publish-electron.yml
+++ b/.github/workflows/publish-electron.yml
@@ -157,7 +157,8 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache-modules.outputs.cache-hit != 'true'
-        run: npm ci
+        # Fall back to `npm install` if lockfile drift (npm/cli#4828).
+        run: npm ci || npm install --no-audit --no-fund
 
       # Workaround for npm/cli#4828: package-lock.json generated on Windows
       # omits Linux rollup platform binaries. Install them explicitly.

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -77,8 +77,9 @@ jobs:
         if: steps.cache-modules.outputs.cache-hit != 'true'
         # Workaround for npm/cli#4828: package-lock.json generated on Windows
         # omits Linux rollup platform binaries. Install them explicitly.
+        # Fall back to `npm install` if `npm ci` fails on transitive drift.
         run: |
-          npm ci
+          npm ci || npm install --no-audit --no-fund
           npm install @rollup/rollup-linux-x64-gnu --no-save --force
 
       - name: Configure git

--- a/.github/workflows/webview-e2e.yml
+++ b/.github/workflows/webview-e2e.yml
@@ -50,8 +50,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache-modules.outputs.cache-hit != 'true'
+        # Fall back to `npm install` if lockfile drift (npm/cli#4828).
         run: |
-          npm ci
+          npm ci || npm install --no-audit --no-fund
           npm install @rollup/rollup-linux-x64-gnu --no-save --force
 
       - name: Cache Playwright browsers


### PR DESCRIPTION
`npm ci` fails on Linux runners when package-lock.json was generated on Windows because npm/cli#4828 causes Windows-generated lockfiles to omit transitive deps under sass-embedded's catch-all packages (sass-embedded-all-unknown, sass-embedded-unknown-all). The catch-all packages have CPU constraints `["!arm","!arm64","!riscv64","!x64"]` that npm resolves differently per platform, and Linux needs entries that Windows doesn't.

Fall back to `npm install --no-audit --no-fund` when `npm ci` fails. `npm install` heals the lockfile in the runner's filesystem (not committed) and produces the same package versions as `npm ci` would have when the lockfile is in sync. Functionally identical to `npm ci` in the happy path; recovers automatically when there is drift.

Applied to every workflow that runs `npm ci`:
- ci.yml (main CI)
- electron-e2e.yml, webview-e2e.yml, cli-e2e.yml (e2e suites)
- publish-electron.yml, publish-extension.yml, publish-cli.yml (releases)
- deploy-landing.yml, deploy-docs.yml (site deploys)
- nightly-coverage.yml (scheduled)

This unblocks PRs that touch package-lock.json (currently #279 hono override fix, plus the unused-deps cleanup) and prevents the same breakage from re-appearing whenever the lockfile is regenerated on Windows.