### PR TITLE
chore(release): cli v0.2.6

### DIFF
--- a/apps/ptah-cli/package.json
+++ b/apps/ptah-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hive-academy/ptah-cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Headless agent-to-agent (A2A) CLI bridge for the Ptah coding orchestra. Drives the same DI graph as the Ptah VS Code extension and Electron app over JSON-RPC 2.0 stdio.",
   "license": "FSL-1.1-MIT",
   "author": "Ptah Extensions",


### PR DESCRIPTION
Auto-generated version bump after publishing @hive-academy/ptah-cli@0.2.6 to npm.