### PR TITLE
chore(release): electron v0.1.60

### DIFF
--- a/apps/ptah-electron/package.json
+++ b/apps/ptah-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptah-desktop",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "Ptah - AI Coding Orchestra. Standalone desktop app.",
   "main": "main.mjs",
   "author": {


### PR DESCRIPTION
Auto-generated version bump after publishing Electron Desktop v0.1.60.