### PR TITLE
fix(electron): keep renderer packages out of the packaged app

### DIFF
--- a/.github/workflows/publish-electron.yml
+++ b/.github/workflows/publish-electron.yml
@@ -268,6 +268,17 @@ jobs:
       - name: Copy tree-sitter WASM (re-copy pre-pack)
         run: node scripts/copy-wasm.js dist/apps/ptah-electron
 
+      # Same cache-restore hazard as the WASM re-copy above, one file over:
+      # build-main's outputs include dist/apps/ptah-electron/package.json, so a
+      # restore brings back the UNPRUNED manifest that Nx generated from the
+      # project graph. Packing that manifest walks electron-builder into the
+      # renderer's packages and it dies on
+      #   production dependency not found  parent=monaco-editor
+      #     dependency=dompurify version=3.2.7
+      # because it does not read npm `overrides`. Re-run the prune (idempotent).
+      - name: Prune renderer-only deps from the packaged manifest (pre-pack)
+        run: node apps/ptah-electron/scripts/prune-dist-deps.js
+
       # macOS / Linux: single-shot package (build app + distributable together).
       # Windows is split below into dir-build -> sign-exe -> repack-NSIS so the
       # main app executable (Ptah.exe) carries the SSL.com IV signature INSIDE

--- a/apps/ptah-electron/project.json
+++ b/apps/ptah-electron/project.json
@@ -202,6 +202,10 @@
             "forwardAllArgs": false
           },
           {
+            "command": "node apps/ptah-electron/scripts/prune-dist-deps.js",
+            "forwardAllArgs": false
+          },
+          {
             "command": "node scripts/copy-wasm.js dist/apps/ptah-electron",
             "forwardAllArgs": false
           }
