### PR TITLE
fix(ci): publish bump script handles prerelease versions safely

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -272,8 +272,16 @@ jobs:
         run: |
           OLD_VERSION=$(node -p "require('./apps/ptah-cli/package.json').version")
           BUMP_TYPE="${{ github.event.inputs.bump || 'patch' }}"
+          # Strip any prerelease / build suffix before parsing so versions
+          # like "1.2.3-rc.1" or "1.2.3+build" never produce NaN segments.
           NEW_VERSION=$(node -e "
-            const [major, minor, patch] = '${OLD_VERSION}'.split('.').map(Number);
+            const base = '${OLD_VERSION}'.split(/[-+]/)[0];
+            const parts = base.split('.').map(Number);
+            if (parts.length !== 3 || parts.some(Number.isNaN)) {
+              console.error('Invalid base version: ${OLD_VERSION} -> ' + base);
+              process.exit(1);
+            }
+            const [major, minor, patch] = parts;
             const bump = '${BUMP_TYPE}';
             if (bump === 'major') console.log(\`\${major+1}.0.0\`);
             else if (bump === 'minor') console.log(\`\${major}.\${minor+1}.0\`);

--- a/.github/workflows/publish-electron.yml
+++ b/.github/workflows/publish-electron.yml
@@ -75,8 +75,16 @@ jobs:
           BUMP_TYPE="${{ github.event.inputs.bump || 'patch' }}"
           OLD_VERSION=$(node -p "require('./apps/ptah-electron/package.json').version")
 
+          # Strip any prerelease / build suffix before parsing so versions
+          # like "1.2.3-rc.1" or "1.2.3+build" never produce NaN segments.
           NEW_VERSION=$(node -e "
-            const [major, minor, patch] = '${OLD_VERSION}'.split('.').map(Number);
+            const base = '${OLD_VERSION}'.split(/[-+]/)[0];
+            const parts = base.split('.').map(Number);
+            if (parts.length !== 3 || parts.some(Number.isNaN)) {
+              console.error('Invalid base version: ${OLD_VERSION} -> ' + base);
+              process.exit(1);
+            }
+            const [major, minor, patch] = parts;
             const bump = '${BUMP_TYPE}';
             if (bump === 'major') console.log(\`\${major+1}.0.0\`);
             else if (bump === 'minor') console.log(\`\${major}.\${minor+1}.0\`);

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -94,8 +94,18 @@ jobs:
           BUMP_TYPE="${{ github.event.inputs.bump || 'patch' }}"
           OLD_VERSION=$(node -p "require('./package.json').version")
 
+          # Strip any prerelease / build suffix (e.g. "0.2.31-debug.4" -> "0.2.31")
+          # before parsing — the naive `.split('.').map(Number)` would otherwise
+          # turn "31-debug" into NaN and produce an invalid "0.2.NaN" version
+          # that vsce rejects at package time.
           NEW_VERSION=$(node -e "
-            const [major, minor, patch] = '${OLD_VERSION}'.split('.').map(Number);
+            const base = '${OLD_VERSION}'.split(/[-+]/)[0];
+            const parts = base.split('.').map(Number);
+            if (parts.length !== 3 || parts.some(Number.isNaN)) {
+              console.error('Invalid base version: ${OLD_VERSION} -> ' + base);
+              process.exit(1);
+            }
+            const [major, minor, patch] = parts;
             const bump = '${BUMP_TYPE}';
             if (bump === 'major') console.log(\`\${major+1}.0.0\`);
             else if (bump === 'minor') console.log(\`\${major}.\${minor+1}.0\`);

--- a/apps/ptah-extension-vscode/package.json
+++ b/apps/ptah-extension-vscode/package.json
@@ -2,7 +2,7 @@
   "name": "ptah-coding-orchestra",
   "displayName": "Ptah - The Coding Orchestra",
   "description": "The AI coding orchestra for VS Code. Provider-agnostic AI orchestration with intelligent workspace analysis, Code Execution MCP server, and project-adaptive multi-agent workflows.",
-  "version": "0.2.31-debug.4",
+  "version": "0.2.31",
   "publisher": "ptah-extensions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The publish-extension workflow failed packaging the VSIX with 'Invalid extension "version": "0.2.NaN"' because the version in apps/ptah-extension-vscode/package.json was left at 0.2.31-debug.4 (set by cb501d5f when wiring the e2e suite) and the bump script naively did:

  const [major, minor, patch] = OLD.split('.').map(Number);

For "0.2.31-debug.4" that produces [0, 2, NaN, 4], patch+1 is NaN, and the next version is "0.2.NaN" — which vsce rejects at package time. publish-cli.yml and publish-electron.yml have the same script and would fail the same way the moment a prerelease tag lands in their package.json.

- Reset extension version to a clean stable semver (0.2.31) so the next patch publish lands on 0.2.32.
- Strip any prerelease ('-X') or build ('+X') suffix before parsing in all three publish workflows, and fail fast with a clear error if the base still doesn't parse as three numeric segments.