### PR TITLE
fix(ci): disable NSIS packElevateHelper to fix --prepackaged repack

### DIFF
--- a/apps/ptah-electron/electron-builder.yml
+++ b/apps/ptah-electron/electron-builder.yml
@@ -149,6 +149,13 @@ linux:
 nsis:
   oneClick: false
   allowToChangeInstallationDirectory: true
+  # packElevateHelper copies elevate.exe into resources/ during NSIS packaging.
+  # Under the signed-app repack (electron-builder --prepackaged), that copy
+  # fails with "ENOENT ... elevate.exe" (electron-builder#7518). The elevate
+  # UAC helper is only needed for per-machine installs / electron-updater; Ptah
+  # ships a per-user installer (perMachine=false, %LOCALAPPDATA%) and updates via
+  # the GitHub Releases API, not electron-updater — so it is safe to drop.
+  packElevateHelper: false
 
 publish:
   provider: github


### PR DESCRIPTION
Building the NSIS installer from the signed win-unpacked dir (electron-builder --prepackaged) failed with "ENOENT ... copyfile elevate.exe -> win-unpacked/resources/elevate.exe". packElevateHelper (default true) copies the elevate UAC helper into resources, and that copy is broken under --prepackaged (electron-builder#7518).

The elevate helper is only needed for per-machine installs / electron-updater. Ptah ships a per-user installer (perMachine=false, installs to %LOCALAPPDATA%) and updates via the GitHub Releases API, so the helper is unnecessary and safe to drop.