### PR TITLE
feat(webview): keep background-workspace sessions streaming after switch

### DIFF
--- a/libs/backend/rpc-handlers/src/lib/chat/streaming/chat-stream-broadcaster.service.spec.ts
+++ b/libs/backend/rpc-handlers/src/lib/chat/streaming/chat-stream-broadcaster.service.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * ChatStreamBroadcaster — in-flight streaming tracking specs.
+ *
+ * Surface under test: the `streamingSessionIds` Set lifecycle exposed via
+ * `isStreaming(sessionId)`. Contract locked here:
+ *   - sessionId is present WHILE the stream loop is running.
+ *   - sessionId is removed after NORMAL completion.
+ *   - sessionId is removed after an ERROR thrown by the stream.
+ *   - sessionId is removed after a USER ABORT (abort-tagged error).
+ *
+ * Mocking posture: direct constructor injection, narrow jest.Mocked
+ * surfaces, no `as any` casts. The streaming loop is driven by a
+ * hand-rolled async iterable so the test can observe `isStreaming` mid-flight.
+ */
+
+import 'reflect-metadata';
+
+import type {
+  Logger,
+  SubagentRegistryService,
+  SentryService,
+} from '@ptah-extension/vscode-core';
+import type { IWorkspaceProvider } from '@ptah-extension/platform-core';
+import type { SessionMetadataStore } from '@ptah-extension/agent-sdk';
+import type {
+  IAgentAdapter,
+  SessionId,
+  FlatStreamEventUnion,
+} from '@ptah-extension/shared';
+
+import {
+  ChatStreamBroadcaster,
+  type WebviewManager,
+} from './chat-stream-broadcaster.service';
+import type { ChatPtahCliService } from '../ptah-cli/chat-ptah-cli.service';
+
+const SESSION_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee' as SessionId;
+const TAB_ID = 'tab-1';
+
+function createMockLogger(): jest.Mocked<
+  Pick<Logger, 'info' | 'debug' | 'warn' | 'error'>
+> {
+  return {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+}
+
+interface Harness {
+  broadcaster: ChatStreamBroadcaster;
+  sdkAdapter: jest.Mocked<
+    Pick<IAgentAdapter, 'isSessionActive' | 'endSession'>
+  >;
+  ptahCli: jest.Mocked<
+    Pick<
+      ChatPtahCliService,
+      'hasSession' | 'deleteSession' | 'getAgentId' | 'setSdkSessionId'
+    >
+  >;
+}
+
+function makeHarness(): Harness {
+  const logger = createMockLogger();
+  const webviewManager: jest.Mocked<WebviewManager> = {
+    sendMessage: jest.fn().mockResolvedValue(undefined),
+    broadcastMessage: jest.fn().mockResolvedValue(undefined),
+  };
+  const sdkAdapter = {
+    isSessionActive: jest.fn().mockReturnValue(false),
+    endSession: jest.fn().mockResolvedValue(undefined),
+  } as jest.Mocked<Pick<IAgentAdapter, 'isSessionActive' | 'endSession'>>;
+  const subagentRegistry = {
+    update: jest.fn(),
+  } as unknown as SubagentRegistryService;
+  const sentryService = {
+    captureException: jest.fn(),
+  } as unknown as SentryService;
+  const sessionMetadataStore = {
+    createChild: jest.fn().mockResolvedValue(undefined),
+  } as unknown as SessionMetadataStore;
+  const workspaceProvider = {
+    getWorkspaceRoot: jest.fn().mockReturnValue('/fake/workspace'),
+  } as unknown as IWorkspaceProvider;
+  const ptahCli = {
+    hasSession: jest.fn().mockReturnValue(false),
+    deleteSession: jest.fn(),
+    getAgentId: jest.fn().mockReturnValue(undefined),
+    setSdkSessionId: jest.fn(),
+  } as jest.Mocked<
+    Pick<
+      ChatPtahCliService,
+      'hasSession' | 'deleteSession' | 'getAgentId' | 'setSdkSessionId'
+    >
+  >;
+
+  const broadcaster = new ChatStreamBroadcaster(
+    logger as unknown as Logger,
+    webviewManager,
+    sdkAdapter as unknown as IAgentAdapter,
+    subagentRegistry,
+    sentryService,
+    sessionMetadataStore,
+    workspaceProvider,
+    ptahCli as unknown as ChatPtahCliService,
+  );
+
+  return { broadcaster, sdkAdapter, ptahCli };
+}
+
+function makeEvent(eventType: string): FlatStreamEventUnion {
+  return {
+    eventType,
+    sessionId: SESSION_ID,
+    messageId: 'msg-1',
+  } as unknown as FlatStreamEventUnion;
+}
+
+describe('ChatStreamBroadcaster.isStreaming', () => {
+  it('marks the session streaming WHILE the loop runs and clears it after NORMAL completion', async () => {
+    const h = makeHarness();
+    let observedMidStream = false;
+
+    async function* stream(): AsyncGenerator<FlatStreamEventUnion> {
+      observedMidStream = h.broadcaster.isStreaming(SESSION_ID as string);
+      yield makeEvent('message_complete');
+    }
+
+    expect(h.broadcaster.isStreaming(SESSION_ID as string)).toBe(false);
+    await h.broadcaster.streamEventsToWebview(SESSION_ID, stream(), TAB_ID);
+
+    expect(observedMidStream).toBe(true);
+    expect(h.broadcaster.isStreaming(SESSION_ID as string)).toBe(false);
+  });
+
+  it('clears the session after the stream throws a generic ERROR', async () => {
+    const h = makeHarness();
+
+    async function* stream(): AsyncGenerator<FlatStreamEventUnion> {
+      yield makeEvent('message_start');
+      throw new Error('stream exploded');
+    }
+
+    await h.broadcaster.streamEventsToWebview(SESSION_ID, stream(), TAB_ID);
+
+    expect(h.broadcaster.isStreaming(SESSION_ID as string)).toBe(false);
+  });
+
+  it('clears the session after a USER ABORT (abort-tagged error)', async () => {
+    const h = makeHarness();
+
+    async function* stream(): AsyncGenerator<FlatStreamEventUnion> {
+      yield makeEvent('message_start');
+      throw new Error('Request aborted by user');
+    }
+
+    await h.broadcaster.streamEventsToWebview(SESSION_ID, stream(), TAB_ID);
+
+    expect(h.broadcaster.isStreaming(SESSION_ID as string)).toBe(false);
+  });
+
+  it('returns false for an unknown session', () => {
+    const h = makeHarness();
+    expect(h.broadcaster.isStreaming('never-streamed')).toBe(false);
+  });
+});

--- a/libs/backend/rpc-handlers/src/lib/chat/streaming/chat-stream-broadcaster.service.ts
+++ b/libs/backend/rpc-handlers/src/lib/chat/streaming/chat-stream-broadcaster.service.ts
@@ -61,6 +61,12 @@ export class ChatStreamBroadcaster {
     private readonly ptahCli: ChatPtahCliService,
   ) {}
 
+  private readonly streamingSessionIds = new Set<string>();
+
+  isStreaming(sessionId: string): boolean {
+    return this.streamingSessionIds.has(sessionId);
+  }
+
   /**
    * Stream flat events to webview
    * Handles SDK AsyncIterable<FlatStreamEventUnion> → webview messages.
@@ -86,6 +92,7 @@ export class ChatStreamBroadcaster {
     const isPtahCliSession = this.ptahCli.hasSession(tabId);
     let streamExitedNormally = false;
 
+    this.streamingSessionIds.add(sessionId as string);
     try {
       for await (const event of stream) {
         eventCount++;
@@ -221,6 +228,7 @@ export class ChatStreamBroadcaster {
         });
       }
     } finally {
+      this.streamingSessionIds.delete(sessionId as string);
       this.ptahCli.deleteSession(sessionId as string);
       this.ptahCli.deleteSession(tabId);
       if (streamExitedNormally && this.sdkAdapter.isSessionActive(sessionId)) {

--- a/libs/backend/rpc-handlers/src/lib/handlers/session-rpc.handlers.spec.ts
+++ b/libs/backend/rpc-handlers/src/lib/handlers/session-rpc.handlers.spec.ts
@@ -128,6 +128,16 @@ function createMockChatSession(): MockChatSession {
   };
 }
 
+type MockStreamBroadcaster = {
+  isStreaming: jest.Mock<boolean, [string]>;
+};
+
+function createMockStreamBroadcaster(): MockStreamBroadcaster {
+  return {
+    isStreaming: jest.fn<boolean, [string]>().mockReturnValue(false),
+  };
+}
+
 /** Factory for minimal metadata fixtures — only fields the handler reads. */
 interface MetadataFixture {
   sessionId: string;
@@ -187,6 +197,7 @@ interface Harness {
   sentry: MockSentryService;
   sdkAdapter: MockSdkAdapter;
   chatSession: MockChatSession;
+  streamBroadcaster: MockStreamBroadcaster;
 }
 
 function makeHarness(opts: { workspaceFolders?: string[] } = {}): Harness {
@@ -200,6 +211,7 @@ function makeHarness(opts: { workspaceFolders?: string[] } = {}): Harness {
   const sentry = createMockSentryService();
   const sdkAdapter = createMockSdkAdapter();
   const chatSession = createMockChatSession();
+  const streamBroadcaster = createMockStreamBroadcaster();
 
   const handlers = new SessionRpcHandlers(
     logger as unknown as Logger,
@@ -210,6 +222,7 @@ function makeHarness(opts: { workspaceFolders?: string[] } = {}): Harness {
     workspace as unknown as IWorkspaceProvider,
     sdkAdapter as unknown as SdkAgentAdapter,
     chatSession as never,
+    streamBroadcaster as never,
   );
 
   return {
@@ -222,6 +235,7 @@ function makeHarness(opts: { workspaceFolders?: string[] } = {}): Harness {
     sentry,
     sdkAdapter,
     chatSession,
+    streamBroadcaster,
   };
 }
 
@@ -278,6 +292,7 @@ describe('SessionRpcHandlers', () => {
           'session:rename',
           'session:rewindFiles',
           'session:stats-batch',
+          'session:status',
           'session:validate',
         ].sort(),
       );
@@ -1690,6 +1705,76 @@ describe('SessionRpcHandlers', () => {
 
       expect(response.success).toBe(false);
       expect(response.error).toMatch(/unauthorized-path-rewrite/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // session:status
+  // -------------------------------------------------------------------------
+
+  describe('session:status', () => {
+    it('reports active + streaming when both sources are true', async () => {
+      const h = makeHarness();
+      h.sdkAdapter.isSessionActive.mockReturnValue(true);
+      h.streamBroadcaster.isStreaming.mockReturnValue(true);
+      h.handlers.register();
+
+      const result = await call<{ isActive: boolean; isStreaming: boolean }>(
+        h,
+        'session:status',
+        { sessionId: VALID_SESSION_ID },
+      );
+
+      expect(result).toEqual({ isActive: true, isStreaming: true });
+      expect(h.sdkAdapter.isSessionActive).toHaveBeenCalled();
+      expect(h.streamBroadcaster.isStreaming).toHaveBeenCalledWith(
+        VALID_SESSION_ID,
+      );
+    });
+
+    it('reports active + idle when the session is alive but not streaming', async () => {
+      const h = makeHarness();
+      h.sdkAdapter.isSessionActive.mockReturnValue(true);
+      h.streamBroadcaster.isStreaming.mockReturnValue(false);
+      h.handlers.register();
+
+      const result = await call<{ isActive: boolean; isStreaming: boolean }>(
+        h,
+        'session:status',
+        { sessionId: VALID_SESSION_ID },
+      );
+
+      expect(result).toEqual({ isActive: true, isStreaming: false });
+    });
+
+    it('reports inactive when the session is not in the lifecycle registry', async () => {
+      const h = makeHarness();
+      h.sdkAdapter.isSessionActive.mockReturnValue(false);
+      h.streamBroadcaster.isStreaming.mockReturnValue(false);
+      h.handlers.register();
+
+      const result = await call<{ isActive: boolean; isStreaming: boolean }>(
+        h,
+        'session:status',
+        { sessionId: VALID_SESSION_ID },
+      );
+
+      expect(result).toEqual({ isActive: false, isStreaming: false });
+    });
+
+    it('rejects a missing sessionId at the Zod boundary (degrades to false/false)', async () => {
+      const h = makeHarness();
+      h.handlers.register();
+
+      const result = await call<{ isActive: boolean; isStreaming: boolean }>(
+        h,
+        'session:status',
+        {},
+      );
+
+      expect(result).toEqual({ isActive: false, isStreaming: false });
+      expect(h.sdkAdapter.isSessionActive).not.toHaveBeenCalled();
+      expect(h.sentry.captureException).toHaveBeenCalled();
     });
   });
 

--- a/libs/backend/rpc-handlers/src/lib/handlers/session-rpc.handlers.ts
+++ b/libs/backend/rpc-handlers/src/lib/handlers/session-rpc.handlers.ts
@@ -54,6 +54,11 @@ import { isAuthorizedWorkspace } from '../utils/workspace-authorization';
 import { z } from 'zod';
 import { CHAT_TOKENS } from '../chat/tokens';
 import type { ChatSessionService } from '../chat/session/chat-session.service';
+import type { ChatStreamBroadcaster } from '../chat/streaming/chat-stream-broadcaster.service';
+import type {
+  SessionStatusParams,
+  SessionStatusResponse,
+} from '@ptah-extension/shared';
 
 /**
  * Minimal schema for JSONL first-line entries in agent session files.
@@ -62,6 +67,15 @@ import type { ChatSessionService } from '../chat/session/chat-session.service';
  */
 export const AgentJsonlFirstLineSchema = z.object({
   sessionId: z.string(),
+});
+
+/**
+ * Boundary schema for `session:status` params. A cold-loaded webview asks
+ * the backend whether a restored session is still alive / mid-stream, so
+ * `sessionId` is the only required field.
+ */
+export const SessionStatusParamsSchema = z.object({
+  sessionId: z.string().min(1),
 });
 
 /**
@@ -84,6 +98,7 @@ export class SessionRpcHandlers {
     'session:stats-batch',
     'session:forkSession',
     'session:rewindFiles',
+    'session:status',
   ] as const satisfies readonly RpcMethodName[];
 
   constructor(
@@ -101,6 +116,8 @@ export class SessionRpcHandlers {
     private readonly sdkAdapter: SdkAgentAdapter,
     @inject(CHAT_TOKENS.SESSION)
     private readonly chatSession: ChatSessionService,
+    @inject(CHAT_TOKENS.STREAM_BROADCASTER)
+    private readonly streamBroadcaster: ChatStreamBroadcaster,
   ) {}
 
   /**
@@ -212,6 +229,7 @@ export class SessionRpcHandlers {
     this.registerSessionStatsBatch();
     this.registerForkSession();
     this.registerRewindFiles();
+    this.registerSessionStatus();
 
     this.logger.debug('Session RPC handlers registered', {
       methods: [
@@ -224,6 +242,7 @@ export class SessionRpcHandlers {
         'session:stats-batch',
         'session:forkSession',
         'session:rewindFiles',
+        'session:status',
       ],
     });
   }
@@ -1013,6 +1032,45 @@ export class SessionRpcHandlers {
             errorSource: 'SessionRpcHandlers.registerRewindFiles',
           });
           throw new Error(`Failed to rewind files: ${errorObj.message}`);
+        }
+      },
+    );
+  }
+
+  /**
+   * session:status - Read-only liveness probe for a restored session.
+   *
+   * A freshly cold-loaded webview (VS Code recreates the webview when its
+   * panel is hidden→reshown; HMR/devtools reload) cannot observe in-flight
+   * streaming state. This returns both whether the session process is alive
+   * (`isActive`, from the SDK lifecycle registry) and whether a turn is
+   * actively streaming right now (`isStreaming`, from the broadcaster's
+   * in-flight set). Unexpected errors degrade to `{ false, false }` rather
+   * than leaking raw error text to the client.
+   */
+  private registerSessionStatus(): void {
+    this.rpcHandler.registerMethod<SessionStatusParams, SessionStatusResponse>(
+      'session:status',
+      async (params: SessionStatusParams) => {
+        try {
+          const { sessionId } = SessionStatusParamsSchema.parse(params);
+
+          return {
+            isActive: this.sdkAdapter.isSessionActive(
+              SessionId.from(sessionId),
+            ),
+            isStreaming: this.streamBroadcaster.isStreaming(sessionId),
+          };
+        } catch (error) {
+          this.logger.error(
+            'RPC: session:status failed',
+            error instanceof Error ? error : new Error(String(error)),
+          );
+          this.sentryService.captureException(
+            error instanceof Error ? error : new Error(String(error)),
+            { errorSource: 'SessionRpcHandlers.registerSessionStatus' },
+          );
+          return { isActive: false, isStreaming: false };
         }
       },
     );

--- a/libs/frontend/chat-state/src/index.ts
+++ b/libs/frontend/chat-state/src/index.ts
@@ -46,3 +46,7 @@ export {
   type CompactionStateView,
 } from './lib/conversation-registry.service';
 export { TabSessionBinding } from './lib/tab-session-binding.service';
+export {
+  SessionLivenessRegistry,
+  type LivenessStatus,
+} from './lib/session-liveness.registry';

--- a/libs/frontend/chat-state/src/lib/session-liveness.registry.spec.ts
+++ b/libs/frontend/chat-state/src/lib/session-liveness.registry.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * SessionLivenessRegistry — signal-backed liveness status map coverage.
+ *
+ * Exercises mark* setters, reactive status() lookup, clear removal,
+ * identity-stable no-op on unchanged value, and empty-sessionId guard.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { SessionLivenessRegistry } from './session-liveness.registry';
+
+describe('SessionLivenessRegistry', () => {
+  let svc: SessionLivenessRegistry;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [SessionLivenessRegistry] });
+    svc = TestBed.inject(SessionLivenessRegistry);
+  });
+
+  describe('mark* setters', () => {
+    it('markStreaming sets streaming', () => {
+      svc.markStreaming('s1');
+      expect(svc.statuses().get('s1')).toBe('streaming');
+    });
+
+    it('markAwaitingBackground sets awaiting-background', () => {
+      svc.markAwaitingBackground('s1');
+      expect(svc.statuses().get('s1')).toBe('awaiting-background');
+    });
+
+    it('markIdle sets idle', () => {
+      svc.markIdle('s1');
+      expect(svc.statuses().get('s1')).toBe('idle');
+    });
+
+    it('markFailed sets failed', () => {
+      svc.markFailed('s1');
+      expect(svc.statuses().get('s1')).toBe('failed');
+    });
+  });
+
+  describe('status() reactivity', () => {
+    it('reflects later mark and clear', () => {
+      const sig = svc.status('s1');
+      expect(sig()).toBeUndefined();
+
+      svc.markStreaming('s1');
+      expect(sig()).toBe('streaming');
+
+      svc.markFailed('s1');
+      expect(sig()).toBe('failed');
+
+      svc.clear('s1');
+      expect(sig()).toBeUndefined();
+    });
+
+    it('tracks only the queried sessionId', () => {
+      const sig = svc.status('s1');
+      svc.markStreaming('s2');
+      expect(sig()).toBeUndefined();
+    });
+  });
+
+  describe('clear', () => {
+    it('removes the entry', () => {
+      svc.markIdle('s1');
+      svc.clear('s1');
+      expect(svc.statuses().has('s1')).toBe(false);
+    });
+
+    it('is an identity-stable no-op when sessionId is absent', () => {
+      const before = svc.statuses();
+      svc.clear('missing');
+      expect(svc.statuses()).toBe(before);
+    });
+  });
+
+  describe('identity stability', () => {
+    it('returns the SAME map reference when the value is unchanged', () => {
+      svc.markStreaming('s1');
+      const before = svc.statuses();
+      svc.markStreaming('s1');
+      expect(svc.statuses()).toBe(before);
+    });
+
+    it('returns a NEW map reference when the value changes', () => {
+      svc.markStreaming('s1');
+      const before = svc.statuses();
+      svc.markIdle('s1');
+      expect(svc.statuses()).not.toBe(before);
+    });
+  });
+
+  describe('empty sessionId guard', () => {
+    it('ignores an empty sessionId on a mutator', () => {
+      const before = svc.statuses();
+      svc.markStreaming('');
+      expect(svc.statuses()).toBe(before);
+      expect(svc.statuses().size).toBe(0);
+    });
+  });
+});

--- a/libs/frontend/chat-state/src/lib/session-liveness.registry.spec.ts
+++ b/libs/frontend/chat-state/src/lib/session-liveness.registry.spec.ts
@@ -98,4 +98,73 @@ describe('SessionLivenessRegistry', () => {
       expect(svc.statuses().size).toBe(0);
     });
   });
+
+  describe('liveWorkspaces()', () => {
+    it('records workspacePath on mark and reports a streaming workspace', () => {
+      svc.markStreaming('s1', '/ws/a');
+      expect(svc.liveWorkspaces().has('/ws/a')).toBe(true);
+    });
+
+    it('reports an awaiting-background workspace', () => {
+      svc.markAwaitingBackground('s1', '/ws/a');
+      expect(svc.liveWorkspaces().has('/ws/a')).toBe(true);
+    });
+
+    it('excludes the workspace once the session goes idle', () => {
+      svc.markStreaming('s1', '/ws/a');
+      expect(svc.liveWorkspaces().has('/ws/a')).toBe(true);
+      svc.markIdle('s1');
+      expect(svc.liveWorkspaces().has('/ws/a')).toBe(false);
+    });
+
+    it('excludes the workspace once the session fails', () => {
+      svc.markStreaming('s1', '/ws/a');
+      svc.markFailed('s1');
+      expect(svc.liveWorkspaces().has('/ws/a')).toBe(false);
+    });
+
+    it('excludes the workspace once the session is cleared', () => {
+      svc.markStreaming('s1', '/ws/a');
+      svc.clear('s1');
+      expect(svc.liveWorkspaces().has('/ws/a')).toBe(false);
+      expect(svc.liveWorkspaces().size).toBe(0);
+    });
+
+    it('is reactive — re-derives when status flips', () => {
+      const sig = svc.liveWorkspaces;
+      svc.markStreaming('s1', '/ws/a');
+      expect(sig().has('/ws/a')).toBe(true);
+      svc.markIdle('s1');
+      expect(sig().has('/ws/a')).toBe(false);
+      svc.markAwaitingBackground('s1');
+      expect(sig().has('/ws/a')).toBe(true);
+    });
+
+    it('keeps a workspace live while any of its sessions is live', () => {
+      svc.markStreaming('s1', '/ws/a');
+      svc.markStreaming('s2', '/ws/a');
+      svc.markIdle('s1');
+      expect(svc.liveWorkspaces().has('/ws/a')).toBe(true);
+      svc.markIdle('s2');
+      expect(svc.liveWorkspaces().has('/ws/a')).toBe(false);
+    });
+
+    it('omits a live session that has no recorded workspace', () => {
+      svc.markStreaming('s1');
+      expect(svc.liveWorkspaces().size).toBe(0);
+    });
+
+    it('mark* stays callable with only a sessionId (no workspace)', () => {
+      svc.markStreaming('s1');
+      expect(svc.statuses().get('s1')).toBe('streaming');
+      expect(svc.liveWorkspaces().size).toBe(0);
+    });
+
+    it('is identity-stable when re-marking same status + workspace', () => {
+      svc.markStreaming('s1', '/ws/a');
+      const before = svc.liveWorkspaces();
+      svc.markStreaming('s1', '/ws/a');
+      expect(svc.liveWorkspaces()).toBe(before);
+    });
+  });
 });

--- a/libs/frontend/chat-state/src/lib/session-liveness.registry.ts
+++ b/libs/frontend/chat-state/src/lib/session-liveness.registry.ts
@@ -6,32 +6,51 @@ export type LivenessStatus =
   | 'idle'
   | 'failed';
 
+const LIVE_STATUSES: ReadonlySet<LivenessStatus> = new Set([
+  'streaming',
+  'awaiting-background',
+]);
+
 @Injectable({ providedIn: 'root' })
 export class SessionLivenessRegistry {
   private readonly _statuses = signal<ReadonlyMap<string, LivenessStatus>>(
     new Map(),
   );
 
+  private readonly _workspaces = signal<ReadonlyMap<string, string>>(new Map());
+
   readonly statuses = this._statuses.asReadonly();
+
+  readonly liveWorkspaces: Signal<ReadonlySet<string>> = computed(() => {
+    const statuses = this._statuses();
+    const workspaces = this._workspaces();
+    const live = new Set<string>();
+    for (const [sessionId, status] of statuses) {
+      if (!LIVE_STATUSES.has(status)) continue;
+      const ws = workspaces.get(sessionId);
+      if (ws) live.add(ws);
+    }
+    return live;
+  });
 
   status(sessionId: string): Signal<LivenessStatus | undefined> {
     return computed(() => this._statuses().get(sessionId));
   }
 
-  markStreaming(sessionId: string): void {
-    this.set(sessionId, 'streaming');
+  markStreaming(sessionId: string, workspacePath?: string): void {
+    this.set(sessionId, 'streaming', workspacePath);
   }
 
-  markAwaitingBackground(sessionId: string): void {
-    this.set(sessionId, 'awaiting-background');
+  markAwaitingBackground(sessionId: string, workspacePath?: string): void {
+    this.set(sessionId, 'awaiting-background', workspacePath);
   }
 
-  markIdle(sessionId: string): void {
-    this.set(sessionId, 'idle');
+  markIdle(sessionId: string, workspacePath?: string): void {
+    this.set(sessionId, 'idle', workspacePath);
   }
 
-  markFailed(sessionId: string): void {
-    this.set(sessionId, 'failed');
+  markFailed(sessionId: string, workspacePath?: string): void {
+    this.set(sessionId, 'failed', workspacePath);
   }
 
   clear(sessionId: string): void {
@@ -41,9 +60,19 @@ export class SessionLivenessRegistry {
       next.delete(sessionId);
       return next;
     });
+    this._workspaces.update((prev) => {
+      if (!prev.has(sessionId)) return prev;
+      const next = new Map(prev);
+      next.delete(sessionId);
+      return next;
+    });
   }
 
-  private set(sessionId: string, status: LivenessStatus): void {
+  private set(
+    sessionId: string,
+    status: LivenessStatus,
+    workspacePath?: string,
+  ): void {
     if (!sessionId) return;
     this._statuses.update((prev) => {
       if (prev.get(sessionId) === status) return prev;
@@ -51,5 +80,13 @@ export class SessionLivenessRegistry {
       next.set(sessionId, status);
       return next;
     });
+    if (workspacePath) {
+      this._workspaces.update((prev) => {
+        if (prev.get(sessionId) === workspacePath) return prev;
+        const next = new Map(prev);
+        next.set(sessionId, workspacePath);
+        return next;
+      });
+    }
   }
 }

--- a/libs/frontend/chat-state/src/lib/session-liveness.registry.ts
+++ b/libs/frontend/chat-state/src/lib/session-liveness.registry.ts
@@ -1,0 +1,55 @@
+import { Injectable, Signal, computed, signal } from '@angular/core';
+
+export type LivenessStatus =
+  | 'streaming'
+  | 'awaiting-background'
+  | 'idle'
+  | 'failed';
+
+@Injectable({ providedIn: 'root' })
+export class SessionLivenessRegistry {
+  private readonly _statuses = signal<ReadonlyMap<string, LivenessStatus>>(
+    new Map(),
+  );
+
+  readonly statuses = this._statuses.asReadonly();
+
+  status(sessionId: string): Signal<LivenessStatus | undefined> {
+    return computed(() => this._statuses().get(sessionId));
+  }
+
+  markStreaming(sessionId: string): void {
+    this.set(sessionId, 'streaming');
+  }
+
+  markAwaitingBackground(sessionId: string): void {
+    this.set(sessionId, 'awaiting-background');
+  }
+
+  markIdle(sessionId: string): void {
+    this.set(sessionId, 'idle');
+  }
+
+  markFailed(sessionId: string): void {
+    this.set(sessionId, 'failed');
+  }
+
+  clear(sessionId: string): void {
+    this._statuses.update((prev) => {
+      if (!prev.has(sessionId)) return prev;
+      const next = new Map(prev);
+      next.delete(sessionId);
+      return next;
+    });
+  }
+
+  private set(sessionId: string, status: LivenessStatus): void {
+    if (!sessionId) return;
+    this._statuses.update((prev) => {
+      if (prev.get(sessionId) === status) return prev;
+      const next = new Map(prev);
+      next.set(sessionId, status);
+      return next;
+    });
+  }
+}

--- a/libs/frontend/chat-state/src/lib/tab-manager.lifecycle.spec.ts
+++ b/libs/frontend/chat-state/src/lib/tab-manager.lifecycle.spec.ts
@@ -396,8 +396,9 @@ describe('TabManagerService — tab lifecycle + selectors', () => {
       expect(TabId.validate(id)).toBe(true);
     });
 
-    it('loadTabState restores persisted tabs and clears streamingState', () => {
+    it('loadTabState restores persisted tabs, clears streamingState, preserves claudeSessionId', () => {
       const persistedId = TabId.create();
+      const persistedSessionId = SessionId.create();
       localStorage.setItem(
         'ptah.tabs',
         JSON.stringify({
@@ -406,7 +407,7 @@ describe('TabManagerService — tab lifecycle + selectors', () => {
           tabs: [
             {
               id: persistedId,
-              claudeSessionId: SessionId.create(),
+              claudeSessionId: persistedSessionId,
               name: 'persisted',
               title: 'persisted',
               order: 0,
@@ -422,7 +423,7 @@ describe('TabManagerService — tab lifecycle + selectors', () => {
       service.loadTabState();
       const tab = service.tabs()[0];
       expect(tab?.streamingState).toBeNull();
-      expect(tab?.claudeSessionId).toBeNull();
+      expect(tab?.claudeSessionId).toBe(persistedSessionId);
       expect(tab?.status).toBe('loaded');
     });
 

--- a/libs/frontend/chat-state/src/lib/tab-manager.service.ts
+++ b/libs/frontend/chat-state/src/lib/tab-manager.service.ts
@@ -415,6 +415,10 @@ export class TabManagerService {
     );
   }
 
+  updateBackgroundTab(tabId: string, updates: Partial<TabState>): boolean {
+    return this.workspacePartition.updateBackgroundTab(tabId, updates);
+  }
+
   // ============================================================================
   // INITIALIZATION
   // ============================================================================

--- a/libs/frontend/chat-state/src/lib/tab-manager.service.ts
+++ b/libs/frontend/chat-state/src/lib/tab-manager.service.ts
@@ -1695,7 +1695,6 @@ export class TabManagerService {
         const sanitizedTabs = state.tabs.map((tab: TabState) => ({
           ...tab,
           streamingState: null,
-          claudeSessionId: null,
           status:
             tab.status === 'streaming' ||
             tab.status === 'resuming' ||

--- a/libs/frontend/chat-streaming/src/lib/streaming-handler.background.spec.ts
+++ b/libs/frontend/chat-streaming/src/lib/streaming-handler.background.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * StreamingHandlerService — background-workspace routing (routeBackgroundEvent).
+ *
+ * When no active-workspace tab is found for an event, processStreamEvent must
+ * fall through to routeBackgroundEvent BEFORE the "No target tab" warn:
+ *   (a) cross-workspace hit  → accumulatorCore.process + updateBackgroundTab
+ *       with status 'streaming'; warn NOT emitted; no batched signal scheduled.
+ *   (b) cross-workspace miss → updateBackgroundTab NOT called; warn fires.
+ *   (c) an active-tab hit never triggers the background route.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { signal, computed } from '@angular/core';
+import {
+  createEmptyStreamingState,
+  type StreamingState,
+  type TabState,
+} from '@ptah-extension/chat-types';
+import type { TextDeltaEvent } from '@ptah-extension/shared';
+import { SessionId } from '@ptah-extension/shared';
+import { StreamingHandlerService } from './streaming-handler.service';
+import { TabManagerService } from '@ptah-extension/chat-state';
+import { SessionManager } from './session-manager.service';
+import { EventDeduplicationService } from './event-deduplication.service';
+import { BatchedUpdateService } from './batched-update.service';
+import { MessageFinalizationService } from './message-finalization.service';
+import { PermissionHandlerService } from './permission-handler.service';
+import { BackgroundAgentStore } from './background-agent.store';
+import { AgentMonitorStore } from './agent-monitor.store';
+import {
+  StreamingAccumulatorCore,
+  type AccumulatorResult,
+} from './accumulator-core.service';
+
+const BG_TAB_ID = 'bg-tab';
+const SESSION_ID = SessionId.create();
+
+function makeTab(overrides: Partial<TabState> = {}): TabState {
+  return {
+    id: BG_TAB_ID,
+    title: 'Background',
+    name: 'Background',
+    status: 'streaming',
+    messages: [],
+    streamingState: null,
+    currentMessageId: null,
+    claudeSessionId: SESSION_ID,
+    ...overrides,
+  } as TabState;
+}
+
+function textDelta(overrides: Partial<TextDeltaEvent> = {}): TextDeltaEvent {
+  return {
+    id: 'evt-text-1',
+    eventType: 'text_delta',
+    timestamp: 2,
+    sessionId: SESSION_ID,
+    messageId: 'msg-1',
+    blockIndex: 0,
+    delta: 'hello',
+    source: 'stream',
+    ...overrides,
+  } as TextDeltaEvent;
+}
+
+describe('StreamingHandlerService — background routing', () => {
+  let service: StreamingHandlerService;
+  let tabsSignal: ReturnType<typeof signal<TabState[]>>;
+  let activeTabIdSignal: ReturnType<typeof signal<string | null>>;
+  let updateBackgroundTab: jest.Mock<boolean, [string, Partial<TabState>]>;
+  let findTabBySessionIdAcrossWorkspaces: jest.Mock;
+  let process: jest.Mock<AccumulatorResult, unknown[]>;
+  let scheduleUpdate: jest.Mock;
+  let flushSync: jest.Mock;
+  let consoleWarn: jest.SpyInstance;
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    tabsSignal = signal<TabState[]>([]);
+    activeTabIdSignal = signal<string | null>(null);
+    updateBackgroundTab = jest.fn().mockReturnValue(true);
+    findTabBySessionIdAcrossWorkspaces = jest.fn().mockReturnValue(null);
+    process = jest.fn().mockReturnValue({} as AccumulatorResult);
+    scheduleUpdate = jest.fn();
+    flushSync = jest.fn();
+
+    const tabManager = {
+      tabs: computed(() => tabsSignal()),
+      activeTab: computed(
+        () => tabsSignal().find((t) => t.id === activeTabIdSignal()) ?? null,
+      ),
+      findTabBySessionId: jest.fn(() => null),
+      findTabsBySessionId: jest.fn((sid: string) =>
+        tabsSignal().filter((t) => t.claudeSessionId === sid),
+      ),
+      findTabBySessionIdAcrossWorkspaces,
+      updateBackgroundTab,
+      attachSession: jest.fn(),
+      markStreaming: jest.fn(),
+      setStreamingState: jest.fn(),
+      setMessages: jest.fn(),
+      markTabIdle: jest.fn(),
+      markTabStreaming: jest.fn(),
+      isTabStreaming: jest.fn().mockReturnValue(false),
+    } as unknown as TabManagerService;
+
+    const sessionManager = {
+      setSessionId: jest.fn(),
+      setStatus: jest.fn(),
+      registerAgent: jest.fn(() => []),
+      clearNodeMaps: jest.fn(),
+    } as unknown as SessionManager;
+
+    const batchedUpdate = {
+      scheduleUpdate,
+      flushSync,
+    } as unknown as BatchedUpdateService;
+
+    const accumulatorCore = { process } as unknown as StreamingAccumulatorCore;
+
+    consoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+    consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+    TestBed.configureTestingModule({
+      providers: [
+        StreamingHandlerService,
+        { provide: TabManagerService, useValue: tabManager },
+        { provide: SessionManager, useValue: sessionManager },
+        {
+          provide: EventDeduplicationService,
+          useValue: { cleanupSession: jest.fn() },
+        },
+        { provide: BatchedUpdateService, useValue: batchedUpdate },
+        {
+          provide: MessageFinalizationService,
+          useValue: { finalizeCurrentMessage: jest.fn() },
+        },
+        {
+          provide: PermissionHandlerService,
+          useValue: { consumeHardDenyToolUseIds: jest.fn(() => new Set()) },
+        },
+        { provide: BackgroundAgentStore, useValue: {} },
+        { provide: AgentMonitorStore, useValue: {} },
+        { provide: StreamingAccumulatorCore, useValue: accumulatorCore },
+      ],
+    });
+    service = TestBed.inject(StreamingHandlerService);
+  });
+
+  afterEach(() => {
+    consoleWarn.mockRestore();
+    consoleError.mockRestore();
+    TestBed.resetTestingModule();
+  });
+
+  describe('cross-workspace hit (background tab present)', () => {
+    it('runs accumulatorCore.process and persists via updateBackgroundTab with status streaming', () => {
+      const bgTab = makeTab();
+      findTabBySessionIdAcrossWorkspaces.mockReturnValue({
+        tab: bgTab,
+        workspacePath: '/ws/bg',
+      });
+
+      const result = service.processStreamEvent(textDelta());
+
+      expect(result).toBeNull();
+      expect(process).toHaveBeenCalledTimes(1);
+      expect(updateBackgroundTab).toHaveBeenCalledTimes(1);
+      const [tabId, updates] = updateBackgroundTab.mock.calls[0];
+      expect(tabId).toBe(BG_TAB_ID);
+      expect(updates.status).toBe('streaming');
+      expect(updates.streamingState).toBeDefined();
+    });
+
+    it('creates an empty streaming state when the background tab has none', () => {
+      findTabBySessionIdAcrossWorkspaces.mockReturnValue({
+        tab: makeTab({ streamingState: null }),
+        workspacePath: '/ws/bg',
+      });
+
+      service.processStreamEvent(textDelta());
+
+      const stateArg = process.mock.calls[0][0] as StreamingState;
+      expect(stateArg).toBeDefined();
+      expect(stateArg.events).toBeInstanceOf(Map);
+    });
+
+    it('swaps to replacementState on compaction_complete before persisting', () => {
+      const replacement = createEmptyStreamingState();
+      replacement.events.set('replaced', {} as never);
+      process.mockReturnValue({
+        compactionComplete: true,
+        replacementState: replacement,
+      } as AccumulatorResult);
+      findTabBySessionIdAcrossWorkspaces.mockReturnValue({
+        tab: makeTab(),
+        workspacePath: '/ws/bg',
+      });
+
+      service.processStreamEvent(textDelta());
+
+      const updates = updateBackgroundTab.mock.calls[0][1];
+      expect(updates.streamingState).toBe(replacement);
+    });
+
+    it('does NOT emit the No-target-tab warn on the background path', () => {
+      findTabBySessionIdAcrossWorkspaces.mockReturnValue({
+        tab: makeTab(),
+        workspacePath: '/ws/bg',
+      });
+
+      service.processStreamEvent(textDelta());
+
+      expect(consoleWarn).not.toHaveBeenCalledWith(
+        expect.stringContaining('No target tab'),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('does NOT schedule a batched signal update on the background path', () => {
+      findTabBySessionIdAcrossWorkspaces.mockReturnValue({
+        tab: makeTab(),
+        workspacePath: '/ws/bg',
+      });
+
+      service.processStreamEvent(textDelta());
+
+      expect(scheduleUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cross-workspace miss (no background tab)', () => {
+    it('does NOT call updateBackgroundTab and runs the existing warn path', () => {
+      findTabBySessionIdAcrossWorkspaces.mockReturnValue(null);
+
+      service.processStreamEvent(textDelta());
+
+      expect(updateBackgroundTab).not.toHaveBeenCalled();
+      expect(process).not.toHaveBeenCalled();
+      expect(consoleWarn).toHaveBeenCalledWith(
+        expect.stringContaining('No target tab'),
+        SESSION_ID,
+        expect.any(String),
+      );
+    });
+  });
+
+  describe('active-tab path is unaffected', () => {
+    it('never triggers the background route when a primaryTab is found by tabId', () => {
+      const tab = makeTab({ streamingState: createEmptyStreamingState() });
+      tabsSignal.set([tab]);
+
+      service.processStreamEvent(textDelta(), BG_TAB_ID);
+
+      expect(findTabBySessionIdAcrossWorkspaces).not.toHaveBeenCalled();
+      expect(updateBackgroundTab).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/frontend/chat-streaming/src/lib/streaming-handler.service.spec.ts
+++ b/libs/frontend/chat-streaming/src/lib/streaming-handler.service.spec.ts
@@ -282,6 +282,8 @@ describe('StreamingHandlerService', () => {
       markTabIdle: jest.fn(),
       markTabStreaming: jest.fn(),
       isTabStreaming: jest.fn().mockReturnValue(false),
+      findTabBySessionIdAcrossWorkspaces: jest.fn(() => null),
+      updateBackgroundTab: jest.fn(() => false),
     } as unknown as jest.Mocked<
       Pick<
         TabManagerService,

--- a/libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts
+++ b/libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts
@@ -147,6 +147,9 @@ export class StreamingHandlerService {
       }
 
       if (!primaryTab) {
+        if (this.routeBackgroundEvent(event)) {
+          return null;
+        }
         if (!this.warnedNoTargetSessions.has(event.sessionId)) {
           this.warnedNoTargetSessions.add(event.sessionId);
           console.warn(
@@ -306,6 +309,35 @@ export class StreamingHandlerService {
     }
 
     return null;
+  }
+
+  private routeBackgroundEvent(event: FlatStreamEventUnion): boolean {
+    const lookup = this.tabManager.findTabBySessionIdAcrossWorkspaces(
+      event.sessionId,
+    );
+    if (!lookup) return false;
+
+    const { tab } = lookup;
+    let state: StreamingState =
+      tab.streamingState ?? createEmptyStreamingState();
+
+    const ctx: AccumulatorContext = {
+      sessionManager: this.sessionManager,
+      deduplication: this.deduplication,
+      batchedUpdate: this.batchedUpdate,
+      backgroundAgentStore: this.backgroundAgentStore,
+      agentMonitorStore: this.agentMonitorStore,
+    };
+
+    const result = this.accumulatorCore.process(state, event, ctx);
+    if (result.compactionComplete && result.replacementState) {
+      state = result.replacementState;
+    }
+
+    return this.tabManager.updateBackgroundTab(tab.id, {
+      streamingState: state,
+      status: 'streaming',
+    });
   }
 
   /**

--- a/libs/frontend/chat-ui/src/lib/molecules/session/tab-item.component.ts
+++ b/libs/frontend/chat-ui/src/lib/molecules/session/tab-item.component.ts
@@ -15,6 +15,17 @@ import {
 import { TabState } from '@ptah-extension/chat-types';
 
 /**
+ * Subset of session liveness surfaced as a tab dot. Mirrors
+ * `@ptah-extension/chat-state` `LivenessStatus` without importing it (chat-ui
+ * is a leaf UI lib and must not depend on chat-state).
+ */
+export type TabLivenessStatus =
+  | 'streaming'
+  | 'awaiting-background'
+  | 'idle'
+  | 'failed';
+
+/**
  * TabItemComponent - Chrome-style individual tab
  *
  * Patterns: Signal-based inputs/outputs, DaisyUI styling
@@ -44,6 +55,18 @@ import { TabState } from '@ptah-extension/chat-types';
       <span class="truncate text-xs flex-1" [title]="tab().title">
         {{ tab().title || 'New Chat' }}
       </span>
+
+      @if (livenessDot(); as dot) {
+        <span
+          class="w-1.5 h-1.5 rounded-full flex-shrink-0"
+          [class.bg-primary]="dot === 'streaming'"
+          [class.animate-pulse]="dot === 'streaming'"
+          [class.bg-error]="dot === 'failed'"
+          [attr.data-test]="'tab-item-liveness-dot'"
+          [attr.data-liveness]="dot"
+          [title]="dot === 'streaming' ? 'Still running' : 'Run failed'"
+        ></span>
+      }
 
       <!-- View mode toggle (hover-reveal) -->
       <button
@@ -76,6 +99,12 @@ export class TabItemComponent {
   readonly isActive = input.required<boolean>();
   /** Visual streaming indicator - isolated from tab.status state machine */
   readonly isStreaming = input<boolean>(false);
+  /**
+   * Cross-workspace session liveness from SessionLivenessRegistry, keyed by the
+   * tab's claudeSessionId. Surfaces a subtle dot for sessions that keep running
+   * (or fail) while their workspace is in the background.
+   */
+  readonly livenessStatus = input<TabLivenessStatus | undefined>(undefined);
 
   readonly tabSelect = output<string>();
   readonly tabClose = output<string>();
@@ -93,6 +122,19 @@ export class TabItemComponent {
   readonly isAwaitingBackground = computed(
     () => this.tab().status === 'awaiting-background',
   );
+
+  readonly livenessDot = computed<'streaming' | 'failed' | null>(() => {
+    const status = this.livenessStatus();
+    if (status === 'failed') return 'failed';
+    if (
+      status === 'streaming' &&
+      !this.isStreaming() &&
+      !this.isAwaitingBackground()
+    ) {
+      return 'streaming';
+    }
+    return null;
+  });
 
   protected onClose(event: Event): void {
     event.stopPropagation();

--- a/libs/frontend/chat/src/lib/components/organisms/tab-bar.component.spec.ts
+++ b/libs/frontend/chat/src/lib/components/organisms/tab-bar.component.spec.ts
@@ -70,6 +70,7 @@ class TabItemStubComponent {
   @Input() tab: TabState | null = null;
   @Input() isActive = false;
   @Input() isStreaming = false;
+  @Input() livenessStatus: unknown = undefined;
   @Output() tabSelect = new EventEmitter<string>();
   @Output() tabClose = new EventEmitter<string>();
   @Output() viewModeToggle = new EventEmitter<string>();

--- a/libs/frontend/chat/src/lib/components/organisms/tab-bar.component.ts
+++ b/libs/frontend/chat/src/lib/components/organisms/tab-bar.component.ts
@@ -17,7 +17,10 @@ import {
   AwaitingBackgroundIndicatorComponent,
   TabItemComponent,
 } from '@ptah-extension/chat-ui';
-import { TabManagerService } from '@ptah-extension/chat-state';
+import {
+  SessionLivenessRegistry,
+  TabManagerService,
+} from '@ptah-extension/chat-state';
 
 /**
  * TabBarComponent - Chrome-style scrollable tab bar
@@ -60,6 +63,7 @@ import { TabManagerService } from '@ptah-extension/chat-state';
             [tab]="tab"
             [isActive]="tab.id === activeTabId()"
             [isStreaming]="tabManager.isTabStreaming(tab.id)"
+            [livenessStatus]="livenessFor(tab.claudeSessionId)"
             (tabSelect)="onSelectTab($event)"
             (tabClose)="onCloseTab($event)"
             (viewModeToggle)="onToggleViewMode($event)"
@@ -95,6 +99,7 @@ import { TabManagerService } from '@ptah-extension/chat-state';
 })
 export class TabBarComponent {
   protected readonly tabManager = inject(TabManagerService);
+  private readonly liveness = inject(SessionLivenessRegistry);
   private readonly injector = inject(Injector);
   private readonly destroyRef = inject(DestroyRef);
   private readonly ngZone = inject(NgZone);
@@ -146,6 +151,13 @@ export class TabBarComponent {
     );
 
     this.destroyRef.onDestroy(() => this.cleanup());
+  }
+
+  protected livenessFor(
+    sessionId: string | null,
+  ): import('@ptah-extension/chat-state').LivenessStatus | undefined {
+    if (!sessionId) return undefined;
+    return this.liveness.statuses().get(sessionId);
   }
 
   protected onScroll(): void {

--- a/libs/frontend/chat/src/lib/components/organisms/workspace-sidebar.component.ts
+++ b/libs/frontend/chat/src/lib/components/organisms/workspace-sidebar.component.ts
@@ -17,6 +17,7 @@ import {
 } from '@angular/core';
 import { LucideAngularModule, FolderOpen, FolderPlus, X } from 'lucide-angular';
 import { ElectronLayoutService } from '@ptah-extension/core';
+import { SessionLivenessRegistry } from '@ptah-extension/chat-state';
 
 @Component({
   selector: 'ptah-workspace-sidebar',
@@ -49,45 +50,55 @@ import { ElectronLayoutService } from '@ptah-extension/core';
 
       <!-- Folder list -->
       <div class="flex-1 overflow-y-auto px-2">
-        @for (folder of layout.workspaceFolders(); track folder.path; let i =
-        $index) {
-        <div
-          class="sidebar-item group relative flex items-center gap-2 px-2 py-2 rounded-md cursor-pointer transition-colors duration-150 mb-0.5 hover:bg-base-300"
-          [class.bg-base-300]="i === layout.activeWorkspaceIndex()"
-          [class.text-primary]="i === layout.activeWorkspaceIndex()"
-          (click)="layout.switchWorkspace(i)"
-          [title]="folder.path"
-        >
-          <lucide-angular
-            [img]="FolderOpenIcon"
-            class="w-4 h-4 flex-shrink-0"
+        @for (
+          folder of layout.workspaceFolders();
+          track folder.path;
+          let i = $index
+        ) {
+          <div
+            class="sidebar-item group relative flex items-center gap-2 px-2 py-2 rounded-md cursor-pointer transition-colors duration-150 mb-0.5 hover:bg-base-300"
+            [class.bg-base-300]="i === layout.activeWorkspaceIndex()"
             [class.text-primary]="i === layout.activeWorkspaceIndex()"
-            [class.opacity-50]="i !== layout.activeWorkspaceIndex()"
-          />
-          <span class="text-sm truncate flex-1">{{ folder.name }}</span>
-          <!-- Remove button (hover reveal) -->
-          <button
-            class="remove-btn opacity-0 btn btn-ghost btn-xs btn-square p-0 min-h-0 w-5 h-5 text-base-content/30 hover:text-error transition-opacity duration-200"
-            (click)="onRemoveFolder($event, i)"
-            title="Remove workspace"
-            aria-label="Remove workspace"
+            (click)="layout.switchWorkspace(i)"
+            [title]="folder.path"
           >
-            <lucide-angular [img]="XIcon" class="w-3 h-3" />
-          </button>
-        </div>
+            <lucide-angular
+              [img]="FolderOpenIcon"
+              class="w-4 h-4 flex-shrink-0"
+              [class.text-primary]="i === layout.activeWorkspaceIndex()"
+              [class.opacity-50]="i !== layout.activeWorkspaceIndex()"
+            />
+            <span class="text-sm truncate flex-1">{{ folder.name }}</span>
+            @if (liveness.liveWorkspaces().has(folder.path)) {
+              <span
+                class="w-1.5 h-1.5 rounded-full bg-primary animate-pulse flex-shrink-0"
+                [attr.data-test]="'workspace-sidebar-liveness-dot'"
+                title="Session running"
+              ></span>
+            }
+            <!-- Remove button (hover reveal) -->
+            <button
+              class="remove-btn opacity-0 btn btn-ghost btn-xs btn-square p-0 min-h-0 w-5 h-5 text-base-content/30 hover:text-error transition-opacity duration-200"
+              (click)="onRemoveFolder($event, i)"
+              title="Remove workspace"
+              aria-label="Remove workspace"
+            >
+              <lucide-angular [img]="XIcon" class="w-3 h-3" />
+            </button>
+          </div>
         } @empty {
-        <div
-          class="flex flex-col items-center justify-center py-8 text-center px-4"
-        >
-          <lucide-angular
-            [img]="FolderOpenIcon"
-            class="w-10 h-10 opacity-15 mb-2"
-          />
-          <span class="text-xs opacity-40">No workspaces open</span>
-          <span class="text-[10px] opacity-25 mt-1">
-            Add a folder to get started
-          </span>
-        </div>
+          <div
+            class="flex flex-col items-center justify-center py-8 text-center px-4"
+          >
+            <lucide-angular
+              [img]="FolderOpenIcon"
+              class="w-10 h-10 opacity-15 mb-2"
+            />
+            <span class="text-xs opacity-40">No workspaces open</span>
+            <span class="text-[10px] opacity-25 mt-1">
+              Add a folder to get started
+            </span>
+          </div>
         }
       </div>
 
@@ -107,6 +118,7 @@ import { ElectronLayoutService } from '@ptah-extension/core';
 })
 export class WorkspaceSidebarComponent {
   protected readonly layout = inject(ElectronLayoutService);
+  protected readonly liveness = inject(SessionLivenessRegistry);
 
   /** Sidebar width in pixels (controlled by parent via resize handle) */
   readonly width = input<number>(220);

--- a/libs/frontend/chat/src/lib/services/chat-message-handler.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-message-handler.service.spec.ts
@@ -62,6 +62,7 @@ describe('ChatMessageHandler — payload validation (TASK_2026_120 Phase B)', ()
   let tabManager: {
     tabs: jest.Mock;
     resetTabToFresh: jest.Mock;
+    findTabBySessionIdAcrossWorkspaces: jest.Mock;
   };
   let consoleWarnSpy: jest.SpyInstance;
 
@@ -82,6 +83,7 @@ describe('ChatMessageHandler — payload validation (TASK_2026_120 Phase B)', ()
     tabManager = {
       tabs: jest.fn(() => [{ id: 'tab-1' }]),
       resetTabToFresh: jest.fn(),
+      findTabBySessionIdAcrossWorkspaces: jest.fn(() => null),
     };
 
     TestBed.configureTestingModule({

--- a/libs/frontend/chat/src/lib/services/chat-message-handler.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-message-handler.service.ts
@@ -33,6 +33,7 @@ import { ChatStore } from './chat.store';
 import { MessageSenderService } from './message-sender.service';
 import { AgentMonitorStore } from '@ptah-extension/chat-streaming';
 import {
+  SessionLivenessRegistry,
   TabId,
   TabManagerService,
   type ClaudeSessionId,
@@ -44,6 +45,7 @@ export class ChatMessageHandler implements MessageHandler {
   private readonly chatStore = inject(ChatStore);
   private readonly agentMonitorStore = inject(AgentMonitorStore);
   private readonly tabManager = inject(TabManagerService);
+  private readonly liveness = inject(SessionLivenessRegistry);
   private readonly messageSender = inject(MessageSenderService);
   /**
    * Authoritative StreamRouter.
@@ -150,7 +152,11 @@ export class ChatMessageHandler implements MessageHandler {
     const data = payload as { command?: unknown; tabId?: unknown };
     if (data.command !== 'clear') return;
     if (typeof data.tabId !== 'string') return;
-    if (!this.tabManager.tabs().some((t) => t.id === data.tabId)) return;
+    const target = this.tabManager.tabs().find((t) => t.id === data.tabId);
+    if (!target) return;
+    if (target.claudeSessionId) {
+      this.liveness.markIdle(target.claudeSessionId);
+    }
     this.tabManager.resetTabToFresh(data.tabId);
   }
 
@@ -168,6 +174,9 @@ export class ChatMessageHandler implements MessageHandler {
         parsed.error,
       );
       return;
+    }
+    if (parsed.data.backgroundTasks.length === 0) {
+      this.liveness.markIdle(parsed.data.sessionId);
     }
     this.chatStore.handleSubagentEndedNotification(parsed.data);
   }
@@ -187,6 +196,11 @@ export class ChatMessageHandler implements MessageHandler {
       );
       return;
     }
+    if (parsed.data.backgroundTasks.length > 0) {
+      this.liveness.markAwaitingBackground(parsed.data.sessionId);
+    } else {
+      this.liveness.markIdle(parsed.data.sessionId);
+    }
     this.chatStore.handleTurnEndedNotification(parsed.data);
   }
 
@@ -205,6 +219,7 @@ export class ChatMessageHandler implements MessageHandler {
       );
       return;
     }
+    this.liveness.markFailed(parsed.data.sessionId);
     this.chatStore.handleTurnFailedNotification(parsed.data);
   }
 
@@ -264,6 +279,9 @@ export class ChatMessageHandler implements MessageHandler {
       event: FlatStreamEventUnion;
     };
 
+    if (event?.sessionId) {
+      this.liveness.markStreaming(event.sessionId);
+    }
     this.chatStore.processStreamEvent(event, tabId, sessionId);
     const originTabId = tabId ? TabId.safeParse(tabId) : null;
     this.streamRouter.routeStreamEvent(event, originTabId ?? undefined);

--- a/libs/frontend/chat/src/lib/services/chat-message-handler.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-message-handler.service.ts
@@ -139,6 +139,11 @@ export class ChatMessageHandler implements MessageHandler {
     }
   }
 
+  private workspaceFor(sessionId: string): string | undefined {
+    return this.tabManager.findTabBySessionIdAcrossWorkspaces(sessionId)
+      ?.workspacePath;
+  }
+
   /**
    * CHAT_COMPLETE is intentionally NOT used to finalize streaming — it fires
    * per-turn (on each message_complete) and SESSION_STATS is the authoritative
@@ -155,7 +160,10 @@ export class ChatMessageHandler implements MessageHandler {
     const target = this.tabManager.tabs().find((t) => t.id === data.tabId);
     if (!target) return;
     if (target.claudeSessionId) {
-      this.liveness.markIdle(target.claudeSessionId);
+      this.liveness.markIdle(
+        target.claudeSessionId,
+        this.workspaceFor(target.claudeSessionId),
+      );
     }
     this.tabManager.resetTabToFresh(data.tabId);
   }
@@ -176,7 +184,10 @@ export class ChatMessageHandler implements MessageHandler {
       return;
     }
     if (parsed.data.backgroundTasks.length === 0) {
-      this.liveness.markIdle(parsed.data.sessionId);
+      this.liveness.markIdle(
+        parsed.data.sessionId,
+        this.workspaceFor(parsed.data.sessionId),
+      );
     }
     this.chatStore.handleSubagentEndedNotification(parsed.data);
   }
@@ -196,10 +207,11 @@ export class ChatMessageHandler implements MessageHandler {
       );
       return;
     }
+    const ws = this.workspaceFor(parsed.data.sessionId);
     if (parsed.data.backgroundTasks.length > 0) {
-      this.liveness.markAwaitingBackground(parsed.data.sessionId);
+      this.liveness.markAwaitingBackground(parsed.data.sessionId, ws);
     } else {
-      this.liveness.markIdle(parsed.data.sessionId);
+      this.liveness.markIdle(parsed.data.sessionId, ws);
     }
     this.chatStore.handleTurnEndedNotification(parsed.data);
   }
@@ -219,7 +231,10 @@ export class ChatMessageHandler implements MessageHandler {
       );
       return;
     }
-    this.liveness.markFailed(parsed.data.sessionId);
+    this.liveness.markFailed(
+      parsed.data.sessionId,
+      this.workspaceFor(parsed.data.sessionId),
+    );
     this.chatStore.handleTurnFailedNotification(parsed.data);
   }
 
@@ -280,7 +295,10 @@ export class ChatMessageHandler implements MessageHandler {
     };
 
     if (event?.sessionId) {
-      this.liveness.markStreaming(event.sessionId);
+      this.liveness.markStreaming(
+        event.sessionId,
+        this.workspaceFor(event.sessionId),
+      );
     }
     this.chatStore.processStreamEvent(event, tabId, sessionId);
     const originTabId = tabId ? TabId.safeParse(tabId) : null;

--- a/libs/frontend/chat/src/lib/services/chat-store/chat-lifecycle.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/chat-lifecycle.service.ts
@@ -12,6 +12,7 @@ import {
 } from '@ptah-extension/chat-streaming';
 import { SessionLoaderService } from './session-loader.service';
 import { CompactionLifecycleService } from './compaction-lifecycle.service';
+import { SessionLivenessReconcilerService } from './session-liveness-reconciler.service';
 import { TabState } from '@ptah-extension/chat-types';
 
 /**
@@ -39,6 +40,9 @@ export class ChatLifecycleService {
   private readonly sessionLoader = inject(SessionLoaderService);
   private readonly streamingHandler = inject(StreamingHandlerService);
   private readonly compactionLifecycle = inject(CompactionLifecycleService);
+  private readonly livenessReconciler = inject(
+    SessionLivenessReconcilerService,
+  );
   private readonly _licenseStatus = signal<LicenseGetStatusResponse | null>(
     null,
   );
@@ -58,6 +62,12 @@ export class ChatLifecycleService {
         });
         this.sessionLoader.restoreCliSessionsForActiveTab().catch((err) => {
           console.warn('[ChatStore] Failed to restore CLI sessions:', err);
+        });
+        this.livenessReconciler.reconcileRestoredTabs().catch((err) => {
+          console.warn(
+            '[ChatStore] Failed to reconcile session liveness:',
+            err,
+          );
         });
       }
       this.authState.loadAuthStatus().catch((err) => {

--- a/libs/frontend/chat/src/lib/services/chat-store/index.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/index.ts
@@ -29,3 +29,4 @@ export { CompactionLifecycleService } from './compaction-lifecycle.service';
 export { MessageDispatchService } from './message-dispatch.service';
 export { SessionStatsAggregatorService } from './session-stats-aggregator.service';
 export { ChatLifecycleService } from './chat-lifecycle.service';
+export { SessionLivenessReconcilerService } from './session-liveness-reconciler.service';

--- a/libs/frontend/chat/src/lib/services/chat-store/session-liveness-reconciler.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/session-liveness-reconciler.service.spec.ts
@@ -1,0 +1,197 @@
+import { TestBed } from '@angular/core/testing';
+import { SessionLivenessReconcilerService } from './session-liveness-reconciler.service';
+import { ClaudeRpcService, VSCodeService } from '@ptah-extension/core';
+import {
+  TabManagerService,
+  SessionLivenessRegistry,
+} from '@ptah-extension/chat-state';
+import type { TabState } from '@ptah-extension/chat-types';
+import { SessionId, SessionStatusResponse } from '@ptah-extension/shared';
+
+const WS = '/ws/active';
+const SESS_STREAM = SessionId.create();
+const SESS_IDLE = SessionId.create();
+const SESS_DEAD = SessionId.create();
+const SESS_REJECT = SessionId.create();
+
+function makeTab(overrides: Partial<TabState> = {}): TabState {
+  return {
+    id: `tab-${overrides.claudeSessionId ?? 'x'}`,
+    title: 'Tab',
+    status: 'loaded',
+    messages: [],
+    streamingState: null,
+    claudeSessionId: null,
+    queuedContent: null,
+    queuedOptions: null,
+    ...overrides,
+  } as unknown as TabState;
+}
+
+describe('SessionLivenessReconcilerService', () => {
+  let service: SessionLivenessReconcilerService;
+  let tabs: TabState[];
+  let callMock: jest.Mock;
+  let markStreamingLiveness: jest.Mock;
+  let markIdleLiveness: jest.Mock;
+  let markStreamingTab: jest.Mock;
+  let markTabStreaming: jest.Mock;
+  let warn: jest.SpyInstance;
+
+  function rpcResult(data: SessionStatusResponse) {
+    return { success: true, data, isSuccess: () => true };
+  }
+
+  beforeEach(() => {
+    tabs = [];
+    callMock = jest.fn();
+    markStreamingLiveness = jest.fn();
+    markIdleLiveness = jest.fn();
+    markStreamingTab = jest.fn();
+    markTabStreaming = jest.fn();
+    warn = jest.spyOn(console, 'warn').mockImplementation();
+
+    const rpcMock = { call: callMock } as unknown as ClaudeRpcService;
+    const vscodeMock = {
+      config: () => ({ workspaceRoot: WS }),
+    } as unknown as VSCodeService;
+    const tabManagerMock = {
+      tabs: () => tabs,
+      markStreaming: markStreamingTab,
+      markTabStreaming,
+    } as unknown as TabManagerService;
+    const livenessMock = {
+      markStreaming: markStreamingLiveness,
+      markIdle: markIdleLiveness,
+    } as unknown as SessionLivenessRegistry;
+
+    TestBed.configureTestingModule({
+      providers: [
+        SessionLivenessReconcilerService,
+        { provide: ClaudeRpcService, useValue: rpcMock },
+        { provide: VSCodeService, useValue: vscodeMock },
+        { provide: TabManagerService, useValue: tabManagerMock },
+        { provide: SessionLivenessRegistry, useValue: livenessMock },
+      ],
+    });
+    service = TestBed.inject(SessionLivenessReconcilerService);
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    TestBed.resetTestingModule();
+  });
+
+  it('streaming response marks liveness streaming and sets the tab streaming marker', async () => {
+    tabs = [makeTab({ claudeSessionId: SESS_STREAM })];
+    callMock.mockResolvedValue(
+      rpcResult({ isActive: true, isStreaming: true }),
+    );
+
+    await service.reconcileRestoredTabs();
+
+    expect(callMock).toHaveBeenCalledWith('session:status', {
+      sessionId: SESS_STREAM,
+    });
+    expect(markStreamingLiveness).toHaveBeenCalledWith(SESS_STREAM, WS);
+    expect(markStreamingTab).toHaveBeenCalledWith(`tab-${SESS_STREAM}`);
+    expect(markTabStreaming).toHaveBeenCalledWith(`tab-${SESS_STREAM}`);
+    expect(markIdleLiveness).not.toHaveBeenCalled();
+  });
+
+  it('active-not-streaming marks idle and does NOT set streaming', async () => {
+    tabs = [makeTab({ claudeSessionId: SESS_IDLE })];
+    callMock.mockResolvedValue(
+      rpcResult({ isActive: true, isStreaming: false }),
+    );
+
+    await service.reconcileRestoredTabs();
+
+    expect(markIdleLiveness).toHaveBeenCalledWith(SESS_IDLE, WS);
+    expect(markStreamingLiveness).not.toHaveBeenCalled();
+    expect(markStreamingTab).not.toHaveBeenCalled();
+    expect(markTabStreaming).not.toHaveBeenCalled();
+  });
+
+  it('inactive session does nothing', async () => {
+    tabs = [makeTab({ claudeSessionId: SESS_DEAD })];
+    callMock.mockResolvedValue(
+      rpcResult({ isActive: false, isStreaming: false }),
+    );
+
+    await service.reconcileRestoredTabs();
+
+    expect(markStreamingLiveness).not.toHaveBeenCalled();
+    expect(markIdleLiveness).not.toHaveBeenCalled();
+    expect(markStreamingTab).not.toHaveBeenCalled();
+    expect(markTabStreaming).not.toHaveBeenCalled();
+  });
+
+  it('skips tabs without a claudeSessionId', async () => {
+    tabs = [makeTab({ id: 'tab-empty', claudeSessionId: null })];
+
+    await service.reconcileRestoredTabs();
+
+    expect(callMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows a rejected probe without affecting sibling tabs', async () => {
+    tabs = [
+      makeTab({ claudeSessionId: SESS_REJECT }),
+      makeTab({ claudeSessionId: SESS_STREAM }),
+    ];
+    callMock.mockImplementation(
+      (_method: string, params: { sessionId: string }) =>
+        params.sessionId === SESS_REJECT
+          ? Promise.reject(new Error('rpc timeout'))
+          : Promise.resolve(rpcResult({ isActive: true, isStreaming: true })),
+    );
+
+    await expect(service.reconcileRestoredTabs()).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith(
+      '[SessionLivenessReconciler] probe failed; leaving tab as restored',
+      expect.objectContaining({ sessionId: SESS_REJECT }),
+    );
+    expect(markStreamingLiveness).toHaveBeenCalledWith(SESS_STREAM, WS);
+    expect(markStreamingTab).toHaveBeenCalledWith(`tab-${SESS_STREAM}`);
+  });
+
+  it('passes undefined workspacePath when workspaceRoot is unavailable', async () => {
+    TestBed.resetTestingModule();
+    tabs = [makeTab({ claudeSessionId: SESS_IDLE })];
+    callMock.mockResolvedValue(
+      rpcResult({ isActive: true, isStreaming: false }),
+    );
+    TestBed.configureTestingModule({
+      providers: [
+        SessionLivenessReconcilerService,
+        { provide: ClaudeRpcService, useValue: { call: callMock } },
+        {
+          provide: VSCodeService,
+          useValue: { config: () => ({ workspaceRoot: null }) },
+        },
+        {
+          provide: TabManagerService,
+          useValue: {
+            tabs: () => tabs,
+            markStreaming: markStreamingTab,
+            markTabStreaming,
+          },
+        },
+        {
+          provide: SessionLivenessRegistry,
+          useValue: {
+            markStreaming: markStreamingLiveness,
+            markIdle: markIdleLiveness,
+          },
+        },
+      ],
+    });
+    service = TestBed.inject(SessionLivenessReconcilerService);
+
+    await service.reconcileRestoredTabs();
+
+    expect(markIdleLiveness).toHaveBeenCalledWith(SESS_IDLE, undefined);
+  });
+});

--- a/libs/frontend/chat/src/lib/services/chat-store/session-liveness-reconciler.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/session-liveness-reconciler.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, inject } from '@angular/core';
+import { ClaudeRpcService, VSCodeService } from '@ptah-extension/core';
+import {
+  TabManagerService,
+  SessionLivenessRegistry,
+} from '@ptah-extension/chat-state';
+
+@Injectable({ providedIn: 'root' })
+export class SessionLivenessReconcilerService {
+  private readonly rpc = inject(ClaudeRpcService);
+  private readonly vscodeService = inject(VSCodeService);
+  private readonly tabManager = inject(TabManagerService);
+  private readonly liveness = inject(SessionLivenessRegistry);
+
+  async reconcileRestoredTabs(): Promise<void> {
+    const workspacePath =
+      this.vscodeService.config().workspaceRoot ?? undefined;
+    const targets = this.tabManager
+      .tabs()
+      .filter((tab) => tab.claudeSessionId != null)
+      .map((tab) => ({
+        tabId: tab.id,
+        sessionId: tab.claudeSessionId as string,
+      }));
+
+    await Promise.allSettled(
+      targets.map((t) => this.probe(t.tabId, t.sessionId, workspacePath)),
+    );
+  }
+
+  private async probe(
+    tabId: string,
+    sessionId: string,
+    workspacePath: string | undefined,
+  ): Promise<void> {
+    try {
+      const result = await this.rpc.call('session:status', { sessionId });
+      if (!result.success || !result.data) return;
+
+      const { isActive, isStreaming } = result.data;
+      if (isStreaming) {
+        this.liveness.markStreaming(sessionId, workspacePath);
+        this.tabManager.markStreaming(tabId);
+        this.tabManager.markTabStreaming(tabId);
+      } else if (isActive) {
+        this.liveness.markIdle(sessionId, workspacePath);
+      }
+    } catch (error: unknown) {
+      console.warn(
+        '[SessionLivenessReconciler] probe failed; leaving tab as restored',
+        { sessionId, error },
+      );
+    }
+  }
+}

--- a/libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.background.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.background.spec.ts
@@ -10,7 +10,8 @@
  *     pendingBackgroundTasks; status 'loaded' only when prior status was
  *     'awaiting-background' AND remaining===0.
  *   - handleTurnFailed: updateBackgroundTab with lastTerminalReason + status
- *     'loaded'; no finalize; handleChatError STILL fires exactly once.
+ *     'loaded'; no finalize; the foreground handleChatError channel is NOT
+ *     invoked (its active-tab fallback would reset an unrelated foreground tab).
  * The existing active-tab path (findTabsBySessionId hit) is unaffected and never
  * calls updateBackgroundTab.
  */
@@ -348,7 +349,7 @@ describe('TurnEndHandlerService — background fallback', () => {
   });
 
   describe('handleTurnFailed background fallback', () => {
-    it('updates the bg tab with lastTerminalReason + loaded, no finalize, error routed once', () => {
+    it('updates the bg tab with lastTerminalReason + loaded, no finalize, no foreground error surface', () => {
       crossWsTab = makeTab();
 
       service.handleTurnFailed(makeTurnFailedPayload());
@@ -362,20 +363,18 @@ describe('TurnEndHandlerService — background fallback', () => {
       expect(setLastTerminalReasonMock).not.toHaveBeenCalled();
       expect(markTabIdleMock).not.toHaveBeenCalled();
 
-      expect(handleChatErrorMock).toHaveBeenCalledTimes(1);
-      expect(handleChatErrorMock).toHaveBeenCalledWith({
-        sessionId: SESS_BG,
-        error: 'Rate limited by Anthropic. Wait a moment and try again.',
-      });
+      // handleChatError's active-tab fallback would reset an unrelated
+      // foreground tab; a background failure must not reach it.
+      expect(handleChatErrorMock).not.toHaveBeenCalled();
     });
 
-    it('still routes handleChatError once when no tab is found anywhere', () => {
+    it('warns without routing handleChatError when no tab is found anywhere', () => {
       crossWsTab = null;
 
       service.handleTurnFailed(makeTurnFailedPayload());
 
       expect(updateBackgroundTabMock).not.toHaveBeenCalled();
-      expect(handleChatErrorMock).toHaveBeenCalledTimes(1);
+      expect(handleChatErrorMock).not.toHaveBeenCalled();
       expect(warn).toHaveBeenCalledWith(
         '[ChatStore] handleTurnFailed: no tab bound to sessionId',
         expect.objectContaining({ sessionId: SESS_BG }),

--- a/libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.background.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.background.spec.ts
@@ -1,0 +1,404 @@
+/**
+ * TurnEndHandlerService — background-workspace fallback.
+ *
+ * When findTabsBySessionId returns [] but a cross-workspace lookup hits, each
+ * handler must apply terminal state to the background tab via
+ * updateBackgroundTab (NO signal markers, NO finalize) and return:
+ *   - handleTurnEnded: pendingBackgroundTasks/pendingSessionCrons/lastTerminalReason,
+ *     status 'awaiting-background' iff backgroundTasks.length>0 else 'loaded'.
+ *   - handleSubagentEnded: onStopped still runs; updateBackgroundTab with
+ *     pendingBackgroundTasks; status 'loaded' only when prior status was
+ *     'awaiting-background' AND remaining===0.
+ *   - handleTurnFailed: updateBackgroundTab with lastTerminalReason + status
+ *     'loaded'; no finalize; handleChatError STILL fires exactly once.
+ * The existing active-tab path (findTabsBySessionId hit) is unaffected and never
+ * calls updateBackgroundTab.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { TabManagerService } from '@ptah-extension/chat-state';
+import {
+  BackgroundAgentStore,
+  MessageFinalizationService,
+} from '@ptah-extension/chat-streaming';
+import {
+  SessionId,
+  type SdkSubagentEndedPayload,
+  type SdkTurnEndedPayload,
+  type SdkTurnFailedPayload,
+} from '@ptah-extension/shared';
+import type { TabState } from '@ptah-extension/chat-types';
+import { ChatLifecycleService } from './chat-lifecycle.service';
+import { TurnEndHandlerService } from './turn-end-handler.service';
+
+const SESS_PRIMARY = SessionId.create();
+const SESS_BG = SessionId.create();
+
+function makeTab(overrides: Partial<TabState> = {}): TabState {
+  return {
+    id: 'bg-tab',
+    title: 'Background',
+    status: 'awaiting-background',
+    messages: [],
+    streamingState: null,
+    currentMessageId: null,
+    claudeSessionId: SESS_BG,
+    ...overrides,
+  } as unknown as TabState;
+}
+
+function makeTurnEndedPayload(
+  overrides: Partial<SdkTurnEndedPayload> = {},
+): SdkTurnEndedPayload {
+  return {
+    sessionId: SESS_BG,
+    cwd: '/workspace',
+    lastAssistantMessage: 'done',
+    backgroundTasks: [],
+    sessionCrons: [],
+    terminalReason: 'completed',
+    timestamp: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function makeTurnFailedPayload(
+  overrides: Partial<SdkTurnFailedPayload> = {},
+): SdkTurnFailedPayload {
+  return {
+    sessionId: SESS_BG,
+    cwd: '/workspace',
+    lastAssistantMessage: null,
+    error: 'rate_limit',
+    errorDetails: null,
+    terminalReason: 'blocking_limit',
+    timestamp: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function makeSubagentEndedPayload(
+  overrides: Partial<SdkSubagentEndedPayload> = {},
+): SdkSubagentEndedPayload {
+  return {
+    sessionId: SESS_BG,
+    cwd: '/workspace',
+    agentId: 'agent-a',
+    agentType: 'subagent',
+    lastAssistantMessage: 'sub done',
+    backgroundTasks: [],
+    timestamp: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function makeBackgroundTask(id: string) {
+  return {
+    id,
+    type: 'subagent' as const,
+    status: 'running' as const,
+    description: 'still going',
+  };
+}
+
+describe('TurnEndHandlerService — background fallback', () => {
+  let service: TurnEndHandlerService;
+  let crossWsTab: TabState | null;
+  let findTabsBySessionIdMock: jest.Mock;
+  let findAcrossWorkspacesMock: jest.Mock;
+  let updateBackgroundTabMock: jest.Mock<boolean, [string, Partial<TabState>]>;
+  let setTurnEndedFieldsMock: jest.Mock;
+  let setLastTerminalReasonMock: jest.Mock;
+  let setPendingBackgroundTasksMock: jest.Mock;
+  let markTabIdleMock: jest.Mock;
+  let markTabAwaitingBackgroundMock: jest.Mock;
+  let markLoadedMock: jest.Mock;
+  let finalizeCurrentMessageMock: jest.Mock;
+  let handleChatErrorMock: jest.Mock;
+  let onStoppedMock: jest.Mock;
+  let findByAgentIdMock: jest.Mock;
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    crossWsTab = null;
+    findTabsBySessionIdMock = jest.fn(() => []);
+    findAcrossWorkspacesMock = jest.fn(() =>
+      crossWsTab ? { tab: crossWsTab, workspacePath: '/ws/bg' } : null,
+    );
+    updateBackgroundTabMock = jest.fn().mockReturnValue(true);
+    setTurnEndedFieldsMock = jest.fn();
+    setLastTerminalReasonMock = jest.fn();
+    setPendingBackgroundTasksMock = jest.fn();
+    markTabIdleMock = jest.fn();
+    markTabAwaitingBackgroundMock = jest.fn();
+    markLoadedMock = jest.fn();
+    finalizeCurrentMessageMock = jest.fn();
+    handleChatErrorMock = jest.fn();
+    onStoppedMock = jest.fn();
+    findByAgentIdMock = jest.fn().mockReturnValue(null);
+
+    const tabManagerMock = {
+      findTabsBySessionId: findTabsBySessionIdMock,
+      findTabBySessionIdAcrossWorkspaces: findAcrossWorkspacesMock,
+      updateBackgroundTab: updateBackgroundTabMock,
+      setTurnEndedFields: setTurnEndedFieldsMock,
+      setLastTerminalReason: setLastTerminalReasonMock,
+      setPendingBackgroundTasks: setPendingBackgroundTasksMock,
+      markTabIdle: markTabIdleMock,
+      markTabAwaitingBackground: markTabAwaitingBackgroundMock,
+      markLoaded: markLoadedMock,
+    } as unknown as TabManagerService;
+
+    const finalizationMock = {
+      finalizeCurrentMessage: finalizeCurrentMessageMock,
+    } as unknown as MessageFinalizationService;
+
+    const lifecycleMock = {
+      handleChatError: handleChatErrorMock,
+    } as unknown as ChatLifecycleService;
+
+    const backgroundAgentStoreMock = {
+      onStopped: onStoppedMock,
+      findByAgentId: findByAgentIdMock,
+    } as unknown as BackgroundAgentStore;
+
+    warn = jest.spyOn(console, 'warn').mockImplementation();
+
+    TestBed.configureTestingModule({
+      providers: [
+        TurnEndHandlerService,
+        { provide: TabManagerService, useValue: tabManagerMock },
+        { provide: MessageFinalizationService, useValue: finalizationMock },
+        { provide: ChatLifecycleService, useValue: lifecycleMock },
+        { provide: BackgroundAgentStore, useValue: backgroundAgentStoreMock },
+      ],
+    });
+    service = TestBed.inject(TurnEndHandlerService);
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+    TestBed.resetTestingModule();
+  });
+
+  describe('handleTurnEnded background fallback', () => {
+    it('updates the background tab with status loaded when no background work', () => {
+      crossWsTab = makeTab();
+
+      service.handleTurnEnded(
+        makeTurnEndedPayload({
+          backgroundTasks: [],
+          sessionCrons: [makeCron('cron-1')],
+        }),
+      );
+
+      expect(updateBackgroundTabMock).toHaveBeenCalledTimes(1);
+      const [tabId, updates] = updateBackgroundTabMock.mock.calls[0];
+      expect(tabId).toBe('bg-tab');
+      expect(updates).toEqual(
+        expect.objectContaining({
+          pendingBackgroundTasks: [],
+          lastTerminalReason: 'completed',
+          status: 'loaded',
+        }),
+      );
+      expect(updates.pendingSessionCrons).toEqual([
+        expect.objectContaining({ id: 'cron-1' }),
+      ]);
+    });
+
+    it('updates the background tab with status awaiting-background when tasks remain', () => {
+      crossWsTab = makeTab();
+
+      service.handleTurnEnded(
+        makeTurnEndedPayload({ backgroundTasks: [makeBackgroundTask('bg-x')] }),
+      );
+
+      expect(updateBackgroundTabMock.mock.calls[0][1].status).toBe(
+        'awaiting-background',
+      );
+    });
+
+    it('does NOT call signal markers or finalize on the background path', () => {
+      crossWsTab = makeTab();
+
+      service.handleTurnEnded(makeTurnEndedPayload());
+
+      expect(setTurnEndedFieldsMock).not.toHaveBeenCalled();
+      expect(markTabIdleMock).not.toHaveBeenCalled();
+      expect(markTabAwaitingBackgroundMock).not.toHaveBeenCalled();
+      expect(finalizeCurrentMessageMock).not.toHaveBeenCalled();
+    });
+
+    it('warns when neither an active nor a background tab is found', () => {
+      crossWsTab = null;
+
+      service.handleTurnEnded(makeTurnEndedPayload());
+
+      expect(updateBackgroundTabMock).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        '[ChatStore] handleTurnEnded: no tab bound to sessionId',
+        expect.objectContaining({ sessionId: SESS_BG }),
+      );
+    });
+
+    it('uses the active-tab path (no updateBackgroundTab) when a bound tab exists', () => {
+      findTabsBySessionIdMock.mockReturnValue([
+        makeTab({ claudeSessionId: SESS_PRIMARY }),
+      ]);
+
+      service.handleTurnEnded(
+        makeTurnEndedPayload({ sessionId: SESS_PRIMARY }),
+      );
+
+      expect(updateBackgroundTabMock).not.toHaveBeenCalled();
+      expect(setTurnEndedFieldsMock).toHaveBeenCalledWith(
+        'bg-tab',
+        expect.objectContaining({ lastTerminalReason: 'completed' }),
+      );
+      expect(finalizeCurrentMessageMock).toHaveBeenCalledWith('bg-tab', false);
+      expect(markTabIdleMock).toHaveBeenCalledWith('bg-tab');
+    });
+  });
+
+  describe('handleSubagentEnded background fallback', () => {
+    it('runs onStopped, then updates the bg tab to loaded when awaiting-background and remaining 0', () => {
+      crossWsTab = makeTab({ status: 'awaiting-background' });
+
+      service.handleSubagentEnded(
+        makeSubagentEndedPayload({ backgroundTasks: [] }),
+      );
+
+      expect(onStoppedMock).toHaveBeenCalledTimes(1);
+      expect(updateBackgroundTabMock).toHaveBeenCalledTimes(1);
+      const updates = updateBackgroundTabMock.mock.calls[0][1];
+      expect(updates.pendingBackgroundTasks).toEqual([]);
+      expect(updates.status).toBe('loaded');
+    });
+
+    it('omits the loaded status flip when background tasks remain', () => {
+      crossWsTab = makeTab({ status: 'awaiting-background' });
+
+      service.handleSubagentEnded(
+        makeSubagentEndedPayload({
+          backgroundTasks: [makeBackgroundTask('bg-b')],
+        }),
+      );
+
+      const updates = updateBackgroundTabMock.mock.calls[0][1];
+      expect(updates.pendingBackgroundTasks).toEqual([
+        expect.objectContaining({ id: 'bg-b' }),
+      ]);
+      expect(updates.status).toBeUndefined();
+    });
+
+    it('omits the loaded status flip when the bg tab was not awaiting-background', () => {
+      crossWsTab = makeTab({ status: 'loaded' });
+
+      service.handleSubagentEnded(
+        makeSubagentEndedPayload({ backgroundTasks: [] }),
+      );
+
+      expect(updateBackgroundTabMock.mock.calls[0][1].status).toBeUndefined();
+    });
+
+    it('does NOT call setPendingBackgroundTasks or markLoaded signal markers', () => {
+      crossWsTab = makeTab({ status: 'awaiting-background' });
+
+      service.handleSubagentEnded(
+        makeSubagentEndedPayload({ backgroundTasks: [] }),
+      );
+
+      expect(setPendingBackgroundTasksMock).not.toHaveBeenCalled();
+      expect(markLoadedMock).not.toHaveBeenCalled();
+    });
+
+    it('runs onStopped even when no tab is found anywhere, then warns', () => {
+      crossWsTab = null;
+
+      service.handleSubagentEnded(makeSubagentEndedPayload());
+
+      expect(onStoppedMock).toHaveBeenCalledTimes(1);
+      expect(updateBackgroundTabMock).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        '[ChatStore] handleSubagentEnded: no tab bound to sessionId',
+        expect.objectContaining({ sessionId: SESS_BG }),
+      );
+    });
+
+    it('uses the active-tab path (no updateBackgroundTab) when a bound tab exists', () => {
+      findTabsBySessionIdMock.mockReturnValue([
+        makeTab({
+          status: 'awaiting-background',
+          claudeSessionId: SESS_PRIMARY,
+        }),
+      ]);
+
+      service.handleSubagentEnded(
+        makeSubagentEndedPayload({
+          sessionId: SESS_PRIMARY,
+          backgroundTasks: [],
+        }),
+      );
+
+      expect(updateBackgroundTabMock).not.toHaveBeenCalled();
+      expect(setPendingBackgroundTasksMock).toHaveBeenCalledWith('bg-tab', []);
+      expect(markLoadedMock).toHaveBeenCalledWith('bg-tab');
+    });
+  });
+
+  describe('handleTurnFailed background fallback', () => {
+    it('updates the bg tab with lastTerminalReason + loaded, no finalize, error routed once', () => {
+      crossWsTab = makeTab();
+
+      service.handleTurnFailed(makeTurnFailedPayload());
+
+      expect(updateBackgroundTabMock).toHaveBeenCalledTimes(1);
+      const updates = updateBackgroundTabMock.mock.calls[0][1];
+      expect(updates.lastTerminalReason).toBe('blocking_limit');
+      expect(updates.status).toBe('loaded');
+
+      expect(finalizeCurrentMessageMock).not.toHaveBeenCalled();
+      expect(setLastTerminalReasonMock).not.toHaveBeenCalled();
+      expect(markTabIdleMock).not.toHaveBeenCalled();
+
+      expect(handleChatErrorMock).toHaveBeenCalledTimes(1);
+      expect(handleChatErrorMock).toHaveBeenCalledWith({
+        sessionId: SESS_BG,
+        error: 'Rate limited by Anthropic. Wait a moment and try again.',
+      });
+    });
+
+    it('still routes handleChatError once when no tab is found anywhere', () => {
+      crossWsTab = null;
+
+      service.handleTurnFailed(makeTurnFailedPayload());
+
+      expect(updateBackgroundTabMock).not.toHaveBeenCalled();
+      expect(handleChatErrorMock).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        '[ChatStore] handleTurnFailed: no tab bound to sessionId',
+        expect.objectContaining({ sessionId: SESS_BG }),
+      );
+    });
+
+    it('uses the active-tab path (no updateBackgroundTab) when a bound tab exists', () => {
+      findTabsBySessionIdMock.mockReturnValue([
+        makeTab({ claudeSessionId: SESS_PRIMARY }),
+      ]);
+
+      service.handleTurnFailed(
+        makeTurnFailedPayload({ sessionId: SESS_PRIMARY }),
+      );
+
+      expect(updateBackgroundTabMock).not.toHaveBeenCalled();
+      expect(finalizeCurrentMessageMock).toHaveBeenCalledWith('bg-tab', true);
+      expect(markTabIdleMock).toHaveBeenCalledWith('bg-tab');
+      expect(handleChatErrorMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+function makeCron(id: string) {
+  return { id, schedule: '*/5 * * * *', recurring: true, prompt: 'ping' };
+}

--- a/libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.service.spec.ts
@@ -341,7 +341,7 @@ describe('TurnEndHandlerService', () => {
       });
     });
 
-    it('warns and still routes the error once when no tab is bound to the sessionId', () => {
+    it('warns and no-ops when no tab is bound to the sessionId', () => {
       tabs = [];
       service.handleTurnFailed(
         makeTurnFailedPayload({ sessionId: SESS_UNKNOWN }),
@@ -349,7 +349,7 @@ describe('TurnEndHandlerService', () => {
 
       expect(setLastTerminalReasonMock).not.toHaveBeenCalled();
       expect(finalizeCurrentMessageMock).not.toHaveBeenCalled();
-      expect(handleChatErrorMock).toHaveBeenCalledTimes(1);
+      expect(handleChatErrorMock).not.toHaveBeenCalled();
       expect(warn).toHaveBeenCalledWith(
         '[ChatStore] handleTurnFailed: no tab bound to sessionId',
         expect.objectContaining({

--- a/libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.service.spec.ts
@@ -153,6 +153,8 @@ describe('TurnEndHandlerService', () => {
 
     const tabManagerMock = {
       findTabsBySessionId: findTabsBySessionIdMock,
+      findTabBySessionIdAcrossWorkspaces: jest.fn(() => null),
+      updateBackgroundTab: jest.fn(() => false),
       setTurnEndedFields: setTurnEndedFieldsMock,
       setLastTerminalReason: setLastTerminalReasonMock,
       setPendingBackgroundTasks: setPendingBackgroundTasksMock,
@@ -339,7 +341,7 @@ describe('TurnEndHandlerService', () => {
       });
     });
 
-    it('warns and no-ops when no tab is bound to the sessionId', () => {
+    it('warns and still routes the error once when no tab is bound to the sessionId', () => {
       tabs = [];
       service.handleTurnFailed(
         makeTurnFailedPayload({ sessionId: SESS_UNKNOWN }),
@@ -347,7 +349,7 @@ describe('TurnEndHandlerService', () => {
 
       expect(setLastTerminalReasonMock).not.toHaveBeenCalled();
       expect(finalizeCurrentMessageMock).not.toHaveBeenCalled();
-      expect(handleChatErrorMock).not.toHaveBeenCalled();
+      expect(handleChatErrorMock).toHaveBeenCalledTimes(1);
       expect(warn).toHaveBeenCalledWith(
         '[ChatStore] handleTurnFailed: no tab bound to sessionId',
         expect.objectContaining({
@@ -489,14 +491,14 @@ describe('TurnEndHandlerService', () => {
       expect(markLoadedMock).toHaveBeenCalledWith('tab-1');
     });
 
-    it('warns and no-ops when no tab is bound to the sessionId', () => {
+    it('warns and still runs onStopped when no tab is bound to the sessionId', () => {
       tabs = [];
 
       service.handleSubagentEnded(
         makeSubagentEndedPayload({ sessionId: SESS_UNKNOWN }),
       );
 
-      expect(onStoppedMock).not.toHaveBeenCalled();
+      expect(onStoppedMock).toHaveBeenCalledTimes(1);
       expect(setPendingBackgroundTasksMock).not.toHaveBeenCalled();
       expect(markLoadedMock).not.toHaveBeenCalled();
       expect(warn).toHaveBeenCalledWith(

--- a/libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.service.ts
@@ -172,9 +172,16 @@ export class TurnEndHandlerService {
 
   /**
    * Handle the `session:turnFailed` push (backend `StopFailure` SDK hook).
-   * Always finalizes as aborted and routes the SDK error through the
-   * existing `ChatLifecycleService.handleChatError` channel so the error
-   * surface, reset semantics, and session refresh stay co-located.
+   *
+   * When a foreground tab is bound to the session, finalizes as aborted and
+   * routes the SDK error through `ChatLifecycleService.handleChatError` so the
+   * error surface, reset semantics, and session refresh stay co-located.
+   *
+   * When no foreground tab is bound, the failure belongs to a background
+   * workspace (or no tab at all): stamp the background tab's terminal state via
+   * `updateBackgroundTab` and return. The foreground `handleChatError` channel
+   * is intentionally skipped — its active-tab fallback would otherwise reset an
+   * unrelated foreground tab for a failure that is not its own.
    */
   handleTurnFailed(payload: SdkTurnFailedPayload): void {
     const tabs = this.tabManager.findTabsBySessionId(
@@ -189,22 +196,19 @@ export class TurnEndHandlerService {
           lastTerminalReason: payload.terminalReason,
           status: 'loaded',
         });
-      } else {
-        console.warn(
-          '[ChatStore] handleTurnFailed: no tab bound to sessionId',
-          {
-            sessionId: payload.sessionId,
-            terminalReason: payload.terminalReason,
-            error: payload.error,
-          },
-        );
+        return;
       }
-    } else {
-      for (const tab of tabs) {
-        this.tabManager.setLastTerminalReason(tab.id, payload.terminalReason);
-        this.finalization.finalizeCurrentMessage(tab.id, true);
-        this.tabManager.markTabIdle(tab.id);
-      }
+      console.warn('[ChatStore] handleTurnFailed: no tab bound to sessionId', {
+        sessionId: payload.sessionId,
+        terminalReason: payload.terminalReason,
+        error: payload.error,
+      });
+      return;
+    }
+    for (const tab of tabs) {
+      this.tabManager.setLastTerminalReason(tab.id, payload.terminalReason);
+      this.finalization.finalizeCurrentMessage(tab.id, true);
+      this.tabManager.markTabIdle(tab.id);
     }
     const errorMessage = this.formatTurnFailedError(payload);
     this.lifecycle.handleChatError({

--- a/libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.service.ts
@@ -10,6 +10,7 @@ import {
   TabManagerService,
   type BackgroundAgentId,
 } from '@ptah-extension/chat-state';
+import type { TabState } from '@ptah-extension/chat-types';
 import {
   BackgroundAgentStore,
   MessageFinalizationService,
@@ -71,7 +72,22 @@ export class TurnEndHandlerService {
     const tabs = this.tabManager.findTabsBySessionId(
       SessionId.from(payload.sessionId),
     );
+    const isAborted =
+      payload.terminalReason !== 'completed' && payload.terminalReason !== null;
+    const hasBackgroundWork = payload.backgroundTasks.length > 0;
     if (tabs.length === 0) {
+      const lookup = this.tabManager.findTabBySessionIdAcrossWorkspaces(
+        payload.sessionId,
+      );
+      if (lookup) {
+        this.tabManager.updateBackgroundTab(lookup.tab.id, {
+          pendingBackgroundTasks: payload.backgroundTasks,
+          pendingSessionCrons: payload.sessionCrons,
+          lastTerminalReason: payload.terminalReason,
+          status: hasBackgroundWork ? 'awaiting-background' : 'loaded',
+        });
+        return;
+      }
       console.warn('[ChatStore] handleTurnEnded: no tab bound to sessionId', {
         sessionId: payload.sessionId,
         terminalReason: payload.terminalReason,
@@ -80,9 +96,6 @@ export class TurnEndHandlerService {
       });
       return;
     }
-    const isAborted =
-      payload.terminalReason !== 'completed' && payload.terminalReason !== null;
-    const hasBackgroundWork = payload.backgroundTasks.length > 0;
     for (const tab of tabs) {
       this.tabManager.setTurnEndedFields(tab.id, {
         pendingBackgroundTasks: payload.backgroundTasks,
@@ -112,13 +125,6 @@ export class TurnEndHandlerService {
   handleSubagentEnded(payload: SdkSubagentEndedPayload): void {
     const sessionId = SessionId.from(payload.sessionId);
     const tabs = this.tabManager.findTabsBySessionId(sessionId);
-    if (tabs.length === 0) {
-      console.warn(
-        '[ChatStore] handleSubagentEnded: no tab bound to sessionId',
-        { sessionId: payload.sessionId, agentId: payload.agentId },
-      );
-      return;
-    }
     const agentKey = payload.agentId as BackgroundAgentId;
     const knownEntry = this.backgroundAgents.findByAgentId(agentKey);
     const resolvedToolCallId = knownEntry?.toolCallId ?? '';
@@ -133,6 +139,26 @@ export class TurnEndHandlerService {
       agentType: payload.agentType,
     });
     const remaining = payload.backgroundTasks.length;
+    if (tabs.length === 0) {
+      const lookup = this.tabManager.findTabBySessionIdAcrossWorkspaces(
+        payload.sessionId,
+      );
+      if (lookup) {
+        const updates: Partial<TabState> = {
+          pendingBackgroundTasks: payload.backgroundTasks,
+        };
+        if (lookup.tab.status === 'awaiting-background' && remaining === 0) {
+          updates.status = 'loaded';
+        }
+        this.tabManager.updateBackgroundTab(lookup.tab.id, updates);
+        return;
+      }
+      console.warn(
+        '[ChatStore] handleSubagentEnded: no tab bound to sessionId',
+        { sessionId: payload.sessionId, agentId: payload.agentId },
+      );
+      return;
+    }
     for (const tab of tabs) {
       this.tabManager.setPendingBackgroundTasks(
         tab.id,
@@ -155,17 +181,30 @@ export class TurnEndHandlerService {
       SessionId.from(payload.sessionId),
     );
     if (tabs.length === 0) {
-      console.warn('[ChatStore] handleTurnFailed: no tab bound to sessionId', {
-        sessionId: payload.sessionId,
-        terminalReason: payload.terminalReason,
-        error: payload.error,
-      });
-      return;
-    }
-    for (const tab of tabs) {
-      this.tabManager.setLastTerminalReason(tab.id, payload.terminalReason);
-      this.finalization.finalizeCurrentMessage(tab.id, true);
-      this.tabManager.markTabIdle(tab.id);
+      const lookup = this.tabManager.findTabBySessionIdAcrossWorkspaces(
+        payload.sessionId,
+      );
+      if (lookup) {
+        this.tabManager.updateBackgroundTab(lookup.tab.id, {
+          lastTerminalReason: payload.terminalReason,
+          status: 'loaded',
+        });
+      } else {
+        console.warn(
+          '[ChatStore] handleTurnFailed: no tab bound to sessionId',
+          {
+            sessionId: payload.sessionId,
+            terminalReason: payload.terminalReason,
+            error: payload.error,
+          },
+        );
+      }
+    } else {
+      for (const tab of tabs) {
+        this.tabManager.setLastTerminalReason(tab.id, payload.terminalReason);
+        this.finalization.finalizeCurrentMessage(tab.id, true);
+        this.tabManager.markTabIdle(tab.id);
+      }
     }
     const errorMessage = this.formatTurnFailedError(payload);
     this.lifecycle.handleChatError({

--- a/libs/shared/src/lib/types/rpc.types.ts
+++ b/libs/shared/src/lib/types/rpc.types.ts
@@ -68,6 +68,8 @@ import type {
   SessionForkResult,
   SessionRewindParams,
   SessionRewindResult,
+  SessionStatusParams,
+  SessionStatusResponse,
 } from './rpc/rpc-session.types';
 
 import type {
@@ -490,6 +492,10 @@ export interface RpcMethodRegistry {
   'session:rewindFiles': {
     params: SessionRewindParams;
     result: SessionRewindResult;
+  };
+  'session:status': {
+    params: SessionStatusParams;
+    result: SessionStatusResponse;
   };
   'context:getAllFiles': {
     params: ContextGetAllFilesParams;
@@ -1981,6 +1987,7 @@ const RPC_METHOD_ENTRIES: Record<RpcMethodName, true> = {
   'session:stats-batch': true,
   'session:forkSession': true,
   'session:rewindFiles': true,
+  'session:status': true,
   'context:getAllFiles': true,
   'context:getFileSuggestions': true,
   'autocomplete:agents': true,

--- a/libs/shared/src/lib/types/rpc/rpc-session.types.ts
+++ b/libs/shared/src/lib/types/rpc/rpc-session.types.ts
@@ -254,6 +254,27 @@ export interface SessionRewindResult {
   deletions?: number;
 }
 
+/** Parameters for the `session:status` RPC method. */
+export interface SessionStatusParams {
+  /** Restored session UUID whose liveness the webview is probing. */
+  sessionId: string;
+}
+
+/**
+ * Response from the `session:status` RPC method.
+ *
+ * Lets a cold-loaded webview (panel hide→reshow, HMR/devtools reload)
+ * recover both whether the session process is alive and whether a turn is
+ * actively streaming right now — state that is otherwise lost across the
+ * webview recreation.
+ */
+export interface SessionStatusResponse {
+  /** Session is in the SDK lifecycle registry (process alive + known). */
+  isActive: boolean;
+  /** A turn is currently mid-stream to the webview for this session. */
+  isStreaming: boolean;
+}
+
 /** Catalog entry for an MCP-style tool advertised by `session.describe`. */
 export interface SessionDescribeToolEntry {
   /** Wire name as it appears in `tools/call` (e.g. `agent_spawn`). */


### PR DESCRIPTION
Switching workspaces left a running session's tab frozen: the backend keeps broadcasting stream events globally, but the frontend resolved the target tab only against the active-workspace signal and dropped events for any tab whose workspace had moved to the background. The user had to close and reopen the session to recover, with no way to tell whether it had finished.

- Add SessionLivenessRegistry: a workspace-agnostic, signal-backed per-session status store fed from the global message router. Tab-bar shows a live/done dot driven by it, so background-session state is observable from any workspace.
- Route background-workspace stream events through the existing (until now unused) findTabBySessionIdAcrossWorkspaces + updateBackgroundTab helpers: run the same accumulator against the background tab's streamingState and persist into the in-memory partition map + debounced storage, with no signal/RAF mutation. The active-workspace fast path is unchanged.
- Apply turn-end / subagent-end / turn-failed terminal state to the background tab when no active tab is bound.

Cold-restart-mid-turn is intentionally out of scope (no buffered replay).