### PR TITLE
feat(ci): mirror release branches instead of merging into them

### DIFF
--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -1,0 +1,144 @@
+# Fast-forward a release/* branch to main, then dispatch its pipeline.
+#
+# WHY THIS EXISTS
+# The release branches carry no unique work — they are deploy triggers that
+# only ever receive main. They used to be updated by opening a PR from main and
+# merging it, which quietly rotted them:
+#
+#   1. main carries files that `nx format:check` flags (there is no format gate).
+#   2. .lintstagedrc.mjs runs `nx format:write` on staged *.{ts,js,json,md}.
+#   3. A LOCAL merge of main into a release branch that hits conflicts stages
+#      those files; committing fires husky, which reformats them. The merge
+#      commit now differs from main in files nobody edited.
+#   4. Next time main touches one of those files, both sides have changed, so
+#      it CONFLICTS. Hand-resolving produces content that exists nowhere in
+#      main, and it sticks — every later merge re-conflicts on it.
+#
+# That is how release/electron ended up holding the pre-open-source premium
+# gating in gateway-chat-bridge.ts months after main deleted it (PR #443).
+#
+# A fast-forward has no merge commit, runs no hook, and has nothing to resolve,
+# so steps 3 and 4 cannot happen. If a release branch has drifted, this job
+# refuses to push and prints the divergent commits instead of papering over it.
+name: Sync Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Release branch to fast-forward to main'
+        required: true
+        type: choice
+        options:
+          - landing
+          - docs
+          - electron
+      trigger_pipeline:
+        description: 'Dispatch the deploy/publish workflow after syncing'
+        required: false
+        type: boolean
+        default: true
+      bump:
+        description: 'Version bump (electron only, ignored otherwise)'
+        required: false
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+
+concurrency:
+  group: sync-release-${{ inputs.target }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  fast-forward:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Fast-forward release/${{ inputs.target }} to main
+        env:
+          BRANCH: release/${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+
+          MAIN_SHA="$(git rev-parse origin/main)"
+          BRANCH_SHA="$(git rev-parse "origin/$BRANCH")"
+
+          if [ "$MAIN_SHA" = "$BRANCH_SHA" ]; then
+            echo "$BRANCH is already at main ($MAIN_SHA). Nothing to push."
+            exit 0
+          fi
+
+          # The whole guarantee: refuse anything that is not a fast-forward.
+          # A release branch that is not an ancestor of main has picked up work
+          # of its own -- reformatted merge commits, a hotfix landed directly,
+          # a hand-resolved conflict. Pushing over it would destroy that, and
+          # merging it back would be how the rot started. Stop and show it.
+          if ! git merge-base --is-ancestor "origin/$BRANCH" origin/main; then
+            {
+              echo "### :x: \`$BRANCH\` has drifted from main"
+              echo
+              echo "It is not an ancestor of main, so this cannot fast-forward."
+              echo
+              echo "Commits on \`$BRANCH\` that main does not have:"
+              echo '```'
+              git log --oneline origin/main.."origin/$BRANCH"
+              echo '```'
+              echo
+              echo "Files differing from main:"
+              echo '```'
+              git diff --stat origin/main "origin/$BRANCH"
+              echo '```'
+              echo
+              echo "Decide deliberately: port anything real onto main, then"
+              echo "reset the branch with \`git push --force-with-lease\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::$BRANCH is not an ancestor of main — refusing to push."
+            exit 1
+          fi
+
+          echo "Fast-forwarding $BRANCH: $BRANCH_SHA -> $MAIN_SHA"
+          git push origin "$MAIN_SHA:refs/heads/$BRANCH"
+
+      - name: Verify the branch now matches main exactly
+        env:
+          BRANCH: release/${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          git fetch origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+          if ! git diff --quiet origin/main "origin/$BRANCH"; then
+            echo "::error::$BRANCH still differs from main after the push."
+            git diff --stat origin/main "origin/$BRANCH"
+            exit 1
+          fi
+          echo ":white_check_mark: \`$BRANCH\` is byte-identical to main." >> "$GITHUB_STEP_SUMMARY"
+
+      # A push made with GITHUB_TOKEN does not trigger other workflows, so the
+      # deploy/publish job that listens on `push: release/*` will NOT fire on
+      # its own. Dispatch it explicitly.
+      - name: Dispatch the pipeline for release/${{ inputs.target }}
+        if: ${{ inputs.trigger_pipeline }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET: ${{ inputs.target }}
+          BUMP: ${{ inputs.bump }}
+        run: |
+          set -euo pipefail
+          case "$TARGET" in
+            landing)  gh workflow run deploy-landing.yml  --ref "release/landing" ;;
+            docs)     gh workflow run deploy-docs.yml     --ref "release/docs" ;;
+            electron) gh workflow run publish-electron.yml --ref "release/electron" -f "bump=$BUMP" ;;
+          esac
+          echo "Dispatched the pipeline for release/$TARGET." >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,28 @@ Scanner rejects extensions containing trademarked AI product names (`copilot`, `
 - Provider settings with trademarked keys moved to `~/.ptah/settings.json` (transparent via `IWorkspaceProvider.getConfiguration()`). Never re-add to `package.json contributes.configuration`.
 - **Once an extension ID fails marketplace validation, that ID is permanently burned.** Test throwaway IDs first.
 
+## Release Branches (`release/electron | landing | docs`)
+
+- **Never merge into a release branch, and never open a PR against one.** They
+  carry no work of their own — they are deploy triggers that mirror `main`.
+  Release with the **Sync Release Branch** workflow (`workflow_dispatch`), which
+  fast-forwards `release/<target>` to `main` and then dispatches its pipeline.
+- **Why the ban**: `main` ships files that `nx format:check` flags (there is no
+  format gate) and `.lintstagedrc.mjs` runs `nx format:write` on staged
+  `*.{ts,js,json,md}`. A _local_ merge into a release branch that hits conflicts
+  stages those files, so committing fires husky and reformats them — the merge
+  commit now differs from `main` in files nobody edited. The next merge then
+  conflicts on them, and hand-resolving mints content that exists nowhere in
+  `main` and never goes away. That is how `release/electron` still held the
+  pre-open-source premium gating in `gateway-chat-bridge.ts` months after `main`
+  deleted it (PR #443). A fast-forward has no merge commit, runs no hook, and
+  has nothing to resolve.
+- **A push made with `GITHUB_TOKEN` does not trigger other workflows**, so the
+  `on: push: release/*` deploy jobs do not fire from the sync. The sync workflow
+  dispatches them explicitly; that is deliberate, not a workaround to remove.
+- If the sync fails with "not an ancestor of main", the branch has drifted.
+  Port anything real onto `main` first — do **not** merge the branch back.
+
 ## Module Index
 
 ### Apps


### PR DESCRIPTION
Follow-up to #443. That PR's conflict was not a one-off — it was the visible end of a loop that regenerates itself on every conflicted local merge.

## The drift engine

1. `main` ships files that `nx format:check` flags — **1030** of them — and no workflow gates formatting (`grep -rn "prettier\|format:check" .github/workflows/*.yml` returns nothing).
2. `.lintstagedrc.mjs:5` runs `npx nx format:write` on staged `*.{ts,js,json,md}`.
3. A **local** merge of `main` into a release branch that hits conflicts stages those files. Committing fires husky, which reformats them — so the merge commit differs from `main` in files nobody edited. `f18eaf740` (local merge, 2026-07-11) is exactly this. The GitHub merge-button merges run no hooks and caused none of it.
4. Next time `main` touches one of those files, both sides have changed → **conflict**. Hand-resolving mints content that exists nowhere in `main`, and it sticks: every later merge re-conflicts on it.

Step 4 compounding is why `release/electron` still held the pre-open-source premium gating in `gateway-chat-bridge.ts` (`isPremiumTier`, `LICENSE_SERVICE`, `resolvePremiumContext`) months after `c00ed384a` deleted it. Its blob matched **no commit** in `main`'s history for that file.

Formatting each blob through the repo's own prettier config shows which side the hook wrote:

| file | `main` | `release/electron` |
|---|---|---|
| `command-replies.ts` | DIRTY | CLEAN |
| `gateway-command.service.ts` | DIRTY | CLEAN |
| `gateway-command.service.spec.ts` | DIRTY | CLEAN |
| `workspace-resolution.spec.ts` | DIRTY | CLEAN |

The release branch holds prettier's output. `main` is the non-compliant one. No human error is required for this to recur.

## The fix

A fast-forward has no merge commit, runs no hook, and has nothing to resolve — steps 3 and 4 become impossible. The release branches carry no work of their own to protect:

| branch | unique non-merge commits | vs `main` |
|---|---|---|
| `release/electron` | 3, all superseded | `main` is ancestor; tree ≡ `main` bar 6 whitespace-only files |
| `release/landing` | 0 | `main` is ancestor; tree **identical** |
| `release/docs` | 0 | **diverged** — 836 behind, `main` not an ancestor |

`Sync Release Branch` (`workflow_dispatch`) fast-forwards `release/<target>` to `main`, then dispatches that branch's pipeline.

**It refuses to guess.** If the target is not an ancestor of `main`, it fails and prints the divergent commits and the file-level diff to the job summary instead of force-pushing over them. So the drift guard comes free with the mechanism. After pushing it re-fetches and asserts `git diff --quiet main release/X`.

**The explicit dispatch is deliberate.** A push made with `GITHUB_TOKEN` does not trigger other workflows, so the `on: push: release/*` jobs would silently never fire. The workflow calls `gh workflow run` for the matching pipeline — that step is load-bearing, not a workaround to delete.

## Also found

Three backwards merges exist on `main` — `c7bd3f949`, `81f676b2b`, `15203c9fc` — because GitHub's conflict editor commits to the PR **head**, which is `main` for a `main → release/*` PR. All three changed **0 files**, so `main` was never polluted; they only advanced the merge base, which is what made the hybrids sticky. Banning PRs against release branches closes that door too.

## Validation

- YAML parses; all three `run` blocks pass `bash -n`.
- `CLAUDE.md` change is a pure 22-line addition (`nx format:write` applied, no unrelated churn).

## Not included

`release/docs` has diverged and will fail this workflow's ancestor check by design until it is reset — it needs a one-time `--force-with-lease` to establish the invariant. Same for the other two. Those pushes fire real pipelines, so they are a separate, deliberate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)