### PR TITLE
fix(api-identity): point WORKOS_REDIRECT_URI at the route that exists

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,7 +97,7 @@ ADMIN_SECRET=CHANGE_ME_generate_with_openssl_rand_hex_32
 #   3. Create new environment (Development for local, Production for live)
 #   4. Copy API Key from "API Keys" section
 #   5. Copy Client ID from "Configuration" -> "OAuth"
-#   6. Add redirect URI: http://localhost:3000/api/auth/callback
+#   6. Add redirect URI: http://localhost:3000/api/v1/auth/callback
 #
 # API Key (starts with sk_test_ for sandbox, sk_live_ for production)
 WORKOS_API_KEY=sk_test_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -106,7 +106,7 @@ WORKOS_API_KEY=sk_test_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 WORKOS_CLIENT_ID=client_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 # OAuth callback URL - must match the redirect URI in WorkOS dashboard
-WORKOS_REDIRECT_URI=http://localhost:3000/api/auth/callback
+WORKOS_REDIRECT_URI=http://localhost:3000/api/v1/auth/callback
 
 # Optional: Redirect URL after logout
 WORKOS_LOGOUT_REDIRECT_URI=http://localhost:4200

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -93,7 +93,7 @@ ADMIN_EMAILS=admin@example.com
 WORKOS_API_KEY=PASTE_WORKOS_LIVE_API_KEY
 # [REQUIRED]
 WORKOS_CLIENT_ID=PASTE_WORKOS_CLIENT_ID
-WORKOS_REDIRECT_URI=https://api.ptah.live/api/auth/callback
+WORKOS_REDIRECT_URI=https://api.ptah.live/api/v1/auth/callback
 WORKOS_LOGOUT_REDIRECT_URI=https://ptah.live
 
 

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - release/server
+  # Needed by the Sync Release Branch workflow: a push made with GITHUB_TOKEN
+  # does not trigger other workflows, so after it fast-forwards release/server
+  # it has to dispatch this one explicitly.
+  workflow_dispatch:
 
 concurrency:
   group: deploy-server

--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -32,6 +32,7 @@ on:
         options:
           - landing
           - docs
+          - server
           - electron
       trigger_pipeline:
         description: 'Dispatch the deploy/publish workflow after syncing'
@@ -139,6 +140,7 @@ jobs:
           case "$TARGET" in
             landing)  gh workflow run deploy-landing.yml  --ref "release/landing" ;;
             docs)     gh workflow run deploy-docs.yml     --ref "release/docs" ;;
+            server)   gh workflow run deploy-server.yml   --ref "release/server" ;;
             electron) gh workflow run publish-electron.yml --ref "release/electron" -f "bump=$BUMP" ;;
           esac
           echo "Dispatched the pipeline for release/$TARGET." >> "$GITHUB_STEP_SUMMARY"