@@ -281,6 +285,7 @@
         "commands": [
           "node scripts/copy-wasm.js dist/apps/ptah-electron",
           "node apps/ptah-electron/scripts/patch-transformers-onnx-dep.js",
+          "node apps/ptah-electron/scripts/prune-dist-deps.js",
           "electron-builder --config electron-builder.yml --project dist/apps/ptah-electron",
           "node apps/ptah-electron/scripts/verify-packed-native.js",
           "node apps/ptah-electron/scripts/verify-packed-wasm.js",

--- a/apps/ptah-electron/scripts/lib/bundle-imports.js
+++ b/apps/ptah-electron/scripts/lib/bundle-imports.js
@@ -1,0 +1,162 @@
+/**
+ * bundle-imports.js
+ *
+ * One definition of "which npm packages does the electron main bundle actually
+ * import". Extracted from validate-deps.js so prune-dist-deps.js can gate on
+ * the same answer -- two scanners that disagree would let a package the bundle
+ * needs be pruned from the packaged manifest, which is exactly the failure the
+ * pruner exists to prevent.
+ *
+ * The bundle is minified ESM with esbuild's CommonJS require shims, so the
+ * specifier forms are matched explicitly rather than by parsing. A bare quoted
+ * string is NOT enough on its own: the bundle contains framework-detection
+ * lookups like `deps["@angular/core"] ? "angular" : ...` that read a scanned
+ * workspace's package.json and must not read as imports.
+ */
+
+'use strict';
+
+// Packages provided by the Electron runtime (never declared as dependencies).
+const RUNTIME_PROVIDED = new Set(['electron']);
+
+const NODE_BUILTINS = new Set([
+  'assert',
+  'buffer',
+  'child_process',
+  'cluster',
+  'console',
+  'constants',
+  'crypto',
+  'dgram',
+  'dns',
+  'domain',
+  'events',
+  'fs',
+  'http',
+  'http2',
+  'https',
+  'module',
+  'net',
+  'os',
+  'path',
+  'perf_hooks',
+  'process',
+  'punycode',
+  'querystring',
+  'readline',
+  'repl',
+  'stream',
+  'string_decoder',
+  'sys',
+  'timers',
+  'tls',
+  'tty',
+  'url',
+  'util',
+  'v8',
+  'vm',
+  'worker_threads',
+  'zlib',
+]);
+
+function isBuiltin(specifier) {
+  if (specifier.startsWith('node:')) return true;
+  const base = specifier.split('/')[0];
+  return NODE_BUILTINS.has(base);
+}
+
+function isValidPackageName(name) {
+  // npm package names: lowercase, may start with @scope/
+  return /^(@[a-z0-9][\w.-]*\/)?[a-z0-9][\w.-]*$/.test(name);
+}
+
+function getPackageName(specifier) {
+  if (specifier.startsWith('@')) {
+    const parts = specifier.split('/');
+    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : specifier;
+  }
+  return specifier.split('/')[0];
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * esbuild emits CommonJS require shims with UNSTABLE minified names when it
+ * targets ESM output. Their identifier changes every build (historically `Fc`,
+ * now `ve` / `yD` / `require`), so hardcoding one name silently misses external
+ * `require()` calls -- packages like chokidar, grammy, croner, better-sqlite3
+ * are loaded this way and were being false-flagged as "unused". Discover the
+ * shim identifiers from the bundle instead.
+ */
+function discoverRequireShims(src) {
+  const shims = new Set(['require', '__require']);
+  const patterns = [
+    // Banner / aliased createRequire result: `const X = <alias>(import.meta.url)`
+    /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*[A-Za-z_$][\w$]*\(import\.meta\.url\)/g,
+    // esbuild __require helper: `var X=(i=>typeof require<"u"?require:...`
+    /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*\(\s*[A-Za-z_$][\w$]*\s*=>\s*typeof require/g,
+  ];
+  for (const re of patterns) {
+    let m;
+    while ((m = re.exec(src)) !== null) shims.add(m[1]);
+  }
+  return shims;
+}
+
+/**
+ * Every bare package name the bundle imports, as a Set. Node builtins are
+ * excluded; `electron` is included (callers filter it via RUNTIME_PROVIDED).
+ */
+function collectExternalImports(bundle) {
+  const requireShims = discoverRequireShims(bundle);
+
+  // Match all import/require forms (handles minified code with no spaces):
+  //   - Static ESM:       from"pkg" / from 'pkg'
+  //   - Dynamic import:   import("pkg")   (how the in-process SDKs + jsonrepair load)
+  //   - Bare side-effect: import"pkg"     (e.g. reflect-metadata)
+  //   - Require shims:    require("pkg") / ve("pkg") / yD("pkg") — names discovered above
+  const importPatterns = [
+    /\bfrom\s*"([^"./][^"]*)"/g,
+    /\bfrom\s*'([^'./][^']*)'/g,
+    /\bimport\s*\(\s*"([^"./][^"]*)"\s*\)/g,
+    /\bimport\s*\(\s*'([^'./][^']*)'\s*\)/g,
+    // Bare side-effect import — must NOT be preceded by an identifier char (avoids
+    // matching the tail of tokens like `SETTINGS_IMPORT"`) and excludes `import(`.
+    /(?<![\w$.])import\s*"([^"(./][^"]*)"/g,
+    /(?<![\w$.])import\s*'([^'(./][^']*)'/g,
+  ];
+  for (const shim of requireShims) {
+    const s = escapeRegExp(shim);
+    importPatterns.push(
+      new RegExp(`(?<![\\w$])${s}\\(\\s*"([^"./][^"]*)"\\s*\\)`, 'g'),
+      new RegExp(`(?<![\\w$])${s}\\(\\s*'([^'./][^']*)'\\s*\\)`, 'g'),
+    );
+  }
+
+  const externalImports = new Set();
+  for (const pattern of importPatterns) {
+    let match;
+    while ((match = pattern.exec(bundle)) !== null) {
+      const specifier = match[1];
+      if (!isBuiltin(specifier)) {
+        const pkgName = getPackageName(specifier);
+        if (isValidPackageName(pkgName)) {
+          externalImports.add(pkgName);
+        }
+      }
+    }
+  }
+  return externalImports;
+}
+
+module.exports = {
+  RUNTIME_PROVIDED,
+  NODE_BUILTINS,
+  isBuiltin,
+  isValidPackageName,
+  getPackageName,
+  discoverRequireShims,
+  collectExternalImports,
+};

--- a/apps/ptah-electron/scripts/prune-dist-deps.js
+++ b/apps/ptah-electron/scripts/prune-dist-deps.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * prune-dist-deps.js
+ *
+ * Build-time gate. `build-main` runs with `generatePackageJson: true`, and Nx
+ * builds that manifest from the PROJECT GRAPH -- which includes
+ * `implicitDependencies: ["ptah-extension-webview"]`. That edge exists so the
+ * electron build cache-busts when the renderer changes (pinned by
+ * renderer-cache-key.spec.ts RI-1) and must stay, but it is a BUILD-TIME edge:
+ * Nx cannot tell it apart from a runtime one, so every renderer npm package
+ * lands in the packaged app's production dependencies.
+ *
+ * That is wrong twice over:
+ *
+ *   1. The renderer's packages are already bundled into
+ *      dist/apps/ptah-electron/renderer/*.js by the Angular build. Shipping
+ *      them again as node_modules is dead weight -- monaco-editor alone is
+ *      tens of MB, and `@angular-eslint/eslint-plugin-template` (a LINT
+ *      plugin) was being declared a production dependency.
+ *
+ *   2. It breaks packaging outright. electron-builder walks the dependency
+ *      tree from this manifest and validates each package's declared deps
+ *      against what is installed. monaco-editor pins `"dompurify": "3.2.7"`
+ *      exactly, while the root package.json deliberately overrides it:
+ *
+ *          "overrides": { "monaco-editor": { "dompurify": "^3.3.2" } }
+ *
+ *      npm honours that and hoists one dompurify. electron-builder does NOT
+ *      read `overrides` -- traversalNodeModulesCollector reads
+ *      monaco-editor/package.json directly and calls locatePackageWithVersion
+ *      for 3.2.7 -- so it fails with:
+ *
+ *          production dependency not found  parent=monaco-editor
+ *            dependency=dompurify version=3.2.7
+ *
+ *      Keeping monaco-editor out of the manifest keeps it out of the traversal.
+ *
+ * The rule: the packaged app's production dependencies are exactly those in the
+ * hand-maintained apps/ptah-electron/package.json. That is already the source
+ * of truth -- validate-deps.js asserts it covers every external import in
+ * main.mjs. This script makes the generated manifest agree with it.
+ *
+ * Safety gates, both fatal:
+ *   - a declared dependency missing from the generated manifest means the
+ *     generator changed semantics; pruning would then ship a broken app.
+ *   - a candidate for removal that main.mjs actually imports would cause
+ *     ERR_MODULE_NOT_FOUND at runtime, so it is never dropped silently.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { collectExternalImports } = require('./lib/bundle-imports');
+
+const ROOT = path.resolve(__dirname, '../../..');
+const DIST_DIR = path.join(ROOT, 'dist', 'apps', 'ptah-electron');
+const DIST_MANIFEST = path.join(DIST_DIR, 'package.json');
+const DIST_LOCKFILE = path.join(DIST_DIR, 'package-lock.json');
+const DIST_MAIN = path.join(DIST_DIR, 'main.mjs');
+const SOURCE_MANIFEST = path.join(
+  ROOT,
+  'apps',
+  'ptah-electron',
+  'package.json',
+);
+
+function fail(message) {
+  console.error(`[prune-dist-deps] ${message}`);
+  process.exit(1);
+}
+
+function readJson(file, label) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    fail(
+      `could not read/parse ${label} at ${file}: ` +
+        `${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+function main() {
+  if (!fs.existsSync(DIST_MANIFEST)) {
+    fail(
+      `generated manifest missing: ${DIST_MANIFEST}. ` +
+        `build-main (generatePackageJson) must run before this script.`,
+    );
+  }
+
+  const raw = fs.readFileSync(DIST_MANIFEST, 'utf8');
+  const generated = readJson(DIST_MANIFEST, 'generated manifest');
+  const source = readJson(SOURCE_MANIFEST, 'source manifest');
+
+  const declared = Object.keys(source.dependencies || {});
+  const generatedDeps = generated.dependencies || {};
+
+  const missing = declared.filter((name) => !(name in generatedDeps));
+  if (missing.length > 0) {
+    fail(
+      `the generated manifest is missing ${missing.length} dependency/ies ` +
+        `declared in apps/ptah-electron/package.json: ${missing.join(', ')}. ` +
+        `generatePackageJson changed semantics -- pruning now would ship a ` +
+        `broken app. Reconcile the two manifests before building.`,
+    );
+  }
+
+  const extra = Object.keys(generatedDeps).filter(
+    (name) => !declared.includes(name),
+  );
+  if (extra.length === 0) {
+    console.log(
+      '[prune-dist-deps] generated manifest already matches ' +
+        `apps/ptah-electron/package.json (${declared.length} dependencies).`,
+    );
+    return;
+  }
+
+  if (!fs.existsSync(DIST_MAIN)) {
+    fail(`main bundle missing: ${DIST_MAIN}. Cannot verify what it imports.`);
+  }
+  const bundle = fs.readFileSync(DIST_MAIN, 'utf8');
+  const imported = collectExternalImports(bundle);
+  const used = extra.filter((name) => imported.has(name));
+  if (used.length > 0) {
+    fail(
+      `refusing to prune ${used.length} package(s) that main.mjs imports: ` +
+        `${used.join(', ')}. Removing them would cause ERR_MODULE_NOT_FOUND ` +
+        `in the packaged app. Add them to apps/ptah-electron/package.json ` +
+        `instead (validate-deps.js enforces the same invariant).`,
+    );
+  }
+
+  for (const name of extra) delete generatedDeps[name];
+
+  const trailingNewline = raw.endsWith('\n') ? '\n' : '';
+  fs.writeFileSync(
+    DIST_MANIFEST,
+    JSON.stringify(generated, null, 2) + trailingNewline,
+  );
+
+  // Keep the generated lockfile's root dependency list in step. electron-builder
+  // prefers its npm collector when it can read a lockfile here and only falls
+  // back to manual traversal otherwise; leaving the two disagreeing would mean
+  // the packaged dependency set depends on which collector wins.
+  if (fs.existsSync(DIST_LOCKFILE)) {
+    const lockRaw = fs.readFileSync(DIST_LOCKFILE, 'utf8');
+    const lock = readJson(DIST_LOCKFILE, 'generated lockfile');
+    const rootEntry = (lock.packages || {})[''];
+    if (rootEntry && rootEntry.dependencies) {
+      for (const name of extra) delete rootEntry.dependencies[name];
+      fs.writeFileSync(
+        DIST_LOCKFILE,
+        JSON.stringify(lock, null, 2) + (lockRaw.endsWith('\n') ? '\n' : ''),
+      );
+    }
+  }
+
+  console.log(
+    `[prune-dist-deps] dropped ${extra.length} renderer-only package(s) from ` +
+      `the packaged manifest, leaving ${Object.keys(generatedDeps).length}: ` +
+      `${extra.sort().join(', ')}.`,
+  );
+}
+
+main();

--- a/apps/ptah-electron/scripts/validate-deps.js
+++ b/apps/ptah-electron/scripts/validate-deps.js
@@ -15,73 +15,14 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const {
+  RUNTIME_PROVIDED,
+  collectExternalImports,
+} = require('./lib/bundle-imports');
 
 const ROOT = path.resolve(__dirname, '..', '..', '..');
 const DIST_MAIN = path.join(ROOT, 'dist', 'apps', 'ptah-electron', 'main.mjs');
 const ELECTRON_PKG = path.join(ROOT, 'apps', 'ptah-electron', 'package.json');
-
-// Packages provided by Electron runtime (not needed in package.json)
-const RUNTIME_PROVIDED = new Set(['electron']);
-
-// Node.js built-in modules
-const NODE_BUILTINS = new Set([
-  'assert',
-  'buffer',
-  'child_process',
-  'cluster',
-  'console',
-  'constants',
-  'crypto',
-  'dgram',
-  'dns',
-  'domain',
-  'events',
-  'fs',
-  'http',
-  'http2',
-  'https',
-  'module',
-  'net',
-  'os',
-  'path',
-  'perf_hooks',
-  'process',
-  'punycode',
-  'querystring',
-  'readline',
-  'repl',
-  'stream',
-  'string_decoder',
-  'sys',
-  'timers',
-  'tls',
-  'tty',
-  'url',
-  'util',
-  'v8',
-  'vm',
-  'worker_threads',
-  'zlib',
-]);
-
-function isBuiltin(specifier) {
-  if (specifier.startsWith('node:')) return true;
-  const base = specifier.split('/')[0];
-  return NODE_BUILTINS.has(base);
-}
-
-function isValidPackageName(name) {
-  // npm package names: lowercase, may start with @scope/
-  return /^(@[a-z0-9][\w.-]*\/)?[a-z0-9][\w.-]*$/.test(name);
-}
-
-function getPackageName(specifier) {
-  if (specifier.startsWith('@')) {
-    const parts = specifier.split('/');
-    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : specifier;
-  }
-  return specifier.split('/')[0];
-}
 
 function validateNativeDeps() {
   const platform = process.platform; // 'win32' | 'darwin' | 'linux'
@@ -155,69 +96,7 @@ if (
 // Step 2: Read the bundle and find external imports
 const bundle = fs.readFileSync(DIST_MAIN, 'utf8');
 
-// esbuild emits CommonJS require shims with UNSTABLE minified names when it
-// targets ESM output. Their identifier changes every build (historically `Fc`,
-// now `ve` / `yD` / `require`), so hardcoding one name silently misses external
-// `require()` calls — packages like chokidar, grammy, croner, better-sqlite3
-// are loaded this way and were being false-flagged as "unused". Discover the
-// shim identifiers from the bundle instead.
-function discoverRequireShims(src) {
-  const shims = new Set(['require', '__require']);
-  const patterns = [
-    // Banner / aliased createRequire result: `const X = <alias>(import.meta.url)`
-    /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*[A-Za-z_$][\w$]*\(import\.meta\.url\)/g,
-    // esbuild __require helper: `var X=(i=>typeof require<"u"?require:...`
-    /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*\(\s*[A-Za-z_$][\w$]*\s*=>\s*typeof require/g,
-  ];
-  for (const re of patterns) {
-    let m;
-    while ((m = re.exec(src)) !== null) shims.add(m[1]);
-  }
-  return shims;
-}
-
-function escapeRegExp(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-const requireShims = discoverRequireShims(bundle);
-
-// Match all import/require forms (handles minified code with no spaces):
-//   - Static ESM:       from"pkg" / from 'pkg'
-//   - Dynamic import:   import("pkg")   (how the in-process SDKs + jsonrepair load)
-//   - Bare side-effect: import"pkg"     (e.g. reflect-metadata)
-//   - Require shims:    require("pkg") / ve("pkg") / yD("pkg") — names discovered above
-const importPatterns = [
-  /\bfrom\s*"([^"./][^"]*)"/g,
-  /\bfrom\s*'([^'./][^']*)'/g,
-  /\bimport\s*\(\s*"([^"./][^"]*)"\s*\)/g,
-  /\bimport\s*\(\s*'([^'./][^']*)'\s*\)/g,
-  // Bare side-effect import — must NOT be preceded by an identifier char (avoids
-  // matching the tail of tokens like `SETTINGS_IMPORT"`) and excludes `import(`.
-  /(?<![\w$.])import\s*"([^"(./][^"]*)"/g,
-  /(?<![\w$.])import\s*'([^'(./][^']*)'/g,
-];
-for (const shim of requireShims) {
-  const s = escapeRegExp(shim);
-  importPatterns.push(
-    new RegExp(`(?<![\\w$])${s}\\(\\s*"([^"./][^"]*)"\\s*\\)`, 'g'),
-    new RegExp(`(?<![\\w$])${s}\\(\\s*'([^'./][^']*)'\\s*\\)`, 'g'),
-  );
-}
-
-const externalImports = new Set();
-for (const pattern of importPatterns) {
-  let match;
-  while ((match = pattern.exec(bundle)) !== null) {
-    const specifier = match[1];
-    if (!isBuiltin(specifier)) {
-      const pkgName = getPackageName(specifier);
-      if (isValidPackageName(pkgName)) {
-        externalImports.add(pkgName);
-      }
-    }
-  }
-}
+const externalImports = collectExternalImports(bundle);
 
 // Step 3: Read electron package.json dependencies
 const electronPkg = JSON.parse(fs.readFileSync(ELECTRON_PKG, 'utf8'));

--- a/apps/ptah-electron/src/config/packaged-deps.spec.ts
+++ b/apps/ptah-electron/src/config/packaged-deps.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Guards the dependency set that actually ships inside the packaged Electron
+ * app.
+ *
+ * `build-main` runs with `generatePackageJson: true`, and Nx builds that
+ * manifest from the PROJECT GRAPH -- which includes
+ * `implicitDependencies: ["ptah-extension-webview"]` (pinned by
+ * renderer-cache-key.spec.ts RI-1, and load-bearing for cache correctness).
+ * Nx cannot tell a build-time edge from a runtime one, so the renderer's npm
+ * packages land in the packaged app's production dependencies: @angular/*,
+ * zone.js, monaco-editor, @xterm/*, gridstack, lucide-angular -- 20 packages,
+ * ~164 MB, all of them already bundled into the renderer's own JS output. One
+ * of them was `@angular-eslint/eslint-plugin-template`, a LINT plugin.
+ *
+ * That is not just waste. electron-builder walks the dependency tree from this
+ * manifest and validates each package's declared deps against what is
+ * installed. monaco-editor pins `"dompurify": "3.2.7"` exactly, while the root
+ * package.json deliberately overrides it to `^3.3.2`. npm honours the override
+ * and hoists a single dompurify; electron-builder does NOT read `overrides`
+ * (traversalNodeModulesCollector reads monaco-editor/package.json directly),
+ * so packaging died with:
+ *
+ *     production dependency not found  parent=monaco-editor
+ *       dependency=dompurify version=3.2.7
+ *
+ * prune-dist-deps.js reconciles the generated manifest back to the
+ * hand-maintained one. These specs pin the wiring that makes it run, and the
+ * invariant it depends on.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..');
+const APP_DIR = join(REPO_ROOT, 'apps', 'ptah-electron');
+const PROJECT_JSON_PATH = join(APP_DIR, 'project.json');
+const APP_MANIFEST_PATH = join(APP_DIR, 'package.json');
+const PUBLISH_WORKFLOW_PATH = join(
+  REPO_ROOT,
+  '.github',
+  'workflows',
+  'publish-electron.yml',
+);
+
+const PRUNE_COMMAND = 'apps/ptah-electron/scripts/prune-dist-deps.js';
+
+interface NxProjectConfig {
+  targets?: Record<
+    string,
+    { options?: { commands?: Array<string | { command?: string }> } }
+  >;
+}
+
+function commandsOf(config: NxProjectConfig, target: string): string[] {
+  return (config.targets?.[target]?.options?.commands ?? []).map((entry) =>
+    typeof entry === 'string' ? entry : (entry.command ?? ''),
+  );
+}
+
+const config = JSON.parse(
+  readFileSync(PROJECT_JSON_PATH, 'utf8'),
+) as NxProjectConfig;
+
+const appManifest = JSON.parse(readFileSync(APP_MANIFEST_PATH, 'utf8')) as {
+  dependencies?: Record<string, string>;
+};
+
+const publishWorkflow = readFileSync(PUBLISH_WORKFLOW_PATH, 'utf8');
+
+describe('packaged electron dependency set', () => {
+  // Anti-vacuity: every assertion below reads one of these, and would pass
+  // against `undefined` or an empty list if the file stopped parsing.
+  it('anti-vacuity: project.json parses with both packaging targets', () => {
+    expect(config.targets).toBeDefined();
+    expect(commandsOf(config, 'build').length).toBeGreaterThan(0);
+    expect(commandsOf(config, 'package').length).toBeGreaterThan(0);
+    expect(Object.keys(appManifest.dependencies ?? {}).length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it('the build target prunes the generated manifest', () => {
+    expect(commandsOf(config, 'build')).toContain(`node ${PRUNE_COMMAND}`);
+  });
+
+  // The prune must run AFTER patch-dist-overrides, which also rewrites the
+  // generated manifest -- running it first would just be overwritten.
+  it('the build target prunes after patching the dist overrides', () => {
+    const commands = commandsOf(config, 'build');
+    const patchIndex = commands.findIndex((c) =>
+      c.includes('patch-dist-overrides.js'),
+    );
+    const pruneIndex = commands.findIndex((c) => c.includes(PRUNE_COMMAND));
+    expect(patchIndex).toBeGreaterThanOrEqual(0);
+    expect(pruneIndex).toBeGreaterThan(patchIndex);
+  });
+
+  it('the package target prunes before electron-builder runs', () => {
+    const commands = commandsOf(config, 'package');
+    const pruneIndex = commands.findIndex((c) => c.includes(PRUNE_COMMAND));
+    const builderIndex = commands.findIndex((c) =>
+      c.startsWith('electron-builder '),
+    );
+    expect(pruneIndex).toBeGreaterThanOrEqual(0);
+    expect(builderIndex).toBeGreaterThan(pruneIndex);
+  });
+
+  // The CI hazard that makes the pre-pack re-run load-bearing: build-main's
+  // outputs include dist/apps/ptah-electron/package.json, so restoring its
+  // cache between `nx build` and packaging resurrects the unpruned manifest.
+  // This is the same reason copy-wasm.js is re-run there.
+  it('the publish workflow re-runs the prune immediately before packing', () => {
+    expect(publishWorkflow).toContain(`node ${PRUNE_COMMAND}`);
+
+    const pruneIndex = publishWorkflow.indexOf(`node ${PRUNE_COMMAND}`);
+    const packIndex = publishWorkflow.indexOf('npx electron-builder --config');
+    expect(packIndex).toBeGreaterThan(pruneIndex);
+  });
+
+  // The invariant prune-dist-deps.js relies on: the hand-maintained manifest is
+  // the source of truth for what the packaged app needs at runtime, and
+  // validate-deps.js independently asserts it covers every external import in
+  // main.mjs. If a renderer-only package were ever added here by hand, the
+  // prune would faithfully keep it and packaging would break again.
+  it('the hand-maintained manifest declares no renderer-only package', () => {
+    const declared = Object.keys(appManifest.dependencies ?? {});
+    const rendererOnly = declared.filter(
+      (name) =>
+        name.startsWith('@angular/') ||
+        name.startsWith('@xterm/') ||
+        name === 'zone.js' ||
+        name === 'monaco-editor' ||
+        name === 'ngx-monaco-editor-v2' ||
+        name === 'gridstack' ||
+        name === 'lucide-angular' ||
+        name === 'dompurify',
+    );
+    expect(rendererOnly).toEqual([]);
+  });
+});


### PR DESCRIPTION
Windows packaging has failed on every `release/electron` push since 2026-07-15 ([latest run](https://github.com/Hive-Academy/ptah-extension/actions/runs/32855952160)). macOS and Linux build fine, so `release` is skipped and nothing publishes.

```
⨯ production dependency not found  parent=monaco-editor dependency=dompurify version=3.2.7
⨯ Production dependency dompurify not found for package monaco-editor
```

## Why

`monaco-editor@0.55.1` pins `"dompurify": "3.2.7"` **exactly**. The root `package.json` deliberately overrides it:

```json
"overrides": { "monaco-editor": { "dompurify": "^3.3.2" } }
```

npm honours that and hoists a single dompurify. electron-builder does **not** read `overrides` — `traversalNodeModulesCollector` reads `monaco-editor/package.json` directly and calls `locatePackageWithVersion` for `3.2.7`:

```js
const prodDeps = await buildPackage(pkg.dependencies, (depName, version) => {
  log.error({ parent: moduleName, dependency: depName, version }, "production dependency not found")
```

## The deeper question: why is monaco walked at all?

`build-main` runs with `generatePackageJson: true`, and Nx builds that manifest from the **project graph** — which includes `implicitDependencies: ["ptah-extension-webview"]`. That edge is load-bearing for cache correctness (pinned by `renderer-cache-key.spec.ts` RI-1) and must stay, but Nx can't tell a build-time edge from a runtime one. So the renderer's npm packages became production dependencies of the packaged Electron app: **61 generated vs 41 hand-maintained**.

The 20 extras — `@angular/*`, `zone.js`, `monaco-editor`, `ngx-monaco-editor-v2`, `@xterm/*`, `gridstack`, `lucide-angular`, `@floating-ui/dom`, `dompurify`, `culori`, and `@angular-eslint/eslint-plugin-template` (a **lint plugin**) — are all already bundled into the renderer's own JS output. ~164 MB, led by monaco-editor (70 MB) and lucide-angular (46 MB).

## The fix

`prune-dist-deps.js` reconciles the generated manifest back to the hand-maintained `apps/ptah-electron/package.json`, which `validate-deps.js` already treats as the source of truth (it asserts that manifest covers every external import in `main.mjs`). Two fatal gates:

- a **declared** dep missing from the generated manifest ⇒ the generator changed semantics, and pruning would ship a broken app;
- a removal candidate that `main.mjs` actually imports is never dropped silently.

That second gate has to agree with `validate-deps.js` **exactly** — two scanners that disagree would prune something the bundle needs, which is the very failure the pruner exists to prevent. So the import scanner moved to `scripts/lib/bundle-imports.js` and both share it.

A naive "is the name quoted anywhere in the bundle" check is not sufficient, and my first attempt failed on it: the bundle contains framework-detection lookups reading a *scanned workspace's* manifest —

```js
deps["@angular/core"] ? "angular" : deps.react ? "react" : ...
```

— which are not imports. All four `@angular/core` occurrences are that pattern.

### Where it runs

`build`, `package` (before electron-builder), and again in the publish workflow immediately before packing. The last is **not** redundant: `build-main`'s outputs include `dist/apps/ptah-electron/package.json`, so a cache restore between `nx build` and packing resurrects the unpruned manifest — the same hazard that already forces `copy-wasm.js` to be re-run there.

## Verification

Reproduced the exact CI failure locally on Windows, then re-ran the same command after the fix:

- packaging now reaches `updating asar integrity executable resource executablePath=dist\release\win-unpacked\Ptah.exe`
- the packed `app.asar` contains **0** renderer-package entries under `node_modules` (13895 entries total)
- `verify-packed-wasm`, `verify-packed-onnx`, `verify-packed-native` all pass against the output — so `@vscode/tree-sitter-wasm` (21 MB) really was build-time only; `copy-wasm.js` places the grammars in `dist/wasm`
- `validate-deps.js` still exits 0 with the same report after the extraction
- `nx test ptah-electron`: 273 passed, 0 failed. `nx lint ptah-electron`: 0 errors (4 pre-existing warnings in untouched files)

The new `packaged-deps.spec.ts` was mutation-checked: removing the prune from `project.json` fails 2 of its 6 tests; restoring passes all 6.

The only thing that still stops the local run is winCodeSign cache extraction needing Windows symlink privilege, which CI runners have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)