--- a/apps/ptah-license-server/src/common/workos-redirect-uri.spec.ts
+++ b/apps/ptah-license-server/src/common/workos-redirect-uri.spec.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
+import { RequestMethod, type Type } from '@nestjs/common';
+import { parse } from 'dotenv';
+
+import {
+  ALL_CONTROLLERS,
+  WORKSPACE_ROOT,
+} from '../testing/controller-registry';
+
+/**
+ * THE WORKOS CALLBACK URL AS AN EXECUTABLE ARTEFACT.
+ *
+ * ⚠️ WHY THIS TEST EXISTS.
+ * `.env.prod.example` shipped `WORKOS_REDIRECT_URI=https://api.ptah.live/api/auth/callback`
+ * while the route is, and always was, `/api/v1/auth/callback` — global prefix
+ * `api` (main.ts) + `@Controller('v1/auth')` + `@Get('callback')`. `.env.example`
+ * carried the same missing `v1` for local dev.
+ *
+ * Nothing catches that. The value is read straight into `AuthService.redirectUri`
+ * (`libs/api/identity/src/lib/services/auth.service.ts`) and handed to WorkOS as
+ * the authorization request's `redirectUri`, so WorkOS faithfully bounces the
+ * browser to whatever it was told. The server never sees the request, the logs
+ * are silent, and the user lands on:
+ *
+ *     {"message":"Cannot GET /api/auth/callback?code=…&state=…",
+ *      "error":"Not Found","statusCode":404}
+ *
+ * — holding a valid authorization code, one path segment from home. The failure
+ * surfaces only in a browser, only after a full round trip through WorkOS, and
+ * only in whichever environment copied the bad example. All four deployment docs
+ * had the URL right the whole time; the two files people actually `cp` had it
+ * wrong. Nobody diffs an example against prose.
+ *
+ * A comment cannot fail a build. This can.
+ *
+ * Deliberately dependency-free — no Postgres, no Nest bootstrap, no WorkOS. Both
+ * sides are DERIVED, never restated: the expected path is rebuilt from the
+ * global prefix in `main.ts` plus `PATH_METADATA`/`METHOD_METADATA` off the real
+ * controller class, and the actual value is read with dotenv's `parse()`, which
+ * returns an object and touches `process.env` for nobody. Hardcoding
+ * `/api/v1/auth/callback` here would just move the stale copy rather than
+ * removing it — rename the controller and this spec must fail, not agree.
+ */
+
+const ENV_FILES = ['.env.example', '.env.prod.example'] as const;
+const MAIN_TS = join(WORKSPACE_ROOT, 'apps/ptah-license-server/src/main.ts');
+
+/** The `const globalPrefix = '…'` that main.ts passes to setGlobalPrefix. */
+function readGlobalPrefix(): string {
+  const source = readFileSync(MAIN_TS, 'utf8');
+  const match = /const\s+globalPrefix\s*=\s*['"]([^'"]+)['"]/.exec(source);
+  if (!match) {
+    throw new Error(
+      `Could not read globalPrefix from ${MAIN_TS}. If setGlobalPrefix stopped ` +
+        `taking a literal, update this reader rather than hardcoding the prefix.`,
+    );
+  }
+  return match[1];
+}
+
+/** `GET`-able paths on a controller, as `<controller-prefix>/<handler-path>`. */
+function getRoutesOf(controller: Type<unknown>): string[] {
+  const strip = (s: string) => s.replace(/^\/+|\/+$/g, '');
+  const prefix = strip(
+    (Reflect.getMetadata(PATH_METADATA, controller) as string) ?? '',
+  );
+  const proto = controller.prototype as object;
+
+  const routes: string[] = [];
+  for (const handler of Object.getOwnPropertyNames(proto)) {
+    if (handler === 'constructor') continue;
+    const fn = Object.getOwnPropertyDescriptor(proto, handler)?.value as
+      | object
+      | undefined;
+    if (!fn) continue;
+
+    // RequestMethod.GET === 0, so this MUST be an undefined check. A falsy
+    // check would drop every GET route and pass vacuously.
+    const method = Reflect.getMetadata(METHOD_METADATA, fn) as
+      | RequestMethod
+      | undefined;
+    if (method === undefined || method !== RequestMethod.GET) continue;
+
+    const path = strip(
+      (Reflect.getMetadata(PATH_METADATA, fn) as string) ?? '',
+    );
+    routes.push([prefix, path].filter(Boolean).join('/'));
+  }
+  return routes;
+}
+
+const globalPrefix = readGlobalPrefix();
+
+const allGetPaths = new Set(
+  ALL_CONTROLLERS.flatMap((entry) =>
+    getRoutesOf(entry.controller as Type<unknown>).map(
+      (route) => `/${globalPrefix}/${route}`,
+    ),
+  ),
+);
+
+const envValues = new Map<string, string | undefined>(
+  ENV_FILES.map((file) => [
+    file,
+    parse(readFileSync(join(WORKSPACE_ROOT, file), 'utf8'))[
+      'WORKOS_REDIRECT_URI'
+    ],
+  ]),
+);
+
+describe('WORKOS_REDIRECT_URI matches a real callback route', () => {
+  // Anti-vacuity. Every assertion below is a membership test against
+  // `allGetPaths`; if the enumerator silently produced nothing, or the env
+  // files stopped parsing, the interesting assertions would still "pass" for
+  // the wrong reason.
+  it('anti-vacuity: the route enumerator and the env reader both work', () => {
+    expect(globalPrefix).toBe('api');
+    expect(allGetPaths.size).toBeGreaterThan(10);
+    for (const [file, value] of envValues) {
+      expect(`${file}: ${value ?? '<missing>'}`).toMatch(/^\S+: https?:\/\//);
+    }
+  });
+
+  // The route this is all about — derived, so renaming the controller or the
+  // handler fails here instead of in a browser after a WorkOS round trip.
+  it('the auth callback route exists under the global prefix', () => {
+    expect([...allGetPaths]).toContain(`/${globalPrefix}/v1/auth/callback`);
+  });
+
+  it.each(ENV_FILES)(
+    '%s points WORKOS_REDIRECT_URI at a route the server actually serves',
+    (file) => {
+      const value = envValues.get(file);
+      expect(value).toBeDefined();
+
+      const { pathname } = new URL(value as string);
+      // The whole bug in one assertion: `/api/auth/callback` is not a route.
+      expect([...allGetPaths]).toContain(pathname);
+    },
+  );
+});


### PR DESCRIPTION
Sign-in ends on a 404. WorkOS completes authentication, then redirects the browser to:

```
https://api.ptah.live/api/auth/callback?code=01M0WT938MGWP8MX8BND210NWS&state=…
{"message":"Cannot GET /api/auth/callback?code=…","error":"Not Found","statusCode":404}
```

The user is holding a **valid authorization code**, one path segment from home.

## Why

The route is `/api/v1/auth/callback` — global prefix `api` (`main.ts:81`) + `@Controller('v1/auth')` + `@Get('callback')`. Probing production shows both halves:

| | |
|---|---|
| `GET /api/auth/callback?code=…` | **404** — no such route |
| `GET /api/v1/auth/callback?code=…` | **401** `{"error":"Invalid session"}` — handler exists and ran |
| `GET /api/health` | 200 |

`WORKOS_REDIRECT_URI` is read into `AuthService.redirectUri` (`libs/api/identity/src/lib/services/auth.service.ts:40`) and passed to WorkOS as the authorization request's `redirectUri`, so WorkOS faithfully sends the browser wherever it was told. Both env templates omitted the `v1`:

```diff
-WORKOS_REDIRECT_URI=https://api.ptah.live/api/auth/callback
+WORKOS_REDIRECT_URI=https://api.ptah.live/api/v1/auth/callback
```

Every environment seeded by copying them inherited it. All four deployment docs (`DIGITALOCEAN.md`, `PRODUCTION_DEPLOYMENT.md`, `PRE_PUBLISH_AUDIT_HANDOFF.md`, `COOKIES.md`) had the URL right the whole time — the two files people actually `cp` had it wrong, and nobody diffs an example against prose.

The failure surfaces only in a browser, only after a full round trip through WorkOS, and only in whichever environment copied the bad template. The server never sees the request; the logs are silent.

## The guard

`workos-redirect-uri.spec.ts` derives **both** sides, so it can't rot into agreement with a stale copy:

- **expected** — global prefix parsed out of `main.ts`, joined with `PATH_METADATA`/`METHOD_METADATA` read off the real controller classes via the existing `ALL_CONTROLLERS` registry (same registry `route-map.spec.ts` and `controller-validation.spec.ts` use, so the structural guards can't disagree about what "every controller" means)
- **actual** — `dotenv.parse()` on the two templates, which returns an object and never touches `process.env`

Hardcoding `/api/v1/auth/callback` would just relocate the stale copy. Rename the controller and this spec must **fail**, not agree.

Dependency-free: no Postgres, no Nest bootstrap, no WorkOS. Follows the idiom of `prisma-config-env.spec.ts` and `route-map.spec.ts` — *"A comment cannot fail a build. This can."*

Mutation-checked: restoring the buggy value fails with
```
Expected value: "/api/auth/callback"
Received array: [… "/api/v1/auth/callback" …]
```

## Also: release/server

While tracing the deploy path I found a **fourth** release branch. `release/server` is 74 commits behind main with 0 unique commits — the same mirroring situation as the three handled in #445, and it was missed there. Added to the Sync Release Branch targets.

Dispatching its deploy needs a `workflow_dispatch` trigger on `deploy-server.yml`, because a push made with `GITHUB_TOKEN` does not trigger other workflows. That's the same constraint already documented in the sync workflow.

## Not included — the live API still needs two manual steps

This PR fixes the templates and the guard. It does **not** fix production, and the fix does not belong in the running container: `deploy-server.yml` writes `.env.prod` on the droplet from the `ENV_PROD_FILE` secret on every deploy, so a hand-edit inside the container is overwritten on the next one. See the PR discussion for the exact steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)