### PR TITLE
fix(chat): close the eight confirmed in-review blockers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,26 @@ jobs:
       # `coverageThreshold` stanzas in each `jest.config.ts` are ratcheted
       # to the current baseline rounded down to the nearest 5. A drop below
       # the floor fails the job; specs are free to increase coverage.
+      # `--maxWorkers=2`, because `--parallel=3` bounds the wrong thing. It caps
+      # Nx TASKS; each task then starts its own Jest coordinator, and no
+      # jest.config in this repo sets `maxWorkers`, so every pool defaults to
+      # `availableParallelism() - 1`. Three tasks on a runner therefore ask for
+      # three coordinators plus up to ~45 workers, under coverage
+      # instrumentation, beside the real `node` children cli-engine's auth specs
+      # spawn on purpose. That is the oversubscription behind suites running
+      # 114-250 s in CI against seconds locally (TASK_2026_392).
+      #
+      # Measured on one host, warm: cli-engine coverage 16.9 s → 9.2 s at
+      # `--maxWorkers=2`; agent-sdk 17.2 s → 8.1 s at `--maxWorkers=4`, and the
+      # "worker process failed to exit gracefully" warning stopped appearing.
+      # Capping is FASTER here, not a trade — an oversubscribed pool spends its
+      # time context-switching.
+      #
+      # `--forceExit` is deliberately NOT used. Jest already force-exits a
+      # worker that misses its 500 ms deadline, so the flag would only cut off
+      # the coordinator's own coverage write, and TASK_2026_392 measured no
+      # leaked handle for it to paper over.
       - name: Run affected tests with coverage
-        run: npx nx affected -t test --coverage --parallel=3
+        run: npx nx affected -t test --coverage --parallel=3 --maxWorkers=2
 
       - run: npx nx affected -t build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,12 @@ jobs:
       # worker that misses its 500 ms deadline, so the flag would only cut off
       # the coordinator's own coverage write, and TASK_2026_392 measured no
       # leaked handle for it to paper over.
+      # Invoked through the local nx binary rather than `npx` for the same
+      # reason the degradation-audit step above is (githubactions:S6505, S8543
+      # — cwe:494, cwe:829). This line was pre-existing and therefore exempt
+      # until the worker cap edited it; an edited line is new code to the
+      # scanner, so the exemption ended with the edit.
       - name: Run affected tests with coverage
-        run: npx nx affected -t test --coverage --parallel=3 --maxWorkers=2
+        run: node node_modules/nx/bin/nx.js affected -t test --coverage --parallel=3 --maxWorkers=2
 
       - run: npx nx affected -t build

--- a/.ptah/specs/TASK_2026_360/task.md
+++ b/.ptah/specs/TASK_2026_360/task.md
@@ -1,6 +1,6 @@
 ---
 id: TASK_2026_360
-status: in_review
+status: done
 type: BUGFIX
 title: >-
   Backend-owned session turn state as the single source of truth for streaming

--- a/.ptah/specs/TASK_2026_361/task.md
+++ b/.ptah/specs/TASK_2026_361/task.md
@@ -1,6 +1,6 @@
 ---
 id: TASK_2026_361
-status: in_review
+status: done
 type: BUGFIX
 title: >-
   Setup wizard: honest phase and generation outcomes, on-disk enhanced prompt,

--- a/.ptah/specs/TASK_2026_364/task.md
+++ b/.ptah/specs/TASK_2026_364/task.md
@@ -1,6 +1,6 @@
 ---
 id: TASK_2026_364
-status: in_review
+status: done
 type: BUGFIX
 title: >-
   CLI agent spawning validates against the process-global workspace root, not the

--- a/.ptah/specs/TASK_2026_366/task.md
+++ b/.ptah/specs/TASK_2026_366/task.md
@@ -1,5 +1,5 @@
 ---
-status: in_review
+status: done
 type: bugfix
 title: Suppress empty assistant message envelopes
 ---

--- a/.ptah/specs/TASK_2026_367/task.md
+++ b/.ptah/specs/TASK_2026_367/task.md
@@ -1,6 +1,6 @@
 ---
 id: TASK_2026_367
-status: in_review
+status: done
 type: BUGFIX
 title: >-
   Fix the seven defect clusters surfaced by tmp/logs/log.log

--- a/.ptah/specs/TASK_2026_368/task.md
+++ b/.ptah/specs/TASK_2026_368/task.md
@@ -1,5 +1,5 @@
 ---
-status: in_review
+status: done
 type: bugfix
 title: Electron main process never exits after a deferred will-quit on Windows
 description: >-

--- a/.ptah/specs/TASK_2026_371/task.md
+++ b/.ptah/specs/TASK_2026_371/task.md
@@ -1,5 +1,5 @@
 ---
-status: in_review
+status: done
 type: bugfix
 title: Resumed session drops its terminal turn_state, so the UI spinner never clears
 description: >-

--- a/.ptah/specs/TASK_2026_376/runtime-gate.md
+++ b/.ptah/specs/TASK_2026_376/runtime-gate.md
@@ -1,0 +1,255 @@
+# TASK_2026_376 — runtime gate
+
+- Date: 2026-09-08
+- Branch: `fix/in-review-blockers` (worktree branch; the task's own history
+  ships through `fix/empty-assistant-bubbles` upstream of this worktree)
+- Worktree: `D:\projects\ptah-extension\.claude-worktrees\in-review-blockers`
+- `git rev-parse HEAD`: `a008d9841399a68e83b9fc7be39b3eed3eca50e5`
+- Working tree was NOT clean: other lanes were editing this worktree
+  concurrently while the build and the test runs in §A executed
+  (uncommitted changes in `sdk-query-runner.service.ts`,
+  `streaming-handler.service.ts`, `message-dispatch.service.ts`,
+  `message-sender.service.ts`, `chat-input.component.ts` and their specs,
+  plus `agent-generation`, `cli-agent-runtime`, `setup-wizard`). None of the
+  files cited in §B is among them, but the numbers in §A are for HEAD plus
+  that in-flight work, not for HEAD alone.
+- The code under test includes commit `1bd7610d4` ("fix(chat-streaming): stop
+  minting empty assistant bubbles from orphaned subagent messages",
+  2026-09-06). `git merge-base --is-ancestor 1bd7610d4 HEAD` confirms it is
+  already an ancestor of HEAD. Its own commit message states behaviours 2 and
+  3 were still observed live three days after TASK_2026_376's original fix
+  reached `main` — that is itself evidence the 2026-09-03 fix did not fully
+  close the gate, so this gate evaluates the tree AFTER 1bd7610d4, not the
+  original TASK_2026_376 diff alone.
+
+## A. Electron e2e run
+
+Command: `npx nx run ptah-electron-e2e:e2e --configuration=ci`, run from the
+worktree root on 2026-09-08 (local time 01:57-03:20). The orchestrator ran it;
+the lane agent did not.
+
+**Environment fix needed before the build would run.** The worktree's
+`node_modules` held only an `ng-packagr` tsbuildinfo cache. Jest resolves
+packages by walking up to `D:\projects\ptah-extension\node_modules`, but the
+Angular builder resolves `angular.json` `styles`/`scripts` entries such as
+`node_modules/prismjs/themes/prism-tomorrow.css` relative to the workspace
+root, so the first attempt failed with three `Could not resolve` errors and
+never reached Playwright (`EXIT=130`). `package.json` in this worktree is
+byte-identical to the main checkout's, so the cache dir was replaced with a
+directory junction `node_modules -> D:\projects\ptah-extension\node_modules`
+(gitignored; not a source change) and the run was repeated.
+
+**Build (second attempt): green.**
+
+```
+NX   Successfully ran target build for project ptah-extension-webview and 3 tasks it depends on
+NX   Successfully ran target build-main for project ptah-electron
+NX   Successfully ran target build-preload for project ptah-electron
+NX   Successfully ran target build-embedder-worker for project ptah-electron
+NX   Successfully ran target build-voice-worker for project ptah-electron
+Running 164 tests using 1 worker
+```
+
+`dist/apps/ptah-electron/main.mjs` written 2026-09-08 02:19:58.
+
+**Full suite: NOT completed.** 37 of 164 specs ran in ~55 minutes (25 passed,
+12 failed) before the orchestrator stopped the run. At ~90 s per spec the
+remaining 127 would have needed ~3 more hours. Every failure sat at the 60 s
+spec timeout (reported at 1.2-1.3 m including teardown) and they were
+scattered across unrelated areas — `auto-updater` (2), `canvas` (1),
+`clipboard` (2), `electron-browser-capabilities` (1), `git/*` (5),
+`chat/streaming-message-handlers` (1). During that window two other Jest runs
+were competing for the same machine (the lane agent's `run-many` and the
+orchestrator's own, §B below), and the main-process log shows
+`SDK supportedModels() timed out after 15000ms` during boot. Read the 12
+failures as host contention, not as verdicts on the specs: the one chat spec
+among them passed cleanly when re-run alone (next paragraph).
+
+**Task-relevant subset, re-run alone after the full run was stopped
+(`npx playwright test --config=playwright.config.ts --reporter=list src/specs/chat`,
+cwd `apps/ptah-electron-e2e`):**
+
+```
+ok 1 chat/empty-assistant-envelope.spec.ts:117 › a naked message_start/message_complete envelope sharing a message id with a real text delivery renders one visible bubble, not an empty "Assistant response" placeholder (13.6s)
+ok 2 chat/empty-assistant-envelope.spec.ts:161 › the naked envelope alone (no follow-up ever) reproduces the pre-fix empty "Assistant response" bubble — proving the assertions above are falsifiable (12.7s)
+ok 3 chat/streaming-message-handlers.spec.ts:63 › valid payloads for all six rewritten schemas are accepted (no reject warning), with the app never having opened a chat session (11.8s)
+ok 4 chat/streaming-message-handlers.spec.ts:190 › invalid payloads for turnEnded and permission:request are rejected (reject warning fires), proving the reject path still works too (13.7s)
+4 passed (52.5s)
+```
+
+And `src/specs/thoth/memory.spec.ts` alone: `3 passed (1.0m)`.
+
+**Which specs touch this task's behaviours, and how far they reach.**
+
+- `chat/empty-assistant-envelope.spec.ts` — behaviour 3, rendering half only.
+  Injects `chat:chunk` events over IPC via `ui.pushEvent`; no SDK. Passed.
+- `chat/streaming-message-handlers.spec.ts` — adjacent to behaviour 1: proves
+  the real app accepts and rejects `session:subagentEnded` payload shapes.
+  Never omits `agentId`, never sends `toolCallId`, never reads
+  `BackgroundAgentStore`. Passed.
+- `thoth/memory.spec.ts` — adjacent to behaviour 4 only in that it renders
+  the Memory tab over mocked RPC. Never reaches the curator. Passed.
+- No e2e spec pushes `background_agent_started`, a backgrounded-placeholder
+  `tool_result`, an orphaned post-turn subagent message, or a curation
+  window. Behaviours 1, 2 and 4 have zero e2e coverage; behaviour 3 has
+  e2e coverage of the TASK_2026_366 envelope shape, not of the
+  `1bd7610d4` orphaned-subagent path.
+
+**Unit suites, run by the orchestrator on this tree**
+(`npx nx run-many -t test -p @ptah-extension/agent-sdk @ptah-extension/memory-curator @ptah-extension/chat-streaming @ptah-extension/chat @ptah-extension/shared --skip-nx-cache`):
+
+```
+NX   Running target test for 5 projects
+Test Suites: 54 passed, 54 total                 Tests: 1254 passed
+Test Suites: 2 skipped, 30 passed, 30 of 32      Tests: 60 skipped, 478 passed
+Test Suites: 1 skipped, 86 passed, 86 of 87      Tests: 2 skipped, 1442 passed
+Test Suites: 22 passed, 22 total                 Tests: 1 skipped, 451 passed
+Test Suites: 64 passed, 64 total                 Tests: 2 skipped, 1008 passed
+NX   Successfully ran target test for 5 projects
+```
+
+5 projects requested, 5 reported. 4633 passed, 0 failed. Each project printed
+Jest's "worker process has failed to exit gracefully" warning — the leaked
+queue waiters the gate review's O4 describes — but no test failed on this
+run. Every spec cited in §B is inside this set.
+
+## B. Per-behaviour evidence
+
+### Behaviour 1 — the missing-`agentId` warning stops, or the agent still reaches a terminal state
+
+**(i) Code.**
+
+- `libs/shared/src/lib/types/sdk-hook.types.ts:161` — `SdkSubagentEndedPayload.toolCallId` is now `readonly toolCallId?: string`, an optional field, with a doc comment (`:151-156`) explaining `agentId` and `toolCallId` are two identity spaces.
+- `libs/shared/src/lib/types/sdk-hook.schemas.ts:109` — `toolCallId: z.string().min(1).optional().catch(undefined)`, so an invalid value degrades to absent instead of rejecting the whole payload (R2's resolution of the finding-1/finding-5 conflict in the review round).
+- `libs/shared/src/lib/types/sdk-hook.parsers.ts:244-245` — `readOptionalCaught(payload, 'toolCallId', isNonEmptyWireString, ...)` carries the field through the hand-rolled parser.
+- `libs/backend/agent-sdk/src/lib/helpers/subagent-stop-hook-handler.ts:87-103` — the producer. It reads the SDK hook's `toolUseID` (`:93`) and includes it on the payload only when present (`:103`), with a comment recording that this is the ONLY place the `agentId` ↔ `toolCallId` pairing is still available, because the `SubagentHookHandler` twin deletes the registry record on the same hook first.
+- `libs/frontend/chat-streaming/src/lib/background-agent.store.ts:301-330` (`adoptRealAgentId`) — re-keys a `toolCallId`-filed entry onto the real `agentId` once it arrives, flipping `hasRealAgentId` to `true` (`:326`). The console warning itself is unchanged and still fires at `:226-227` (`[BackgroundAgentStore] background_agent event missing agentId; falling back to toolCallId as storage key`) — the fix does not silence the warning, it gives the entry a repair path afterwards.
+- `libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.service.ts:145-151` — the consumer. `findByAgentId(payload.agentId)` is tried first; on a miss, and only when `payload.toolCallId` is present, it falls through to `adoptRealAgentId(payload.toolCallId, payload.agentId)` before finalising the stop.
+
+**(ii) Unit specs.** `libs/frontend/chat/src/lib/services/chat-store/turn-end-handler.rekey.spec.ts`:
+- `'reaches a terminal state when the started event had no agentId'` (line 131)
+- `'keeps isBackgroundAgent(originalToolCallId) true after the re-key'` (line 147)
+- `'marks the re-keyed entry with hasRealAgentId'` (line 159)
+- `'bumps revision once for the re-key and once for the stop'` (line 174)
+- `'behaves exactly as before when the payload carries no toolCallId'` (line 185)
+- `'leaves an entry that already had a real agentId on the existing path'` (line 200)
+- `'does not adopt an entry belonging to a different Task tool call'` (line 215)
+
+Pass/fail: all seven passed in the 5-project run recorded in §A (`@ptah-extension/chat`).
+
+**(iii) Electron e2e.** `apps/ptah-electron-e2e/src/specs/chat/streaming-message-handlers.spec.ts` sends a `session:subagentEnded` payload with `agentId: 'agent-1'` set (line 118-128) and asserts the schema accepts it without a reject warning — that is a **parser-shape test** (Unit 10, TASK_2026_187), not a test of the missing-`agentId` → `toolCallId` fallback → `adoptRealAgentId` re-keying path. It never omits `agentId`, never supplies `toolCallId`, and never inspects `BackgroundAgentStore` state. It exercises an adjacent surface (payload validation), not this behaviour. `empty-assistant-envelope.spec.ts` and `apps/ptah-electron-e2e/src/specs/thoth/memory.spec.ts` do not touch this behaviour at all.
+
+**(iv)** Observed live: NO — requires a human-driven Electron session with a real SDK background subagent whose `SubagentStart` hook fires after the placeholder tool_result; nothing in this tree drives the real SDK.
+
+### Behaviour 2 — the inline agent card tracks real state instead of showing `completed` early
+
+**(i) Code.**
+
+- `libs/backend/agent-sdk/src/lib/message-transform/assistant-message.transformer.ts:288-324` — `background_agent_started` is pushed at `:299` (`events.push(bgEvent)`), strictly before the `tool_result` push at `:324` (`events.push(toolResultEvent)`), for the same `tool_use_id`. The comment at `:277-287` states the ordering is load-bearing (TASK_2026_376 F2) and must not be reversed — this is the Style-3 WHY comment the orchestrator closed after the review round.
+- `libs/frontend/chat-streaming/src/lib/accumulator-core.service.ts:442-443` — the guard: `backgroundAgentStore.isBackgroundAgent(event.toolCallId) || isBackgroundedToolResult(event.output)`. With the ordering above, the first half is now true by construction when the store has registered the agent.
+- `libs/frontend/chat-streaming/src/lib/accumulator-core.service.ts:179` — `BACKGROUNDED_TOOL_RESULT_MARKER` was broadened from the literal `'running in the background'` to the bare substring `'in the background'` by commit `1bd7610d4`, because Claude Code 2.1.259 words its placeholder "working in the background" and omits `run_in_background` from the tool input on its own default background-spawn path, so the narrower marker missed it and every such agent was terminalised on its own placeholder — a second live occurrence of the same symptom F2 named, three days after the original fix.
+
+**(ii) Unit specs.**
+- `libs/backend/agent-sdk/src/lib/message-transform/assistant-message.transformer.spec.ts:624` — `'emits background_agent_started BEFORE the tool_result for the same toolCallId'`.
+- `libs/frontend/chat-streaming/src/lib/accumulator-core.service.spec.ts:868` — `'background_agent_started → onStarted'`; `:876` `'background_agent_stopped → onStopped'`.
+- `libs/frontend/chat-streaming/src/lib/accumulator-core.service.spec.ts:921` — `'skips the SDK "running in the background" placeholder tool_result'`; `:931` — `'skips the Claude Code 2.1.259 "working in the background" placeholder (default background spawn)'`, added by `1bd7610d4`.
+
+**(iii) Electron e2e.** None of the three named specs drive a real Task tool_use / tool_result pair through the transformer or exercise `BackgroundAgentStore`'s card-state transitions. `streaming-message-handlers.spec.ts` only validates the `session:subagentEnded` payload shape (see behaviour 1). No e2e spec pushes a `background_agent_started` or a backgrounded-placeholder `tool_result` chunk and asserts on a rendered card's status. This behaviour has unit coverage only.
+
+**(iv)** Observed live: NO — requires a live session where a background subagent (Task tool) keeps running past its placeholder tool_result; nothing in this tree drives the real SDK.
+
+### Behaviour 3 — no empty `Assistant response` bubbles
+
+**(i) Code.**
+
+- `libs/backend/agent-sdk/src/lib/message-transform/assistant-message.transformer.ts:136` — the text branch is now guarded with `if (block.text)`, matching the thinking-branch guard immediately above it, so a text block whose `text` is `''` no longer unconditionally pushes a `text_delta`.
+- `libs/backend/agent-sdk/src/lib/message-transform/assistant-message.transformer.ts:344` — `if (events.length === 0)` still skips a content-free delivery entirely (the pre-existing, correct guard F3 confirmed was never the cause).
+- `libs/frontend/chat-streaming/src/lib/message-finalization.service.ts` empty-tree branch, rewritten by `1bd7610d4`: when `finalTree.length === 0`, if there is a `pendingStats` and the last message in the tab is an assistant message that is not already finalised, the pending token/cost/duration stats are folded onto that LAST assistant message instead of minting a new one with `streamingState: null`; otherwise the branch now only calls `clearStreamingForLoaded` and returns. Before this commit, that branch minted an empty assistant message carrying the orphaned subagent's 2-5 token usage whenever `messageId` was not already known — the literal empty "Assistant response" bubble.
+
+**(ii) Unit specs.**
+- `libs/backend/agent-sdk/src/lib/message-transform/assistant-message.transformer.spec.ts:198` — `'suppresses envelopes for an empty-string text block'`; `:141` `'suppresses envelopes for signature-only empty thinking'`; `:222` `'still emits text_delta with the correct blockIndex for a non-empty text block'`.
+- `libs/frontend/chat-streaming/src/lib/message-finalization.service.spec.ts:287` — `'does not mint an empty assistant message when the tree has no root'`; `:307` — `'folds pending stats onto the last assistant message when the tree has no root'`. Both added by `1bd7610d4`.
+
+**(iii) Electron e2e.** `apps/ptah-electron-e2e/src/specs/chat/empty-assistant-envelope.spec.ts` is purpose-built to pin this exact defect shape (its own header comment cites "23 real transcripts, 265/612 signature-only-empty thinking blocks"). It injects `chat:chunk` (`MESSAGE_TYPES.CHAT_CHUNK`) `FlatStreamEventUnion` payloads directly over the `to-renderer` IPC channel via `ui.pushEvent` — there is no real SDK anywhere in this harness — and asserts on `[data-testid="chat-tool-output"]` for the literal fallback title `'Assistant response'`. It is real coverage of the RENDERING half of behaviour 3 (a content-free delivery reaching the UI as a titled bubble) but it does not exercise the orphaned-background-subagent PRODUCER path `1bd7610d4` fixed (`message-finalization.service.ts`'s empty-tree branch folding pending stats) — that path only fires when a background task settles after its parent turn ended, a timing this harness's synthetic chunk injection does not reproduce. `streaming-message-handlers.spec.ts` and `thoth/memory.spec.ts` do not touch this behaviour.
+
+**(iv)** Observed live: NO for the `1bd7610d4` orphaned-subagent-message path specifically — requires a live session with a background subagent still streaming after its parent turn ends and a settling turn_state on another task, which needs a real SDK. The narrower empty-content-block rendering path IS exercised by `empty-assistant-envelope.spec.ts` against injected events, which is closer to observed-in-the-app than the other three behaviours, but it is still not a real SDK session.
+
+### Behaviour 4 — a multi-window curation completes without an `extracted: 0` from a sibling timeout
+
+**(i) Code.**
+
+- `libs/backend/memory-curator/src/lib/curator-llm/curator-job-queue.ts:61` — `CURATOR_QUEUE_WAIT_CEILING_MS = 180_000`, replacing the destructive 60 s `InternalQueryQueueTimeoutError` wait that F4 diagnosed. `CuratorJobQueue.run` (`:118-159`) gives the CALLER its own promise, separate from the serialising chain, so a waiter past the ceiling rejects with the new `CuratorQueueWaitTimeoutError` (`:70-77`) without breaking the chain or letting two passes run at once.
+- `libs/backend/memory-curator/src/lib/curator-llm/queue-slot-timeout.ts` — recognises `InternalQueryQueueTimeoutError` (the GLOBAL-ceiling timeout from `agent-sdk`) by error name through a bounded `cause` walk, feeding `QueueSlotRetryBudget` (one allowance of 2, shared across every extract window plus the resolve call of a single pass) so one congested window can retry against the same query instead of failing the whole pass.
+- `libs/backend/memory-curator/src/lib/curator-llm/curator-window-runner.ts:209-221` — a `no-output` window (§ see behaviour-4-adjacent defect below) and a `stalled` window both abandon the pass rather than unioning the remaining windows' drafts into a result the caller would read as complete.
+- `libs/backend/memory-curator/src/lib/memory-curator.service.ts:360-367` — `curate()` catches `CuratorQueueWaitTimeoutError` and returns `recordCuratorDeferral(..., 'curator-queue-wait-timeout')`, mapped to `outcome: 'stalled'`.
+- `libs/backend/memory-curator/src/lib/triggers/memory-trigger.service.ts:814-825` — `stats.outcome === 'stalled'` reattaches the detached episode and returns WITHOUT calling `observationQueue.markProcessed`, so a deferred pass keeps its drained observations for the next drain.
+
+**(ii) Unit specs.**
+- `libs/backend/memory-curator/src/lib/curator-llm/curator-job-queue.spec.ts:70` — `'rejects a waiter that never gets its turn within the ceiling'`; `:152` `'ships a bounded default ceiling'`; plus (not individually re-quoted here) the sibling specs for "lets a later pass run normally after an abandoned one" and "never rejects a pass that gets its turn inside the ceiling".
+- `libs/backend/memory-curator/src/lib/curator-llm/curator-window-runner.spec.ts:139-236` — the queue-slot-timeout describe block: `'re-queues the window that lost its slot and keeps its drafts'`, `'a sibling window still runs after the first one had to wait'`, `'defers rather than failing once the allowance is spent'`, `'shares ONE allowance across the whole window set'`, `'still reports a non-congestion failure as failed'`, `'does not re-queue a window whose pass was aborted'`. Line `283` — `'carries the arm to the caller and stops spending windows'` (the `no-output` abandonment case).
+- `libs/backend/memory-curator/src/lib/memory-curator.service.spec.ts:1211` — `'a stalled window stops the loop and takes the stall path'`; `:1677` — `'maps a NO-OUTPUT extraction to stalled, so the observations survive'`.
+
+**(iii) Electron e2e.** `apps/ptah-electron-e2e/src/specs/thoth/memory.spec.ts` mocks `memory:stats`, `memory:list` and `memory:searchSymbols` RPCs with fixture data (lines 50-60) to render the Memory tab — it never invokes `MemoryCuratorService.curate`, never drives `CuratorWindowRunner`, and never touches the curator LLM path. **There is no e2e coverage of the curator LLM path**, congested or otherwise, anywhere in `apps/ptah-electron-e2e`.
+
+**(iv)** Observed live: NO — requires a live session that splits into multiple curation windows AND a concurrent competing pass on the `memory-curator` lane (the exact two-session collision the original F4 capture showed), which is not reproducible without a real multi-window transcript and a real internal-query concurrency contest.
+
+## C. What cannot be observed without a human
+
+- All four acceptance behaviours require a live Electron session with a real `@anthropic-ai/claude-agent-sdk` connection: a background `Task` subagent whose `SubagentStart` hook can race its own placeholder tool_result (behaviour 1), a subagent that keeps streaming past its parent turn's terminal `turn_state` (behaviours 2 and 3's `1bd7610d4` path specifically), and a transcript that plans multiple curation windows while a second session's pass is queued behind it on the same lane (behaviour 4).
+- None of the three named Electron e2e specs drives the real SDK; all three inject synthetic IPC payloads or mock RPC responses. This is a structural property of the current e2e harness (documented in its own spec comments), not a gap introduced by this task.
+- The curator LLM path (`InternalQueryService` → `SdkInternalQueryCuratorLlm` → the real provider) has zero e2e coverage of any kind, congested or not.
+
+## D. Follow-up filed
+
+`TASK_2026_391` — the curator's `extract()` fall-through arm (`sdk-internal-query.curator-llm.ts:315`) still cannot distinguish an honest empty extraction from a final assistant message that is prose or truncated/malformed JSON, so `MemoryTriggerService` consumes the session's observations on a pass that never actually read anything extractable — the same data-loss shape F4/R1 just closed on the `tools-only`/`silent`/queue-timeout arms, left open on this one arm.
+
+## E. Recommendation
+
+**No — TASK_2026_376 cannot move to `done` on this evidence.** Keep it at
+`in_review`.
+
+Why, in order of weight:
+
+1. **The task's own gate is a live-session gate, and no live session has been
+   run.** `context.md:385-401` names four behaviours that must be confirmed
+   in one Electron session with a real background subagent and a compaction.
+   This lane established that nothing in the tree can produce that
+   observation: every e2e spec injects synthetic IPC payloads or mocks RPC,
+   and the curator LLM path has no e2e coverage at all (§C). All four
+   behaviours are recorded above as **Observed live: NO**. A unit spec that
+   passes proves the code does what it says; it does not prove the symptom a
+   human watched on 2026-09-03 is gone, which is the distinction the task's
+   author drew when refusing `done` the first time.
+2. **The code under test already needed a second fix for two of the four
+   behaviours.** `1bd7610d4` (2026-09-06) re-fixed behaviours 2 and 3 three
+   days after the 376 fixes reached `main`, and its commit message records
+   that both were still observed live: the placeholder marker did not match
+   Claude Code 2.1.259's wording, and orphaned subagent messages still minted
+   empty bubbles. That is direct evidence the original 376 fix did not close
+   the gate, and it is the strongest argument for insisting on a live run
+   now rather than inferring one: the shape that broke was a runtime wording
+   change and a cross-turn timing that no unit spec anticipated.
+3. **What this lane DID establish, so the live run is the only thing left.**
+   The Electron app builds from this tree; the 4 chat e2e specs and the 3
+   memory-tab specs pass; 4633 unit tests across the five relevant projects
+   pass, including every spec that pins the 376 and `1bd7610d4` logic; and
+   every file:line cited in §B was re-read in this tree. The engineering
+   evidence is complete. The product evidence is absent.
+4. **The curator follow-up is filed** (`TASK_2026_391`, §D), so gate Blocker
+   1 no longer needs to hold 376 hostage — but that does not substitute for
+   the session.
+
+What would flip this to `yes`: one human-driven Electron session on a build
+from this tree (or later), with a `Task` subagent spawned in the background
+under Claude Code 2.1.259 or newer and a `/compact` mid-session, recording
+for each of the four behaviours what the console and the transcript showed.
+Append that record to this file. If behaviours 1-3 hold and behaviour 4 can
+only be partially provoked (it needs two sessions contending for the
+`memory-curator` lane), say so and let the reviewer decide whether the
+`curator-job-queue.spec.ts` ceiling proof is enough for 4.
+
+Caveat on the e2e evidence itself: the full 164-spec suite was stopped at 37
+with 12 timeouts under host contention (§A). Those failures are outside this
+task's surface and were not diagnosed here; a quiet-machine run of the full
+suite is worth doing before the next Electron release, but it is not a
+condition on 376.

--- a/.ptah/specs/TASK_2026_382/task.md
+++ b/.ptah/specs/TASK_2026_382/task.md
@@ -1,6 +1,6 @@
 ---
 id: TASK_2026_382
-status: in_review
+status: done
 type: BUGFIX
 title: >-
   Mid-stream sends bypass the queue: reconcile the busy predicate with

--- a/.ptah/specs/TASK_2026_390/task.md
+++ b/.ptah/specs/TASK_2026_390/task.md
@@ -1,6 +1,6 @@
 ---
 id: TASK_2026_390
-status: in_review
+status: done
 type: bugfix
 title: >-
   Codex/Cursor SDK failures: bound the forwarded error text and name the usage

--- a/.ptah/specs/TASK_2026_391/context.md
+++ b/.ptah/specs/TASK_2026_391/context.md
@@ -1,0 +1,121 @@
+# TASK_2026_391 — curator extract: prose or truncated JSON is not an empty extraction
+
+## Origin
+
+Filed 2026-09-08 from the TASK_2026_376 independent gate review
+(`.ptah/specs/TASK_2026_376/codex-review.md`, Blocker 1, and the
+`runtime-gate.md` lane that recorded the gate). The gate confirmed the chain
+end to end and demoted it from "block 376" to "file its own task" because the
+behaviour predates 376 and is pinned by an older spec as intended.
+
+## The defect chain (every line verified in the tree at `a008d9841`)
+
+1. `libs/backend/agent-sdk/src/lib/curator-llm-adapter/sdk-internal-query.curator-llm.ts:315`
+   — `extract()`'s fall-through arm:
+
+   ```ts
+   return { status: 'extracted', drafts: this.parseDrafts(outcome.text) };
+   ```
+
+   This arm is reached for every run whose last assistant message contained
+   text (`runQuery` returns `{ kind: 'text', ... }` at `:461-462`).
+
+2. `sdk-internal-query.curator-llm.ts:477-481` — `parseDrafts` returns `[]`
+   in BOTH of these cases:
+   - `extractJsonObject(text)` finds no balanced JSON object (`:479`);
+   - `ExtractedResponseSchema.safeParse(json)` fails (`:481`).
+
+   A parse failure is therefore byte-identical to the honest reply
+   `{"memories": []}`.
+
+3. `libs/backend/memory-curator/src/lib/memory-curator.service.ts:583-599`
+   — the `drafts.length === 0` arm builds `outcome: 'ran', extracted: 0` and
+   returns it. The `'no-output'` arm immediately above it (`:579-581`) is the
+   input-preserving path TASK_2026_376 R1 added; the prose case never
+   reaches it.
+
+4. `libs/backend/memory-curator/src/lib/triggers/memory-trigger.service.ts:814-825`
+   — only `stats.outcome === 'stalled'` returns before
+   `this.observationQueue.markProcessed(ids)`. A `'ran'` with zero drafts
+   consumes every drained observation row for the session.
+
+## Pinned as intended
+
+`libs/backend/agent-sdk/src/lib/curator-llm-adapter/sdk-internal-query.curator-llm.spec.ts:695-706`
+— `it('returns an EXTRACTED status with no drafts when model output is
+non-JSON garbage')` asserts exactly `{ status: 'extracted', drafts: [] }` for
+the input `'not json at all'`. Both the arm and the spec come from commit
+`5dfedc09c` (2026-08-23). This is a deliberate pre-existing design, not a
+376 regression.
+
+## Failure scenario
+
+The curator spends four of its six turns reading memory through the Ptah MCP
+and closes with:
+
+> I reviewed the transcript and found nothing worth storing.
+
+`extractJsonObject` finds no object, `drafts: []`, `outcome: 'ran'`, the
+session's queued observations are marked processed, and that session can never
+be curated again. The same outcome for a JSON object the model truncated at
+the output limit or wrapped in prose that breaks the balanced-brace scan.
+
+## Why it is now more likely
+
+`CURATOR_MAX_TURNS = 6` (`sdk-internal-query.curator-llm.ts:186`, TASK_2026_376
+F8, previously `maxTurns: 1`). A single-turn model either emits the JSON or
+emits nothing; a six-turn model that has just finished a run of tool calls is
+far more likely to close with a natural-language wrap-up. R1 closed the
+`tools-only` and `silent` arms as `no-output` for exactly this reason
+(`libs/backend/memory-contracts/src/lib/curator-llm.port.ts:66-84` documents
+the argument) and left the third way a run can end without JSON open.
+
+## Required fix
+
+- Treat "text present but no parseable JSON" as `no-output`, not as
+  `extracted: []`. Either widen the existing `no-output` variant of
+  `CuratorExtraction` (`curator-llm.port.ts:96-101`) with a reason such as
+  `'unparseable-text'` alongside `usedTools` / `toolNames`, or add a fourth
+  arm; the caller mapping in `memory-curator.service.ts:579-581`
+  (`recordCuratorNoOutput`) already preserves the input, so the consumer side
+  should need no new branch.
+- `parseDrafts` (or a sibling) must distinguish "no JSON object found" and
+  "schema rejected" from "valid envelope with an empty `memories` array".
+  An honest `{"memories": []}` stays `extracted` with zero drafts and
+  continues to consume the observations — that is a correct empty result.
+- Flip `sdk-internal-query.curator-llm.spec.ts:695` to assert `no-output`
+  for `'not json at all'`, and add cases for a truncated JSON object
+  (`'{"memories": [{"content": "x"'`) and for prose that wraps a valid
+  object (which should still parse). Each new spec must fail before the
+  change and pass after it.
+- Log the arm at `info` with the first ~200 characters of the text so the
+  next live session can tell a prose wrap-up from a malformed envelope.
+
+## Acceptance criteria
+
+1. A final assistant message with no balanced JSON object yields
+   `status: 'no-output'` and `MemoryTriggerService` does NOT call
+   `markProcessed` for that session.
+2. A final assistant message whose JSON fails `ExtractedResponseSchema`
+   yields `status: 'no-output'` with the same consequence.
+3. `{"memories": []}` still yields `status: 'extracted', drafts: []` and the
+   observations are consumed.
+4. The `:695` spec is flipped, not deleted; the truncated-JSON case is
+   added; `npx nx run-many -t test -p @ptah-extension/agent-sdk
+   @ptah-extension/memory-curator` is green.
+
+## Related, optional scope (gate observation O1)
+
+Two other curator paths return a success-shaped `'ran'` and consume input:
+
+- `memory-curator.service.ts:950-960` — `recordCuratorError` returns
+  `outcome: 'ran'` for a dispatched-and-failed call. The comment at
+  `:952-958` records this as a deliberate carry-over ("whether a FAILED pass
+  should also preserve its input is a separate question"). Decide it here
+  or file it separately; do not leave it undecided a third time.
+- `memory-curator.service.ts:705-742` — every per-draft persist can fall into
+  `skipped` (`:713`) and the aggregate still reports `'ran'` (`:722`), so a
+  run whose persistence failed entirely consumes its input.
+
+Both are the same data-loss class as this task; neither is required to close
+it.

--- a/.ptah/specs/TASK_2026_391/task.md
+++ b/.ptah/specs/TASK_2026_391/task.md
@@ -1,0 +1,21 @@
+---
+status: backlog
+type: BUGFIX
+title: >-
+  Curator extract treats an unparseable final message as an honest empty
+  extraction and consumes the session's observations
+description: >-
+  The extract() fall-through arm in sdk-internal-query.curator-llm.ts returns
+  extracted with zero drafts when the model's final message is prose or a
+  truncated JSON object, because parseDrafts returns [] for both "no JSON
+  found" and "Zod rejected it". The trigger reads that as a run that honestly
+  found nothing and marks the session's queued observations processed, so
+  the session can never be curated again. Pinned as intended by a spec since
+  2026-08-23; TASK_2026_376 raised the turn budget 1 to 6, which makes a
+  prose wrap-up after tool calls the ordinary shape of a run.
+---
+
+# TASK_2026_391
+
+Defect chain, failure scenario, required fix and acceptance criteria are in
+`context.md`. Origin: TASK_2026_376 independent gate review, Blocker 1.

--- a/.ptah/specs/TASK_2026_392/investigation.md
+++ b/.ptah/specs/TASK_2026_392/investigation.md
@@ -1,0 +1,261 @@
+# CI affected-test cancellation investigation
+
+## 1. Verdict
+
+The local evidence does **not** show a leaked Jest handle holding the parent Nx process open after Nx reports success. The normal parallel runs reproduce Jest's warning, but Jest's implementation force-terminates any test worker that takes more than 500 ms to exit and waits for it; all local Nx commands then return normally. `--detectOpenHandles --runInBand` found no handle in either `@ptah-extension/cli-engine` or `@ptah-extension/agent-sdk`. It found one real, named `Timeout` in `@ptah-extension/cli-agent-runtime`: the fire-and-forget OpenRouter pricing warmup started by a DI smoke test. That timeout is inside the Jest process and is bounded to 10 seconds, so it explains a worker warning, not a parent Nx process that remains alive indefinitely. There are genuine unjoined production teardown defects in the inspected code, but none was observed as the handle behind these CI endings. The final `##[error]The operation was canceled.` is therefore more consistent with an external GitHub Actions cancellation arriving after Nx printed its verdict. The configured concurrency rule remains a live candidate: “one CI run per commit” does not rule it out, because one run for a *newer commit on the same PR* has the same concurrency group and cancels the older run. Without run overlap/cancellation metadata, the exact external actor cannot be determined.
+
+## 2. Evidence
+
+All commands below were run from `D:\projects\ptah-extension\.claude-worktrees\deploy-blockers`, one Nx project per command, with Nx cache bypassed where applicable. ANSI colour codes are omitted from the excerpts.
+
+### `@ptah-extension/cli-engine`
+
+Command:
+
+```text
+npx nx run "@ptah-extension/cli-engine:test" --detectOpenHandles --runInBand --skip-nx-cache
+```
+
+Result (wall time 63.3 s):
+
+```text
+Test Suites: 17 passed, 17 total
+Tests:       169 passed, 169 total
+Snapshots:   0 total
+Time:        59.554 s, estimated 545 s
+Ran all test suites.
+NX   Successfully ran target test for project @ptah-extension/cli-engine
+```
+
+Jest printed **no open-handle section**.
+
+The ordinary worker-mode run did reproduce the reported warning:
+
+```text
+npx nx run "@ptah-extension/cli-engine:test" --skip-nx-cache
+
+A worker process has failed to exit gracefully and has been force exited.
+This is likely caused by tests leaking due to improper teardown. Try running
+with --detectOpenHandles to find leaks. Active timers can also cause this,
+ensure that .unref() was called on them.
+Test Suites: 17 passed, 17 total
+Tests:       169 passed, 169 total
+Time:        15.895 s, estimated 48 s
+NX   Successfully ran target test for project @ptah-extension/cli-engine
+```
+
+This warning is not evidence that Nx remains alive. Installed Jest calls `worker.end()`, and `jest-worker` force-exits a worker after `workerGracefulExitTimeout ?? 500` ms (`node_modules/jest-runner/build/index.js:567-575`; `node_modules/jest-worker/build/index.js:551-574`).
+
+### `@ptah-extension/agent-sdk`
+
+Command:
+
+```text
+npx nx run "@ptah-extension/agent-sdk:test" --detectOpenHandles --runInBand --skip-nx-cache
+```
+
+Result (wall time 72.8 s):
+
+```text
+Test Suites: 1 skipped, 86 passed, 86 of 87 total
+Tests:       2 skipped, 1472 passed, 1474 total
+Snapshots:   0 total
+Time:        67.968 s, estimated 508 s
+Ran all test suites.
+NX   Successfully ran target test for project @ptah-extension/agent-sdk
+```
+
+Jest printed **no open-handle section**.
+
+The ordinary run reproduced the same forced-worker warning and took 17.159 s. A capped run did not print the warning:
+
+```text
+npx nx run "@ptah-extension/agent-sdk:test" --maxWorkers=4 --skip-nx-cache
+
+Test Suites: 1 skipped, 86 passed, 86 of 87 total
+Tests:       2 skipped, 1472 passed, 1474 total
+Time:        8.084 s, estimated 47 s
+NX   Successfully ran target test for project @ptah-extension/agent-sdk
+```
+
+This supports “worker took more than Jest's 500 ms graceful-exit allowance under high fan-out,” not an indefinitely live Nx parent.
+
+### `@ptah-extension/cli-agent-runtime`
+
+Command:
+
+```text
+npx nx run "@ptah-extension/cli-agent-runtime:test" --detectOpenHandles --runInBand --skip-nx-cache
+```
+
+Result (wall time 51.5 s):
+
+```text
+Test Suites: 51 passed, 51 total
+Tests:       1 skipped, 658 passed, 659 total
+Time:        46.516 s
+Ran all test suites.
+
+Jest has detected the following 1 open handle potentially keeping Jest from exiting:
+
+  ●  Timeout
+
+      201 |   private async httpJson<T>(url: string): Promise<T> {
+      202 |     const controller = new AbortController();
+    > 203 |     const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+          |                   ^
+      204 |     try {
+      205 |       const res = await fetch(url, {
+      206 |         method: 'GET',
+
+      at OpenRouterPricingService.httpJson
+        (../auth-providers/src/lib/providers/openrouter/openrouter-pricing.service.ts:203:19)
+      at OpenRouterPricingService.fetchCatalog
+        (../auth-providers/src/lib/providers/openrouter/openrouter-pricing.service.ts:154:31)
+      at OpenRouterPricingService.ensureCatalog
+        (../auth-providers/src/lib/providers/openrouter/openrouter-pricing.service.ts:136:25)
+      at OpenRouterPricingService.fetchAndRegister
+        (../auth-providers/src/lib/providers/openrouter/openrouter-pricing.service.ts:94:32)
+      at OpenRouterPricingService.warmup
+        (../auth-providers/src/lib/providers/openrouter/openrouter-pricing.service.ts:67:31)
+      at warmupPricing (../auth-providers/src/lib/di/register.ts:166:13)
+      at registerAuthProvidersServices (../auth-providers/src/lib/di/register.ts:117:3)
+      at buildSmokeContainer
+        (src/lib/di/register.ptah-cli-registry.smoke.spec.ts:133:32)
+      at Object.<anonymous>
+        (src/lib/di/register.ptah-cli-registry.smoke.spec.ts:147:17)
+```
+
+The focused reproduction gave the same single handle:
+
+```text
+npx jest --config libs/backend/cli-agent-runtime/jest.config.ts \
+  --runTestsByPath libs/backend/cli-agent-runtime/src/lib/di/register.ptah-cli-registry.smoke.spec.ts \
+  --detectOpenHandles --runInBand
+
+Test Suites: 1 passed, 1 total
+Tests:       2 passed, 2 total
+Time:        2.571 s, estimated 20 s
+Jest has detected the following 1 open handle potentially keeping Jest from exiting:
+  ●  Timeout
+```
+
+The ordinary `cli-agent-runtime` run also printed the forced-worker warning. It took 47.03 s, versus 46.516 s serial: default worker fan-out produced no speedup for this project on this host.
+
+### Coverage and process exit
+
+`cli-engine` coverage completed and returned to the shell locally in both default and capped worker modes:
+
+```text
+npx nx run "@ptah-extension/cli-engine:test" --coverage --skip-nx-cache
+Test Suites: 17 passed, 17 total
+Tests:       169 passed, 169 total
+Time:        67.016 s
+NX   Successfully ran target test for project @ptah-extension/cli-engine
+```
+
+A warm-cache repeat took 16.871 s and printed the forced-worker warning. With two Jest workers it took 9.236 s and printed no warning:
+
+```text
+npx nx run "@ptah-extension/cli-engine:test" --coverage --maxWorkers=2 --skip-nx-cache
+Test Suites: 17 passed, 17 total
+Tests:       169 passed, 169 total
+Time:        9.236 s, estimated 344 s
+NX   Successfully ran target test for project @ptah-extension/cli-engine
+```
+
+The 67.016-to-9.236 comparison is confounded by Jest transform/coverage cache warmup, so it is not a valid isolated speedup claim. The warm 16.871-to-9.236 comparison is the useful directional result, but is still only one sample. The local host reported:
+
+```json
+{"availableParallelism":16,"cpus":16,"totalmemGiB":"27.86","freememGiB":"14.02"}
+```
+
+No tested coverage command hung after Nx's verdict. This rules against a deterministic V8/Babel coverage-writer hang in these projects.
+
+## 3. Creation sites
+
+### Handle actually reported by Jest: OpenRouter request timeout
+
+- Creation: `libs/backend/auth-providers/src/lib/providers/openrouter/openrouter-pricing.service.ts:201-212`; the reported handle is the ref'd `setTimeout` at line 203. `REQUEST_TIMEOUT_MS` is 10,000 ms at line 13.
+- Normal close: `httpJson` clears the timeout in `finally` at `openrouter-pricing.service.ts:231-233`, but only after `fetch` settles or aborts.
+- Why the test leaks it: `registerAuthProvidersServices` unconditionally starts a void-returning pricing warmup at `libs/backend/auth-providers/src/lib/di/register.ts:117` and `:161-166`. `buildSmokeContainer` calls that registration in each `beforeEach` at `libs/backend/cli-agent-runtime/src/lib/di/register.ptah-cli-registry.smoke.spec.ts:133,146-148`, without mocking `fetch`, awaiting warmup, aborting it, or disposing the container afterward. The test ends while the real network fetch and its abort timeout are still live.
+- Exact missing test control: this DI smoke test should stub `global.fetch` to a settled response before `buildSmokeContainer` and restore it in `afterEach`. Clearing container instances is useful isolation hygiene, but tsyringe cannot abort or join the already-started warmup, so it does not close this handle. A stronger production contract is for `OpenRouterPricingService` to own the active `AbortController` and expose `dispose()` that aborts and joins any warmup; merely calling the existing `clearCache()` does not abort an in-flight request. Calling `timer.unref()` prevents the timeout itself from keeping a process alive, but does not close an in-flight socket and is therefore incomplete on its own.
+
+### Lifecycle defects found by trace but **not** reported by these Jest diagnostics
+
+These are real teardown risks and should be fixed, but they must not be relabelled as the proven cause of the CI cancellation:
+
+- `SdkAgentAdapter.dispose()` is fire-and-forget: `libs/backend/agent-sdk/src/lib/sdk-agent-adapter.ts:526-540` returns `void` while starting `disposeAllSessions().catch(...).finally(...)`. `withEngine` awaits that void at `libs/backend/cli-engine/src/lib/bootstrap/with-engine.ts:432-445`, then clears DI instances at `:547-550`. Missing join: make `SdkAgentAdapter.dispose(): Promise<void>` await `disposeAllSessions()` and run `sessionLifecycle.dispose()` in `finally`; `disposeSdkAdapter` at `with-engine.ts:432-445` is already the correct caller on both normal (`:416-421`) and SDK-init-failure (`:344-346`) paths.
+- Losing `Promise.race` timers are never cleared: `libs/backend/agent-sdk/src/lib/helpers/session-lifecycle/session-control.service.ts:80-88` (3 s), `:218-226` (5 s), and `:306-320` (5 s per live query). If `interrupt()` wins, the ref'd timeout remains until expiry. Missing teardown: retain each timer, clear it in `finally`, and `unref()` it defensively.
+- `OffThreadProcessSpawner` creates a `Worker` at `libs/backend/agent-sdk/src/lib/helpers/off-thread-process-spawner.ts:294`, tracks workers at `:593-595,671-678`, and provides the required async join at `:687-698`. It is a singleton registered at `libs/backend/agent-sdk/src/lib/di/register.ts:315-319`, but no production host calls `dispose()`. Missing teardown: after awaited SDK/session and CLI-agent shutdown, resolve `SDK_TOKENS.SDK_PROCESS_SPAWNER` in the `withEngine` finally path and await `dispose()` before `runDispose` clears instances.
+- `PtahCliRegistry.disposeAll()` clears ownership and calls `void lease.stop()` at `libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry.ts:879-888`. The lease stop awaits a real proxy/server stop at `:1176-1192`. `shutdownHostRuntime` awaits `disposeAll`, but currently receives `undefined` (`libs/backend/cli-engine/src/lib/bootstrap/shutdown-host-runtime.ts:62-78,113-132`). Missing teardown: make `disposeAll(): Promise<void>` await all unique `lease.stop()` calls; retain the existing exact teardown site in `shutdownHostRuntime`.
+- `CronScheduler.start()` arms each Cron timer at `libs/backend/cron-scheduler/src/lib/cron-scheduler.ts:119-125,247-266` before setting `started = true`. If a later timer creation throws, prior timers remain, but `stop()` returns early because `started` is false (`:133-141`). `activateThoth` then catches and discards the scheduler reference at `libs/backend/cli-engine/src/lib/bootstrap/thoth-runtime.ts:345-358`. Missing teardown: make `start()` exception-safe by stopping/clearing already-created timers in `catch` before rethrowing; `stop()` should also clean `timers` even when `started` is false.
+- `SqliteConnectionService.openAndMigrate()` creates the database at `libs/backend/persistence-sqlite/src/lib/sqlite-connection.service.ts:197-204`, but does not assign `this.database` until line 210. This is a theoretical unexpected-exception gap, not a demonstrated operational leak: `applyPragmas`, vector loading, and health probes catch their expected failures internally (`sqlite-connection.service.ts:555-565,573-592,653-688`). If an unexpected throw nevertheless escapes between factory creation and ownership assignment, `close()` at `:505-531` cannot reach the local handle and `activateThoth` discards the failed reference at `libs/backend/cli-engine/src/lib/bootstrap/thoth-runtime.ts:93-107`. Defensive hardening would wrap all post-factory initialization in `try/catch` and close the local `db` before rethrowing, or assign ownership immediately and call the idempotent service `close()` on failure.
+
+The normal CLI Thoth shutdown order itself is sound and explicit: push bridges, chat bridge, gateway, cron, skill trigger/service, memory trigger/service, embedder, SQLite at `libs/backend/cli-engine/src/lib/bootstrap/thoth-runtime.ts:147-184`; `withEngine` invokes it in `finally` at `with-engine.ts:393-421`.
+
+## 4. Does this explain the CI cancel
+
+### Argument that a leak is plausible
+
+The code has resources capable of keeping Node alive: ref'd timers, listening translation-proxy sockets, worker threads, subprocesses, Cron timers, and SQLite handles. Several teardown contracts are unjoined or exception-unsafe. The supplied cleanup line `Terminate orphan process: pid (5311) (MainThread)` proves that at least one descendant survived far enough for the Actions runner's post-job sweep in run 102148697007. A descendant that inherits an Actions-captured stdout/stderr pipe can also delay pipe EOF after its parent exits.
+
+### Argument against the observed Jest leak being the cancellation cause
+
+The actual diagnostics are decisive for the three required projects:
+
+1. `cli-engine` and `agent-sdk` expose no live handle in serial Jest diagnostics.
+2. The one reported `cli-agent-runtime` timeout is bounded to 10 seconds and runs inside Jest.
+3. In normal mode, Jest does not leave that worker around indefinitely: installed `jest-worker` sends the end message, waits 500 ms, force-exits the worker, and awaits its exit (`node_modules/jest-worker/build/index.js:551-574`). The warning is printed only after that cleanup returns (`node_modules/jest-runner/build/index.js:567-575`).
+4. Every local Nx command, including coverage, returned normally after printing the Nx success verdict.
+5. The Nx daemon is disabled automatically in CI unless `NX_DAEMON=true` (`node_modules/nx/src/daemon/client/client.js:82-109`). The workflow does not set it; it sets only `NX_TUI=false` at `.github/workflows/ci.yml:24-32`. `nx.json:82-89` registers only the ESLint plugin, not a test inference plugin. The Nx daemon/plugin theory therefore has little support.
+6. Nx prints `Successfully ran ...` in the lifecycle's `endCommand()` only after its Jest-backed tasks have returned (`node_modules/nx/src/tasks-runner/life-cycles/static-run-many-terminal-output-life-cycle.js:52-68`; `node_modules/nx/src/tasks-runner/default-tasks-runner.js:56-64`). A surviving arbitrary descendant is possible, but the tested parent command did not wait on one locally.
+
+### Committed answer
+
+The leaked-Jest-worker hypothesis is **not supported as the cause of these CI cancellations**. It explains the warning, not `##[error]The operation was canceled.` The Actions runner message requires a cancellation token from outside the completed Nx task graph: concurrency, a user/API cancellation, runner/service interruption, or an unshown higher-level policy.
+
+The concurrency reasoning in the prompt is incomplete. `.github/workflows/ci.yml:15-18` groups every run for one PR as `ci-<PR number>` with `cancel-in-progress: true`. Exactly one run per commit rules out duplicate runs for the same SHA; it does **not** rule out the one run for commit B canceling the still-running one run for earlier commit A on the same PR. To rule concurrency out, compare each canceled run's end timestamp with the creation/queue timestamp of every later run on that PR, including manual reruns; cancellation can occur while the replacement is queued, before its `run_started_at`. That run inventory was not supplied and cannot be fetched under this task's constraints.
+
+The pass/fail pattern is consistent with an external race. A failed test usually ends the job promptly, reducing the interval in which a later same-PR run can cancel it. A successful test proceeds toward later CI steps and leaves a longer interval. Run 102148697007 is not a contradiction: an external cancellation can arrive after Nx has already produced a failed target result but before the Actions shell/job wrapper has finalized it. Run 102173721253 exited cleanly because its failure reached `exit 1` before such a cancellation arrived.
+
+Resource exhaustion is a credible cause of slowness but a weak cause of the cancellation annotation. The supplied logs contain no OOM, exit 137, ENOSPC, disk annotation, signal, or runner-lost message. Coverage-specific flushing is also weak: local coverage completed, and the warning appeared inconsistently across warm/cold coverage runs rather than at a unique coverage-writer stack.
+
+## 5. The `cli-engine` slowness
+
+The evidence supports a separate resource-contention problem, not a leaked-handle delay:
+
+- `.github/workflows/ci.yml:131-132` permits up to three Nx test tasks concurrently.
+- Nx `--parallel=3` limits Nx tasks, not Jest workers. Each test task launches its own Jest coordinator. No repository Jest config sets `maxWorkers`.
+- Installed Jest defaults each pool to `availableParallelism() - 1` workers (`node_modules/jest-worker/build/index.js:1842-1848`). The actual CI worker count is not in the supplied logs. On the measured local host, one default pool can use 15 workers; three concurrent Nx projects can therefore request up to 45 Jest workers plus coordinators and any application subprocesses.
+- Coverage instruments code and aggregates/writes reports in every project, increasing CPU, memory, and I/O demand.
+- `libs/backend/cli-engine/src/lib/platform/cli-platform-commands.spec.ts:50-76` documents that six specs deliberately spawn real cold Node children. The repository's recorded CI observation is 140.33 s for that file under `--parallel=3 --coverage`, with every `cli-engine` suite at 114-250 s. The creation site is `libs/backend/cli-engine/src/lib/platform/cli-platform-commands.ts:119-180` (`cross-spawn` at line 132). This is real-process startup competing with the nested Jest/coverage workload, not a wait for a leaked handle after the tests finish.
+- Locally, warm `cli-engine --coverage` was 16.871 s with default workers and 9.236 s with `--maxWorkers=2`. `agent-sdk` fell from 17.159 s with the warning to 8.084 s with `--maxWorkers=4` and no warning. Those are single-host samples, but they demonstrate oversubscription sensitivity. The cold 67.016 s coverage run must not be used as an isolated worker-cap comparison because Jest cache warmup differs.
+
+Conclusion: `cli-engine` CI slowness is most plausibly nested parallelism plus coverage and real child-process startup under a constrained/contended runner. It may increase the probability of overlapping a later PR push and triggering the concurrency rule, but it is not evidence that the test process remains alive after completion.
+
+## 6. Recommendations
+
+1. **First diagnose the actual cancellation source (highest priority, no code workaround).** For each affected run, compare its cancellation time with the creation/queue time of every later run on the same PR/concurrency key; inspect the Actions UI/API/audit metadata for the cancellation actor and runner-loss/service messages. Add timestamps around the CI test command and a guaranteed shell `trap`/post-step diagnostic if another reproduction is needed. This is the only action that can confirm concurrency versus manual/platform cancellation.
+
+2. **Performance/robustness fix: bound the two levels of parallelism.** Keep Nx at three projects only if each Jest invocation is capped; add `--maxWorkers=2` to the CI command as the first trial, or set an explicit CI-only Jest worker limit through the Nx Jest target configuration. Cost: possibly slower small projects on large runners, but substantially lower peak RAM/process count and more predictable execution. Measure the full affected set before choosing 1, 2, or a percentage. This is a real fix for the measured slowness/resource amplification and can reduce concurrency overlap; it is not a direct fix for external cancellation.
+
+3. **Real leak fix: remove the network warmup from the DI smoke test.** In `register.ptah-cli-registry.smoke.spec.ts`, install a settled `global.fetch` stub before `buildSmokeContainer`, restore it and clear the child container after every test. Separately give `OpenRouterPricingService` abortable/awaitable disposal and unref its request timeout. Cost: small API/test change; benefit: removes the only handle Jest actually named and prevents unit tests from performing live network I/O.
+
+4. **Real lifecycle fix: make teardown awaitable end to end.** Make `SdkAgentAdapter.dispose()` async; await `disposeAllSessions`; clear losing race timers; make `PtahCliRegistry.disposeAll()` await proxy stops; and await `OffThreadProcessSpawner.dispose()` in both `withEngine` teardown paths before clearing DI. Exact sites are listed in section 3. Cost: public lifecycle signatures and tests must be updated, and shutdown can now wait up to the intentional interrupt bounds instead of returning early. Benefit: closes worker, process, socket, and timer ownership deterministically.
+
+5. **Real exception-safety fix:** clean partially armed Cron timers when `start()` throws and close locally created SQLite databases when initialization throws before ownership assignment. Cost: focused service/spec changes. These are correctness fixes, but no observed diagnostic connects them to these CI runs.
+
+6. **`--forceExit` workaround: do not ship it for this incident.** Jest already force-exits non-graceful test workers. Adding `--forceExit` forces the Jest coordinator to terminate after results, can cut off pending async cleanup/coverage writes, hides regressions, and still cannot prevent GitHub from externally canceling the Actions step. It would be defensible only as a short-lived emergency workaround if a reproduction proved the *Jest coordinator* was the process stuck after results. The present reproduction proves the opposite, so its cost is not justified.
+
+7. **Optional CI clarity:** set `NX_DAEMON=false` explicitly. Nx already disables it under CI, so this changes no expected behavior; it only makes the invariant visible in logs/config. Do not expect it to fix the incident.
+
+## 7. What I could not determine
+
+- The exact cancellation actor/source. This needs GitHub run timing, concurrency, audit, and runner metadata that the task explicitly made unavailable.
+- Whether a later commit or manual rerun started on the same PR at each canceled run's end. “One run per commit” is insufficient to answer that question.
+- The identity of orphan PID 5311 named `MainThread`. A cleanup line alone cannot distinguish a Jest worker, Node worker thread host, child CLI, proxy helper, or unrelated descendant; the needed evidence is a `ps`/`pstree` snapshot with command line and parent PID before runner cleanup.
+- Live Linux handle inventory for the exact 24-project `nx affected --coverage --parallel=3` process tree. The three required local Windows diagnostics do not reproduce the Actions runner environment or the full affected graph.
+- Actual CPU, RAM, disk, and process-count telemetry from the canceled jobs. Without it, resource contention is supported by timing and architecture but resource exhaustion cannot be proven.
+- Which individual suite caused the generic forced-worker warning in `cli-engine` or `agent-sdk`. Serial `--detectOpenHandles` found none, and reducing worker count removed the warning in the measured `agent-sdk` run. Jest's warning means a worker missed a 500 ms exit deadline; it does not include the worker PID or suite name. Identifying it would require per-suite worker lifecycle instrumentation or repeated bisection under the exact CI host load.
+- Whether the supplied CI per-suite durations are repeatable. I report them as repository/run evidence, not as measurements I took. My measured numbers are the whole-project local times quoted above.

--- a/.ptah/specs/TASK_2026_392/task.md
+++ b/.ptah/specs/TASK_2026_392/task.md
@@ -1,13 +1,39 @@
 ---
+id: TASK_2026_392
 status: in_review
-type: devops
-title: Pin license-server runtime deps and add API uptime monitoring
+type: BUGFIX
+title: >-
+  CI test step is killed ~150 ms after Nx reports success, and nested Jest
+  parallelism runs the affected set 5-10x slower than it needs to
 description: >-
-  Pin the eight unpinned packages in the Dockerfile deps stage to exact
-  lockfile versions, fail the deploy workflow when the API is not serving,
-  and probe api.ptah.live on a schedule with a deduplicated outage issue.
+  The `main` CI job ends with `##[error]The operation was canceled.` between
+  141 and 224 ms after Nx prints `Successfully ran target test for 24
+  projects`, on six runs across two pull requests. The step is marked
+  cancelled, later steps are skipped, and the job fails while every test
+  passed. Two hypotheses are eliminated by measurement. A leaked Jest handle
+  is refuted: `--detectOpenHandles --runInBand` finds no handle in cli-engine
+  or agent-sdk, the one named handle (a 10 s OpenRouter warmup timer in
+  cli-agent-runtime) lives inside a worker Jest force-exits after 500 ms, and
+  a 150 ms gap is not a hang. The concurrency rule is refuted from the run
+  inventory: no cancelled run has any later run on its pull request, and a
+  concurrency cancel would set the run conclusion to `cancelled` rather than
+  `failure`. What IS measured is real oversubscription — `--parallel=3` caps
+  Nx tasks, not Jest workers, and with no `maxWorkers` anywhere each of the
+  three coordinators defaults to `availableParallelism() - 1`, so one runner
+  is asked for up to ~45 workers under coverage beside the real child
+  processes the cli-engine auth specs spawn. Capping workers is measurably
+  faster, so it ships as a fix on its own merits; whether it also stops the
+  kill is the open question this task carries.
+executor: devops-engineer
+estimate: M
+labels:
+  - ci
+  - jest
+  - nx
+relates_to: []
 ---
 
-Prevention work for the 2026-09-04 to 2026-09-08 api.ptah.live outage.
-Outage timeline, root cause, the four monitoring gaps and the mandatory
-droplet hotfix removal procedure are in `context.md`.
+<!-- Ptah carrier: machine-owned metadata. Ptah rewrites the frontmatter above. Do NOT write prose here — prose belongs in ./context.md. -->
+
+Evidence, eliminated hypotheses, teardown defects found along the way and
+ranked recommendations are in [./investigation.md](./investigation.md).

--- a/apps/ptah-electron-e2e/src/specs/task-360-failed-start-leaves-tab-idle.spec.ts
+++ b/apps/ptah-electron-e2e/src/specs/task-360-failed-start-leaves-tab-idle.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from '../support/fixtures';
+import type { UiDriver } from '../support/ui-driver';
+
+/**
+ * Pins the TASK_2026_360 "dead tab after a failed start" fix.
+ *
+ * ## The defect
+ *
+ * `MessageSenderService.startNewConversation` (message-sender.service.ts)
+ * marks the tab busy OPTIMISTICALLY — `applyNewConversationStreaming` +
+ * `markTabStreaming(tabId)` — BEFORE the `chat:start` RPC is issued. Those are
+ * two separate stores: `status` and the `_streamingTabIds` spinner set.
+ *
+ * When `chat:start` fails STRUCTURALLY (transport succeeded, the backend
+ * rejected the turn — here with `errorCode: 'AUTH_REQUIRED'`), the failure exit
+ * used to call `markLoaded(tabId)` only. `markLoaded` writes `status` and
+ * nothing else, so the tab stayed in `_streamingTabIds`. Nothing downstream
+ * could ever repair that: the turn never created a broadcaster, so no
+ * `turn_state` and no `CHAT_ERROR` event was ever going to arrive for it.
+ *
+ * `isTabBusyGenerating` (message-dispatch.service.ts) ORs the spinner set in,
+ * so every following send was routed to `ConversationService.queueOrAppendMessage`
+ * instead of the sender — and the only drains for that queue are a root
+ * turn-end (which cannot happen: there is no turn) and the Stop button. The
+ * tile was a dead end until reload.
+ *
+ * ## The fix
+ *
+ * `markTabIdle(activeTabId)` after `markLoaded` on BOTH pre-stream exits of
+ * `startNewConversation` — the structural-failure branch and the `catch`
+ * branch — mirroring what `runContinueConversation` already did.
+ *
+ * ## Falsifiability — what fails WITHOUT the fix
+ *
+ * The tab stays in `_streamingTabIds`, so `isTabBusyGenerating` returns true
+ * and three assertions below break:
+ *
+ * 1. `[data-testid="chat-stop-btn"]` is rendered (the Stop button reads the
+ *    same predicate), so `toHaveCount(0)` fails.
+ * 2. The second send is queued, so the literal "Message queued" banner
+ *    (chat-view.component.html) appears and `toHaveCount(0)` fails.
+ * 3. No second RPC leaves the renderer, so the observed send-call total stays
+ *    at 1 instead of reaching 2.
+ *
+ * ## Method
+ *
+ * `UiDriver`'s fake main-process 'rpc' listener answers every renderer RPC
+ * from a mock map, wrapping the mocked value as
+ * `{ type: 'rpc:response', success: true, data: V }`. Mocking `chat:start` to
+ * `{ success: false, errorCode: 'AUTH_REQUIRED' }` is therefore a STRUCTURAL
+ * failure, not a transport failure — `result.success` is true and
+ * `result.data.success` is false, which is exactly the branch the fix lives
+ * in. The `ptah-auth-required-banner` assertion proves the run really took
+ * that AUTH_REQUIRED path (`handleAuthRequired` ->
+ * `AuthStateService.flagAuthRequired`) rather than some other exit.
+ */
+
+const FIRST_MARKER = 'PTAH_E2E_360_FIRST_SEND_MARKER';
+const SECOND_MARKER = 'PTAH_E2E_360_SECOND_SEND_MARKER';
+
+const TEXTAREA = 'ptah-chat-input textarea[role="combobox"]';
+const SEND_BUTTON = '[data-testid="chat-send-btn"]';
+const STOP_BUTTON = '[data-testid="chat-stop-btn"]';
+const QUEUED_BANNER_TEXT = 'Message queued';
+
+interface ObservedCall {
+  method: string;
+  params: unknown;
+}
+
+/**
+ * Every RPC that carries a user's message to the backend, in order. A send is
+ * `chat:start` on an unbound tab and `chat:continue` on a bound one; the
+ * failure under test leaves the tab unbound, so both are counted rather than
+ * assumed.
+ */
+async function sendCalls(ui: UiDriver): Promise<ObservedCall[]> {
+  const starts = await ui.getObservedCalls('chat:start');
+  const continues = await ui.getObservedCalls('chat:continue');
+  return [...starts, ...continues];
+}
+
+function promptOf(call: ObservedCall): string {
+  const params = call.params as { prompt?: string } | null;
+  return params?.prompt ?? '';
+}
+
+test.describe('Failed chat:start leaves the tab idle (TASK_2026_360)', () => {
+  test('a chat:start that fails before any stream (AUTH_REQUIRED) leaves the tile with no Stop button and the next send dispatches instead of queuing', async ({
+    ui,
+  }) => {
+    const page = ui.page;
+
+    // Mocked BEFORE the send, so the very first `chat:start` takes the
+    // structural-failure exit.
+    await ui.mockRpc({
+      'chat:start': {
+        success: false,
+        errorCode: 'AUTH_REQUIRED',
+        error: 'Authentication required.',
+      },
+    });
+
+    await ui.goto('chat');
+
+    const textarea = page.locator(TEXTAREA).first();
+    const sendButton = page.locator(SEND_BUTTON).first();
+
+    await textarea.fill(FIRST_MARKER);
+    await sendButton.click();
+
+    const firstStart = await ui.waitForObservedCall('chat:start');
+    expect(promptOf(firstStart)).toBe(FIRST_MARKER);
+
+    // The failure really was the AUTH_REQUIRED structural path: only
+    // `handleAuthRequired` raises this banner. Scoped to the canvas tile
+    // because the banner reads GLOBAL `AuthStateService` state, so every
+    // mounted `ptah-chat-view` renders one — including the shell's own
+    // non-canvas instance, which is never visible in Electron.
+    await expect(
+      page
+        .locator('[data-testid="canvas-tile"] ptah-auth-required-banner')
+        .first(),
+    ).toBeVisible();
+
+    // The tab settled idle. `toHaveCount(0)` waits, so this is not a race
+    // against the button appearing late.
+    await expect(page.locator(STOP_BUTTON)).toHaveCount(0);
+    await expect(page.getByText(QUEUED_BANNER_TEXT)).toHaveCount(0);
+
+    await textarea.fill(SECOND_MARKER);
+    await expect(sendButton).toBeEnabled();
+
+    await sendButton.click();
+
+    // A NEW RPC left the renderer immediately. Pre-fix the dispatcher queued
+    // this content and the total stayed at 1.
+    await expect
+      .poll(async () => (await sendCalls(ui)).length, { timeout: 10_000 })
+      .toBe(2);
+
+    const calls = await sendCalls(ui);
+    expect(promptOf(calls[calls.length - 1])).toBe(SECOND_MARKER);
+
+    await expect(page.getByText(QUEUED_BANNER_TEXT)).toHaveCount(0);
+    await expect(page.locator(STOP_BUTTON)).toHaveCount(0);
+  });
+});

--- a/apps/ptah-electron-e2e/src/specs/task-382-late-post-turn-event.spec.ts
+++ b/apps/ptah-electron-e2e/src/specs/task-382-late-post-turn-event.spec.ts
@@ -1,0 +1,281 @@
+import { randomUUID } from 'crypto';
+import { test, expect } from '../support/fixtures';
+import type { UiDriver } from '../support/ui-driver';
+
+/**
+ * Pins the TASK_2026_382 "late post-turn event pins the tab into queue-only
+ * mode" fix.
+ *
+ * ## The defect
+ *
+ * A subagent routinely outlives its parent turn, so `agent_progress` /
+ * `agent_completed` events keep arriving for a session AFTER the root
+ * `turn_state` phase `idle` settled the tab (status `loaded`,
+ * `streamingState` cleared by `MessageFinalizationService`).
+ *
+ * `StreamingHandlerService.processStreamEventForTab` used to mint an EMPTY
+ * `StreamingState` for any event routed to a tab that had none. Only
+ * `message_start` ever sets `currentMessageId`, and
+ * `MessageFinalizationService.finalizeCurrentMessage` early-returns on a null
+ * `currentMessageId` — so that minted state was unfinalizable debris.
+ *
+ * The dispatch predicate then read `streamingState != null` as "busy", so
+ * every following send went to the queue. The Stop button read only the
+ * `_streamingTabIds` spinner set, which the injected events never touch, so it
+ * stayed HIDDEN. Queue with no drain and no drain affordance: a dead tile
+ * until reload.
+ *
+ * ## The fix (three parts, all exercised here)
+ *
+ * a. `streaming-handler.service.ts` `STORE_ONLY_EVENT_TYPES` — the six
+ *    store-only event types run the accumulator on a scratch state and never
+ *    create one on a tab that has none.
+ * b. `message-dispatch.service.ts` `isTabBusyGenerating` — a tree with a null
+ *    `currentMessageId` is debris, not a turn in flight.
+ * c. `chat-input.component.ts` `isActiveTabStreaming` — the Stop button reads
+ *    that same predicate, so the queue gate and its only manual drain cannot
+ *    disagree.
+ *
+ * ## Falsifiability — what fails WITHOUT the fix
+ *
+ * With (a) reverted, the late `agent_progress` mints an empty
+ * `StreamingState`. With (b) also reverted, `isTabBusyGenerating` reports
+ * busy, so:
+ *
+ * 1. The follow-up send is queued — the literal "Message queued" banner
+ *    (chat-view.component.html) renders and `toHaveCount(0)` fails.
+ * 2. No `chat:continue` ever leaves the renderer, so
+ *    `waitForObservedCall('chat:continue')` times out.
+ * 3. The user bubble for the follow-up marker is appended by the SENDER, not
+ *    by the queue path, so it never renders.
+ *
+ * With (c) alone reverted the Stop button would stay hidden while the send is
+ * queued — the shape that made the pre-fix state unrecoverable. This spec's
+ * Stop assertions are taken while the tab is genuinely idle, so they read the
+ * predicate's negative side.
+ *
+ * ## Method
+ *
+ * `ui.pushEvent` injects `chat:chunk` payloads straight onto the `to-renderer`
+ * IPC channel, the same seam `empty-assistant-envelope.spec.ts` uses. No
+ * `tabId` is passed, so the fresh unbound canvas tile auto-binds to the first
+ * event's `sessionId` (the `StreamingHandlerService` "hijack" branch) exactly
+ * as a real first turn binds it. That binding is what makes the follow-up send
+ * a `chat:continue` rather than a `chat:start`.
+ */
+
+const CHAT_CHUNK = 'chat:chunk';
+const TURN_TEXT_MARKER = 'PTAH_E2E_382_TURN_TEXT_MARKER';
+const FOLLOW_UP_MARKER = 'PTAH_E2E_382_FOLLOW_UP_MARKER';
+
+const TEXTAREA = 'ptah-chat-input textarea[role="combobox"]';
+const SEND_BUTTON = '[data-testid="chat-send-btn"]';
+const STOP_BUTTON = '[data-testid="chat-stop-btn"]';
+const ASSISTANT_BUBBLE = '[data-testid="chat-tool-output"]';
+const USER_BUBBLE = '.chat-bubble-primary';
+const QUEUED_BANNER_TEXT = 'Message queued';
+
+function chunk(sessionId: string, event: Record<string, unknown>) {
+  return { type: CHAT_CHUNK, payload: { sessionId, event } };
+}
+
+function messageStart(sessionId: string, messageId: string, timestamp: number) {
+  return chunk(sessionId, {
+    id: randomUUID(),
+    eventType: 'message_start',
+    timestamp,
+    sessionId,
+    source: 'complete',
+    messageId,
+    role: 'assistant',
+  });
+}
+
+function textDelta(
+  sessionId: string,
+  messageId: string,
+  timestamp: number,
+  delta: string,
+) {
+  return chunk(sessionId, {
+    id: randomUUID(),
+    eventType: 'text_delta',
+    timestamp,
+    sessionId,
+    source: 'complete',
+    messageId,
+    delta,
+    blockIndex: 0,
+  });
+}
+
+function messageComplete(
+  sessionId: string,
+  messageId: string,
+  timestamp: number,
+) {
+  return chunk(sessionId, {
+    id: randomUUID(),
+    eventType: 'message_complete',
+    timestamp,
+    sessionId,
+    source: 'complete',
+    messageId,
+  });
+}
+
+function turnStateIdle(sessionId: string, timestamp: number, revision = 1) {
+  return chunk(sessionId, {
+    id: randomUUID(),
+    eventType: 'turn_state',
+    timestamp,
+    sessionId,
+    messageId: `turn-state-${sessionId}`,
+    phase: 'idle',
+    revision,
+    backgroundTasks: [],
+    sessionCrons: [],
+    terminalReason: 'completed',
+  });
+}
+
+/** Every required field of `AgentProgressEvent` (stream-background.ts). */
+function agentProgress(
+  sessionId: string,
+  timestamp: number,
+  parentToolUseId: string,
+  taskId: string,
+) {
+  return chunk(sessionId, {
+    id: randomUUID(),
+    eventType: 'agent_progress',
+    timestamp,
+    sessionId,
+    source: 'complete',
+    messageId: randomUUID(),
+    parentToolUseId,
+    taskId,
+    description: 'Still working after the turn ended',
+    totalTokens: 12,
+    toolUses: 1,
+    durationMs: 250,
+  });
+}
+
+/** Every required field of `AgentCompletedEvent` (stream-background.ts). */
+function agentCompleted(
+  sessionId: string,
+  timestamp: number,
+  parentToolUseId: string,
+  taskId: string,
+) {
+  return chunk(sessionId, {
+    id: randomUUID(),
+    eventType: 'agent_completed',
+    timestamp,
+    sessionId,
+    source: 'complete',
+    messageId: randomUUID(),
+    parentToolUseId,
+    taskId,
+    status: 'completed',
+    summary: 'done',
+    outputFile: '',
+  });
+}
+
+/** Diagnostic dump used only when an expectation about routing fails. */
+async function describeSendCalls(ui: UiDriver): Promise<string> {
+  const starts = await ui.getObservedCalls('chat:start');
+  const continues = await ui.getObservedCalls('chat:continue');
+  return JSON.stringify({ 'chat:start': starts, 'chat:continue': continues });
+}
+
+test.describe('Late post-turn event does not pin the tab busy (TASK_2026_382)', () => {
+  test('a stray agent_progress / agent_completed arriving after the root turn settled leaves the tile idle, and the next send dispatches as chat:continue instead of queuing', async ({
+    ui,
+  }) => {
+    const page = ui.page;
+
+    await ui.mockRpc({
+      // The tab is bound by the hijack below, so the follow-up send takes the
+      // continue path — which validates the session on disk first. Without
+      // this mock the validator reports "missing" and the send silently
+      // degrades to a fresh `chat:start`, testing nothing.
+      'session:validate': { exists: true },
+      'chat:continue': { success: true },
+    });
+
+    await ui.goto('chat');
+
+    const sessionId = randomUUID();
+    const messageId = randomUUID();
+    const t0 = Date.now();
+
+    // A complete root turn, injected exactly as the SDK would deliver it.
+    await ui.pushEvent(messageStart(sessionId, messageId, t0));
+    await ui.pushEvent(
+      textDelta(sessionId, messageId, t0 + 1, TURN_TEXT_MARKER),
+    );
+    await ui.pushEvent(messageComplete(sessionId, messageId, t0 + 2));
+    await ui.pushEvent(turnStateIdle(sessionId, t0 + 4));
+
+    const assistantBubble = page.locator(ASSISTANT_BUBBLE);
+    await expect(assistantBubble).toContainText(TURN_TEXT_MARKER);
+
+    // Sanity: the turn is over, so the busy predicate is false.
+    await expect(page.locator(STOP_BUTTON)).toHaveCount(0);
+
+    // The stray post-turn traffic. Both event types are store-only, so
+    // neither may create a StreamingState on this settled tab.
+    const parentToolUseId = `toolu_late_${randomUUID().replace(/-/g, '')}`;
+    const taskId = 'task_late';
+    await ui.pushEvent(
+      agentProgress(sessionId, t0 + 5, parentToolUseId, taskId),
+    );
+    await ui.pushEvent(
+      agentCompleted(sessionId, t0 + 6, parentToolUseId, taskId),
+    );
+
+    // Give the renderer a beat by waiting on a real condition rather than
+    // sleeping: the transcript is still settled after both events.
+    await expect(assistantBubble).toContainText(TURN_TEXT_MARKER);
+    await expect(page.locator(STOP_BUTTON)).toHaveCount(0);
+
+    const textarea = page.locator(TEXTAREA).first();
+    const sendButton = page.locator(SEND_BUTTON).first();
+    await textarea.fill(FOLLOW_UP_MARKER);
+    await sendButton.click();
+
+    let continueCall: { method: string; params: unknown };
+    try {
+      continueCall = await ui.waitForObservedCall('chat:continue');
+    } catch (error: unknown) {
+      const detail = await describeSendCalls(ui);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `${message}\nObserved send RPCs at failure: ${detail}\n` +
+          'A queued send makes no RPC at all; a chat:start instead of a ' +
+          'chat:continue means the tab lost its session binding.',
+      );
+    }
+
+    const params = continueCall.params as {
+      prompt?: string;
+      sessionId?: string;
+    };
+    expect(params.prompt).toBe(FOLLOW_UP_MARKER);
+    expect(params.sessionId).toBe(sessionId);
+
+    // Exactly ONE new send RPC left the renderer, and it was the continue.
+    expect(await ui.getObservedCalls('chat:continue')).toHaveLength(1);
+    expect(await ui.getObservedCalls('chat:start')).toHaveLength(0);
+
+    // The sender appends the user bubble; the queue path does not.
+    await expect(
+      page.locator(USER_BUBBLE).filter({ hasText: FOLLOW_UP_MARKER }),
+    ).toHaveCount(1);
+
+    await expect(page.getByText(QUEUED_BANNER_TEXT)).toHaveCount(0);
+  });
+});

--- a/libs/backend/agent-generation/src/lib/services/analysis-storage.service.ts
+++ b/libs/backend/agent-generation/src/lib/services/analysis-storage.service.ts
@@ -212,6 +212,13 @@ export class AnalysisStorageService {
   /**
    * Read a phase output file's modification time.
    * Returns null if the file doesn't exist or stats aren't available.
+   *
+   * The mtime is an OPTIONAL signal by design: `recordPhaseOutcome` uses it to
+   * tell "the agent rewrote the file with identical bytes" apart from "the
+   * agent wrote nothing", and falls back to comparing content when it is
+   * absent. A provider that cannot stat therefore behaves exactly as it did
+   * before the mtime signal existed, which is why null is an answer here and
+   * not a failure.
    */
   async readPhaseFileMtime(
     slugDir: string,
@@ -220,6 +227,9 @@ export class AnalysisStorageService {
     try {
       return (await this.fs.stat(join(slugDir, filename))).mtime;
     } catch {
+      // degradation-audit: optional-capability - a missing file or a provider
+      // with no usable stat returns null, and the caller falls back to the
+      // content comparison. Nothing downstream is skipped or degraded.
       return null;
     }
   }

--- a/libs/backend/agent-generation/src/lib/services/analysis-storage.service.ts
+++ b/libs/backend/agent-generation/src/lib/services/analysis-storage.service.ts
@@ -234,6 +234,25 @@ export class AnalysisStorageService {
     }
   }
 
+  /**
+   * Remove a readable stale phase file before a resumed phase runs.
+   * Returns false when the provider cannot remove it so callers can retain
+   * their observational freshness fallback.
+   */
+  async tryRemovePhaseFile(
+    slugDir: string,
+    filename: string,
+  ): Promise<boolean> {
+    try {
+      await this.fs.delete(join(slugDir, filename));
+      return true;
+    } catch {
+      // degradation-audit: optional-capability - some providers may reject a
+      // phase-file delete; the caller then retains content/mtime freshness.
+      return false;
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Analysis manifest (version 3)
   // ---------------------------------------------------------------------------

--- a/libs/backend/agent-generation/src/lib/services/analysis-storage.service.ts
+++ b/libs/backend/agent-generation/src/lib/services/analysis-storage.service.ts
@@ -209,6 +209,21 @@ export class AnalysisStorageService {
     }
   }
 
+  /**
+   * Read a phase output file's modification time.
+   * Returns null if the file doesn't exist or stats aren't available.
+   */
+  async readPhaseFileMtime(
+    slugDir: string,
+    filename: string,
+  ): Promise<number | null> {
+    try {
+      return (await this.fs.stat(join(slugDir, filename))).mtime;
+    } catch {
+      return null;
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Analysis manifest (version 3)
   // ---------------------------------------------------------------------------

--- a/libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.spec.ts
+++ b/libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.spec.ts
@@ -415,7 +415,7 @@ describe('MultiPhaseAnalysisService', () => {
       expect(manifest.lifecycle).toBe('completed');
       expect(manifest.totalDurationMs).toBeGreaterThanOrEqual(5_000);
       expect(execute).toHaveBeenCalledTimes(3);
-      expect(fs.delete).not.toHaveBeenCalled();
+      expect(fs.delete).toHaveBeenCalledWith(join(SLUG_DIR, FILES[1]));
       expect(await fs.readFile(join(SLUG_DIR, FILES[0]))).toBe('OLD PROFILE');
       expect(await fs.readFile(join(SLUG_DIR, FILES[1]))).toContain(
         'agent wrote',
@@ -490,6 +490,35 @@ describe('MultiPhaseAnalysisService', () => {
       expect(await fs.readFile(join(SLUG_DIR, FILES[1]))).not.toBe('Done.');
     });
 
+    it('completes an identical rewrite when its modification time is unchanged without overwriting the file', async () => {
+      fs.stat.mockResolvedValue({
+        type: 1,
+        ctime: 0,
+        mtime: 100,
+        size: STALE_STUB.length,
+      });
+      await storage.writeManifest(SLUG_DIR, seedPausedManifest());
+      await storage.writePhaseFile(SLUG_DIR, FILES[0], 'OLD PROFILE');
+      await storage.writePhaseFile(SLUG_DIR, FILES[1], STALE_STUB);
+      scenarios = [
+        streamOf([assistant('Done.'), success('Done.')], () =>
+          storage.writePhaseFile(SLUG_DIR, FILES[1], STALE_STUB),
+        ),
+        ...FILES.slice(2).map((file) => agentWritesFile(file)),
+      ];
+
+      const result = await service.analyzeWorkspace(WORKSPACE, {
+        mcpServerRunning: true,
+        resume: true,
+      });
+
+      expect(result.value!.phases['architecture-assessment'].status).toBe(
+        'completed',
+      );
+      expect(await fs.readFile(join(SLUG_DIR, FILES[1]))).toBe(STALE_STUB);
+      expect(await fs.readFile(join(SLUG_DIR, FILES[1]))).not.toBe('Done.');
+    });
+
     it('rejects an unchanged stale file when the resumed phase writes nothing', async () => {
       await storage.writeManifest(SLUG_DIR, seedPausedManifest());
       await storage.writePhaseFile(SLUG_DIR, FILES[0], 'OLD PROFILE');
@@ -512,6 +541,57 @@ describe('MultiPhaseAnalysisService', () => {
       );
       expect(result.value!.lifecycle).toBe('failed');
       expect(await fs.readFile(join(SLUG_DIR, FILES[1]))).toBe(STALE_STUB);
+    });
+
+    it('restores the stale phase file when a resumed phase is paused before writing', async () => {
+      await storage.writeManifest(SLUG_DIR, seedPausedManifest());
+      await storage.writePhaseFile(SLUG_DIR, FILES[0], 'OLD PROFILE');
+      await storage.writePhaseFile(SLUG_DIR, FILES[1], STALE_STUB);
+      scenarios = [
+        hangingStream(() => {
+          service.cancelAnalysis();
+        }),
+      ];
+
+      const result = await service.analyzeWorkspace(WORKSPACE, {
+        mcpServerRunning: true,
+        resume: true,
+      });
+
+      expect(result.value!.lifecycle).toBe('paused');
+      expect(result.value!.phases['architecture-assessment'].status).toBe(
+        'pending',
+      );
+      expect(await fs.readFile(join(SLUG_DIR, FILES[1]))).toBe(STALE_STUB);
+    });
+
+    it('retains the content and mtime fallback when stale-file removal is unavailable', async () => {
+      fs.delete.mockRejectedValue(new Error('delete unavailable'));
+      fs.stat.mockResolvedValue({
+        type: 1,
+        ctime: 0,
+        mtime: 100,
+        size: STALE_STUB.length,
+      });
+      await storage.writeManifest(SLUG_DIR, seedPausedManifest());
+      await storage.writePhaseFile(SLUG_DIR, FILES[0], 'OLD PROFILE');
+      await storage.writePhaseFile(SLUG_DIR, FILES[1], STALE_STUB);
+      scenarios = [
+        streamOf([assistant('Done.'), success('Done.')], () =>
+          storage.writePhaseFile(SLUG_DIR, FILES[1], STALE_STUB),
+        ),
+        ...FILES.slice(2).map((file) => agentWritesFile(file)),
+      ];
+
+      const result = await service.analyzeWorkspace(WORKSPACE, {
+        mcpServerRunning: true,
+        resume: true,
+      });
+
+      expect(result.value!.phases['architecture-assessment'].status).toBe(
+        'completed',
+      );
+      expect(await fs.readFile(join(SLUG_DIR, FILES[1]))).toBe('Done.');
     });
 
     it('falls back to changed content when the provider cannot report modification times', async () => {

--- a/libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.spec.ts
+++ b/libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.spec.ts
@@ -459,7 +459,38 @@ describe('MultiPhaseAnalysisService', () => {
       expect(file).not.toContain('run was interrupted');
     });
 
-    it('fails a resumed phase that writes no file and captures no text instead of trusting the stale one', async () => {
+    it('completes an identical rewrite when its modification time advances without overwriting the file', async () => {
+      let phaseMtime = 100;
+      fs.stat.mockImplementation(async () => ({
+        type: 1,
+        ctime: 0,
+        mtime: phaseMtime,
+        size: STALE_STUB.length,
+      }));
+      await storage.writeManifest(SLUG_DIR, seedPausedManifest());
+      await storage.writePhaseFile(SLUG_DIR, FILES[0], 'OLD PROFILE');
+      await storage.writePhaseFile(SLUG_DIR, FILES[1], STALE_STUB);
+      scenarios = [
+        streamOf([assistant('Done.'), success('Done.')], async () => {
+          await storage.writePhaseFile(SLUG_DIR, FILES[1], STALE_STUB);
+          phaseMtime = 200;
+        }),
+        ...FILES.slice(2).map((file) => agentWritesFile(file)),
+      ];
+
+      const result = await service.analyzeWorkspace(WORKSPACE, {
+        mcpServerRunning: true,
+        resume: true,
+      });
+
+      expect(result.value!.phases['architecture-assessment'].status).toBe(
+        'completed',
+      );
+      expect(await fs.readFile(join(SLUG_DIR, FILES[1]))).toBe(STALE_STUB);
+      expect(await fs.readFile(join(SLUG_DIR, FILES[1]))).not.toBe('Done.');
+    });
+
+    it('rejects an unchanged stale file when the resumed phase writes nothing', async () => {
       await storage.writeManifest(SLUG_DIR, seedPausedManifest());
       await storage.writePhaseFile(SLUG_DIR, FILES[0], 'OLD PROFILE');
       await storage.writePhaseFile(SLUG_DIR, FILES[1], STALE_STUB);
@@ -481,6 +512,32 @@ describe('MultiPhaseAnalysisService', () => {
       );
       expect(result.value!.lifecycle).toBe('failed');
       expect(await fs.readFile(join(SLUG_DIR, FILES[1]))).toBe(STALE_STUB);
+    });
+
+    it('falls back to changed content when the provider cannot report modification times', async () => {
+      fs.stat.mockRejectedValue(new Error('stat unavailable'));
+      await storage.writeManifest(SLUG_DIR, seedPausedManifest());
+      await storage.writePhaseFile(SLUG_DIR, FILES[0], 'OLD PROFILE');
+      await storage.writePhaseFile(SLUG_DIR, FILES[1], STALE_STUB);
+      const rewrittenContent = '# Architecture Assessment\nComplete analysis';
+      scenarios = [
+        streamOf([assistant('Done.'), success('Done.')], () =>
+          storage.writePhaseFile(SLUG_DIR, FILES[1], rewrittenContent),
+        ),
+        ...FILES.slice(2).map((file) => agentWritesFile(file)),
+      ];
+
+      const result = await service.analyzeWorkspace(WORKSPACE, {
+        mcpServerRunning: true,
+        resume: true,
+      });
+
+      expect(result.value!.phases['architecture-assessment'].status).toBe(
+        'completed',
+      );
+      expect(await fs.readFile(join(SLUG_DIR, FILES[1]))).toBe(
+        rewrittenContent,
+      );
     });
 
     it('falls back to a fresh run when no resumable manifest exists', async () => {

--- a/libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.spec.ts
+++ b/libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.spec.ts
@@ -13,6 +13,8 @@
  * - user pause => `paused`, active phase back to `pending`, slug kept
  * - resume skips completed phases, restarts a stale `running` phase, keeps
  *   the runId, never deletes
+ * - a phase file left by an earlier run never satisfies the resumed phase:
+ *   fresh text replaces it, and no text at all fails the phase
  * - resume without a resumable manifest falls back to a fresh run
  * - text capture ignores the throttled UI emitter
  */
@@ -424,6 +426,61 @@ describe('MultiPhaseAnalysisService', () => {
         'pending',
       );
       expect(firstWrite.lifecycle).toBe('running');
+    });
+
+    // A FAILED or PAUSED run leaves its lossy diagnostic text on disk and
+    // nothing deletes it, so on resume the phase file is already there before
+    // the agent starts. It must never stand in for output this run produced.
+    const STALE_STUB = '# Architecture Assessment\n(run was interrupted)';
+
+    it('replaces the stale phase file when the resumed phase succeeds without writing it', async () => {
+      await storage.writeManifest(SLUG_DIR, seedPausedManifest());
+      await storage.writePhaseFile(SLUG_DIR, FILES[0], 'OLD PROFILE');
+      await storage.writePhaseFile(SLUG_DIR, FILES[1], STALE_STUB);
+      scenarios = [
+        // Succeeds, returns text, writes NO file — the F2 failure mode.
+        streamOf([
+          assistant('fresh architecture text'),
+          success('fresh architecture text'),
+        ]),
+        ...FILES.slice(2).map((file) => agentWritesFile(file)),
+      ];
+
+      const result = await service.analyzeWorkspace(WORKSPACE, {
+        mcpServerRunning: true,
+        resume: true,
+      });
+
+      expect(result.isOk()).toBe(true);
+      const phase = result.value!.phases['architecture-assessment'];
+      expect(phase.status).toBe('completed');
+      const file = await fs.readFile(join(SLUG_DIR, FILES[1]));
+      expect(file).toBe('fresh architecture text');
+      expect(file).not.toContain('run was interrupted');
+    });
+
+    it('fails a resumed phase that writes no file and captures no text instead of trusting the stale one', async () => {
+      await storage.writeManifest(SLUG_DIR, seedPausedManifest());
+      await storage.writePhaseFile(SLUG_DIR, FILES[0], 'OLD PROFILE');
+      await storage.writePhaseFile(SLUG_DIR, FILES[1], STALE_STUB);
+      scenarios = [
+        // Succeeds, writes no file, says nothing.
+        streamOf([success()]),
+        ...FILES.slice(2).map((file) => agentWritesFile(file)),
+      ];
+
+      const result = await service.analyzeWorkspace(WORKSPACE, {
+        mcpServerRunning: true,
+        resume: true,
+      });
+
+      const phase = result.value!.phases['architecture-assessment'];
+      expect(phase.status).toBe('failed');
+      expect(phase.error).toBe(
+        'Agent did not write the phase file and no text was captured',
+      );
+      expect(result.value!.lifecycle).toBe('failed');
+      expect(await fs.readFile(join(SLUG_DIR, FILES[1]))).toBe(STALE_STUB);
     });
 
     it('falls back to a fresh run when no resumable manifest exists', async () => {

--- a/libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.ts
+++ b/libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.ts
@@ -227,6 +227,16 @@ export class MultiPhaseAnalysisService {
           phaseConfig.label,
         );
 
+        // Snapshot the phase file BEFORE the agent runs. On resume the file a
+        // previous FAILED or PAUSED run left behind is still on disk — nothing
+        // deletes it — so a bare existence check after the run would let that
+        // stale stub satisfy the file requirement and mark the phase
+        // `completed`.
+        const priorFileContent = await this.storageService.readPhaseFile(
+          slugDir,
+          phaseConfig.file,
+        );
+
         const phaseStart = Date.now();
         let outcome: PhaseExecutionOutcome;
         try {
@@ -268,6 +278,7 @@ export class MultiPhaseAnalysisService {
           phaseConfig.file,
           outcome,
           Date.now() - phaseStart,
+          priorFileContent,
         );
 
         const statuses = checkpoint.statuses();
@@ -351,10 +362,16 @@ export class MultiPhaseAnalysisService {
   /**
    * Turn an execution outcome into the phase's terminal manifest state.
    *
-   * `completed` requires a successful result AND a phase file — either one the
-   * agent wrote or one created from the complete captured text. Everything
-   * else is `failed` with a non-empty error; captured text is still written
-   * to the phase file for diagnosis, but the manifest says failed.
+   * `completed` requires a successful result AND a phase file THIS RUN wrote —
+   * either one the agent wrote or one created from the complete captured text.
+   * A file left over from an earlier failed or paused run does not count: it
+   * is stale, lossy partial text and promoting it to `completed` would feed it
+   * to the enhanced-prompt designer. Everything else is `failed` with a
+   * non-empty error; captured text is still written to the phase file for
+   * diagnosis, but the manifest says failed.
+   *
+   * @param priorFileContent - The phase file's content immediately before this
+   *   run executed the phase, or null when there was no readable file.
    */
   private async recordPhaseOutcome(
     checkpoint: AnalysisRunCheckpoint,
@@ -362,16 +379,19 @@ export class MultiPhaseAnalysisService {
     filename: string,
     outcome: PhaseExecutionOutcome,
     durationMs: number,
+    priorFileContent: string | null,
   ): Promise<void> {
-    const fileExists = await this.storageService.phaseFileExists(
+    const currentFileContent = await this.storageService.readPhaseFile(
       checkpoint.slugDir,
       filename,
     );
+    const fileWrittenThisRun =
+      currentFileContent !== null && currentFileContent !== priorFileContent;
     const succeeded =
       outcome.resultReceived && !outcome.timedOut && !outcome.error;
 
     if (succeeded) {
-      if (!fileExists) {
+      if (!fileWrittenThisRun) {
         if (!outcome.assistantText) {
           this.logger.warn(
             `${SERVICE_TAG} Phase ${phaseId}: no file written and no text captured`,
@@ -384,7 +404,7 @@ export class MultiPhaseAnalysisService {
           return;
         }
         this.logger.warn(
-          `${SERVICE_TAG} Phase ${phaseId}: agent did not write file, creating it from the complete captured text`,
+          `${SERVICE_TAG} Phase ${phaseId}: agent did not write file this run, creating it from the complete captured text`,
         );
         await this.storageService.writePhaseFile(
           checkpoint.slugDir,
@@ -401,7 +421,7 @@ export class MultiPhaseAnalysisService {
       (outcome.timedOut
         ? `analysis_timeout: phase exceeded ${PER_PHASE_TIMEOUT_MS} ms`
         : 'Stream ended without a result');
-    if (!fileExists && outcome.assistantText) {
+    if (!fileWrittenThisRun && outcome.assistantText) {
       this.logger.warn(
         `${SERVICE_TAG} Phase ${phaseId}: keeping captured text as a diagnostic file (phase still failed)`,
       );

--- a/libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.ts
+++ b/libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.ts
@@ -236,6 +236,33 @@ export class MultiPhaseAnalysisService {
           this.storageService.readPhaseFile(slugDir, phaseConfig.file),
           this.storageService.readPhaseFileMtime(slugDir, phaseConfig.file),
         ]);
+        // Then REMOVE it, so that afterwards the file EXISTING is itself the
+        // proof this run wrote it. Comparing the file to its own snapshot
+        // cannot deliver that proof: a rewrite with identical bytes is
+        // invisible to a content compare, and mtime granularity is not
+        // guaranteed to be finer than the gap between this snapshot and the
+        // agent's write, so a strict `>` reads a real write as no write. The
+        // asymmetric cost of that mistake is what forces an exact answer —
+        // `recordPhaseOutcome` OVERWRITES the file with the captured assistant
+        // text when it believes nothing was written, and for these prompts
+        // that text is often a bare "Done.".
+        //
+        // The content lives in `priorFileContent` for the whole phase and is
+        // written back by `restorePriorPhaseFileIfMissing` on every exit that
+        // did not produce a replacement — abort, pause, and both failure
+        // paths. The residue is a crash window: the file is absent on disk for
+        // the duration of the phase, so losing the process outright loses that
+        // stale text. It is stale, lossy partial output whose only use is
+        // diagnosis, and the phase re-runs from scratch after a crash anyway.
+        //
+        // A provider that refuses the delete reports `false` and the run keeps
+        // the content/mtime fallback — worse, but exactly as good as before.
+        const staleFileRemoved =
+          priorFileContent !== null &&
+          (await this.storageService.tryRemovePhaseFile(
+            slugDir,
+            phaseConfig.file,
+          ));
 
         const phaseStart = Date.now();
         let outcome: PhaseExecutionOutcome;
@@ -252,6 +279,12 @@ export class MultiPhaseAnalysisService {
           );
         } catch (error: unknown) {
           if (masterAbortController.signal.aborted) {
+            await this.restorePriorPhaseFileIfMissing(
+              slugDir,
+              phaseConfig.file,
+              priorFileContent,
+              staleFileRemoved,
+            );
             await checkpoint.pause(phaseId);
             paused = true;
             break;
@@ -267,6 +300,12 @@ export class MultiPhaseAnalysisService {
           this.logger.info(
             `${SERVICE_TAG} Phase ${phaseId} paused by user; partial file kept`,
           );
+          await this.restorePriorPhaseFileIfMissing(
+            slugDir,
+            phaseConfig.file,
+            priorFileContent,
+            staleFileRemoved,
+          );
           await checkpoint.pause(phaseId);
           paused = true;
           break;
@@ -280,6 +319,7 @@ export class MultiPhaseAnalysisService {
           Date.now() - phaseStart,
           priorFileContent,
           priorFileMtime,
+          staleFileRemoved,
         );
 
         const statuses = checkpoint.statuses();
@@ -364,10 +404,11 @@ export class MultiPhaseAnalysisService {
    * Turn an execution outcome into the phase's terminal manifest state.
    *
    * `completed` requires a successful result AND a phase file THIS RUN wrote,
-   * detected by an advanced modification time or changed content, or one
-   * created from the complete captured text. A stale file left by an earlier
-   * failed or paused run does not count. Everything else is `failed` with a
-   * non-empty error; captured text is still written for diagnosis.
+   * proven by removing a readable stale file before execution, or detected by
+   * the prior content/mtime fallback when removal was unavailable. A stale
+   * file left by an earlier failed or paused run does not count. Everything
+   * else is `failed` with a non-empty error; captured text is still written
+   * for diagnosis.
    *
    * @param priorFileContent - The phase file's content immediately before this
    *   run executed the phase, or null when there was no readable file.
@@ -382,6 +423,7 @@ export class MultiPhaseAnalysisService {
     durationMs: number,
     priorFileContent: string | null,
     priorFileMtime: number | null,
+    staleFileRemoved: boolean,
   ): Promise<void> {
     const [currentFileContent, currentFileMtime] = await Promise.all([
       this.storageService.readPhaseFile(checkpoint.slugDir, filename),
@@ -389,9 +431,10 @@ export class MultiPhaseAnalysisService {
     ]);
     const fileWrittenThisRun =
       currentFileContent !== null &&
-      ((priorFileMtime !== null &&
-        currentFileMtime !== null &&
-        currentFileMtime > priorFileMtime) ||
+      (staleFileRemoved ||
+        (priorFileMtime !== null &&
+          currentFileMtime !== null &&
+          currentFileMtime > priorFileMtime) ||
         currentFileContent !== priorFileContent);
     const succeeded =
       outcome.resultReceived && !outcome.timedOut && !outcome.error;
@@ -401,6 +444,12 @@ export class MultiPhaseAnalysisService {
         if (!outcome.assistantText) {
           this.logger.warn(
             `${SERVICE_TAG} Phase ${phaseId}: no file written and no text captured`,
+          );
+          await this.restorePriorPhaseFileIfMissing(
+            checkpoint.slugDir,
+            filename,
+            priorFileContent,
+            staleFileRemoved,
           );
           await checkpoint.markFailed(
             phaseId,
@@ -437,11 +486,37 @@ export class MultiPhaseAnalysisService {
         outcome.assistantText,
       );
     }
+    await this.restorePriorPhaseFileIfMissing(
+      checkpoint.slugDir,
+      filename,
+      priorFileContent,
+      staleFileRemoved,
+    );
     this.logger.error(
       `${SERVICE_TAG} Phase ${phaseId} failed after ${durationMs}ms: ${error}`,
       { phaseId, durationMs, timedOut: outcome.timedOut },
     );
     await checkpoint.markFailed(phaseId, durationMs, error);
+  }
+
+  private async restorePriorPhaseFileIfMissing(
+    slugDir: string,
+    filename: string,
+    priorFileContent: string | null,
+    staleFileRemoved: boolean,
+  ): Promise<void> {
+    if (
+      !staleFileRemoved ||
+      priorFileContent === null ||
+      (await this.storageService.phaseFileExists(slugDir, filename))
+    ) {
+      return;
+    }
+    await this.storageService.writePhaseFile(
+      slugDir,
+      filename,
+      priorFileContent,
+    );
   }
 
   /**

--- a/libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.ts
+++ b/libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.ts
@@ -232,10 +232,10 @@ export class MultiPhaseAnalysisService {
         // deletes it — so a bare existence check after the run would let that
         // stale stub satisfy the file requirement and mark the phase
         // `completed`.
-        const priorFileContent = await this.storageService.readPhaseFile(
-          slugDir,
-          phaseConfig.file,
-        );
+        const [priorFileContent, priorFileMtime] = await Promise.all([
+          this.storageService.readPhaseFile(slugDir, phaseConfig.file),
+          this.storageService.readPhaseFileMtime(slugDir, phaseConfig.file),
+        ]);
 
         const phaseStart = Date.now();
         let outcome: PhaseExecutionOutcome;
@@ -279,6 +279,7 @@ export class MultiPhaseAnalysisService {
           outcome,
           Date.now() - phaseStart,
           priorFileContent,
+          priorFileMtime,
         );
 
         const statuses = checkpoint.statuses();
@@ -362,16 +363,16 @@ export class MultiPhaseAnalysisService {
   /**
    * Turn an execution outcome into the phase's terminal manifest state.
    *
-   * `completed` requires a successful result AND a phase file THIS RUN wrote —
-   * either one the agent wrote or one created from the complete captured text.
-   * A file left over from an earlier failed or paused run does not count: it
-   * is stale, lossy partial text and promoting it to `completed` would feed it
-   * to the enhanced-prompt designer. Everything else is `failed` with a
-   * non-empty error; captured text is still written to the phase file for
-   * diagnosis, but the manifest says failed.
+   * `completed` requires a successful result AND a phase file THIS RUN wrote,
+   * detected by an advanced modification time or changed content, or one
+   * created from the complete captured text. A stale file left by an earlier
+   * failed or paused run does not count. Everything else is `failed` with a
+   * non-empty error; captured text is still written for diagnosis.
    *
    * @param priorFileContent - The phase file's content immediately before this
    *   run executed the phase, or null when there was no readable file.
+   * @param priorFileMtime - The phase file's modification time immediately
+   *   before this run executed the phase, or null when unavailable.
    */
   private async recordPhaseOutcome(
     checkpoint: AnalysisRunCheckpoint,
@@ -380,13 +381,18 @@ export class MultiPhaseAnalysisService {
     outcome: PhaseExecutionOutcome,
     durationMs: number,
     priorFileContent: string | null,
+    priorFileMtime: number | null,
   ): Promise<void> {
-    const currentFileContent = await this.storageService.readPhaseFile(
-      checkpoint.slugDir,
-      filename,
-    );
+    const [currentFileContent, currentFileMtime] = await Promise.all([
+      this.storageService.readPhaseFile(checkpoint.slugDir, filename),
+      this.storageService.readPhaseFileMtime(checkpoint.slugDir, filename),
+    ]);
     const fileWrittenThisRun =
-      currentFileContent !== null && currentFileContent !== priorFileContent;
+      currentFileContent !== null &&
+      ((priorFileMtime !== null &&
+        currentFileMtime !== null &&
+        currentFileMtime > priorFileMtime) ||
+        currentFileContent !== priorFileContent);
     const succeeded =
       outcome.resultReceived && !outcome.timedOut && !outcome.error;
 

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-runner.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-runner.service.spec.ts
@@ -298,6 +298,68 @@ describe('SdkQueryRunner', () => {
     });
   });
 
+  /**
+   * TASK_2026_364 blocker B3 — the one-shot query was the last anonymous Ptah
+   * MCP consumer.
+   *
+   * A bare `http://localhost:{port}` cannot say which folder the caller belongs
+   * to, so its path-resolving tool calls landed on whichever workspace was most
+   * recently activated. Worse, `McpCallerWorkspaceResolver` now REFUSES an
+   * anonymous caller outright when more than one folder is open, so every
+   * `ptah_agent_*` call from a one-shot hard-failed in a two-folder window —
+   * this query runs `bypassPermissions` and its system prompt tells the model
+   * to spawn CLI agents.
+   */
+  describe('runOneShot — the MCP URL declares the query workspace', () => {
+    async function capturedPtahMcpUrl(cwd: string): Promise<string> {
+      const h = makeRunner();
+      await h.runner.runOneShot({
+        mode: 'oneShot',
+        cwd,
+        model: 'claude-sonnet-4-20250514',
+        prompt: 'hi',
+        mcpServerRunning: true,
+        mcpPort: 51820,
+      });
+      const [params] = h.queryFn.mock.calls[0] as [
+        { prompt: unknown; options: SdkQueryOptions },
+      ];
+      const servers = params.options.mcpServers as Record<
+        string,
+        { url?: string }
+      >;
+      return servers['ptah'].url as string;
+    }
+
+    it('carries the /workspace/{encoded cwd} segment, never the bare origin', async () => {
+      await expect(capturedPtahMcpUrl('/work/project')).resolves.toBe(
+        'http://localhost:51820/workspace/%2Fwork%2Fproject',
+      );
+    });
+
+    it('percent-encodes a Windows root, so no separator survives as a path segment', async () => {
+      const url = await capturedPtahMcpUrl('D:\\projects\\ptah-extension');
+      expect(url).toBe(
+        'http://localhost:51820/workspace/D%3A%5Cprojects%5Cptah-extension',
+      );
+      // `harness-sync`'s `inferTransportType` reads a literal `/sse` anywhere in
+      // a URL as an SSE endpoint. Encoding every separator is what makes that
+      // impossible for a scoped URL, whatever the directory is called.
+      expect(url.slice('http://localhost:51820/workspace/'.length)).not.toMatch(
+        /[/\\]/,
+      );
+    });
+
+    it('declares the SANITIZED cwd — the same directory the SDK is given', async () => {
+      // An empty cwd is rewritten to the home directory before the SDK sees it;
+      // the URL must name that directory too, not an anonymous origin.
+      const url = await capturedPtahMcpUrl('');
+      expect(url).toBe(
+        `http://localhost:51820/workspace/${encodeURIComponent(os.homedir())}`,
+      );
+    });
+  });
+
   describe('invokeWithLoadedQuery', () => {
     it('invokes the loaded queryFn with the prompt + options and returns its query', () => {
       const h = makeRunner();

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-runner.service.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-runner.service.ts
@@ -381,6 +381,7 @@ export class SdkQueryRunner {
     const mcpServers = this.buildOneShotMcpServers(
       input.mcpServerRunning,
       input.mcpPort,
+      input.cwd,
     );
 
     const hooks = this.buildOneShotHooks(input.cwd);
@@ -485,9 +486,37 @@ export class SdkQueryRunner {
     };
   }
 
+  /**
+   * The one-shot query's Ptah MCP server entry.
+   *
+   * A one-shot has no Ptah session, so it cannot send the `/session/{id}`
+   * segment the interactive path sends — but it always knows the directory it
+   * runs in, and the URL states it as `/workspace/{encodeURIComponent(cwd)}`
+   * (TASK_2026_364). Two things depend on it. Path-resolving tool calls
+   * resolved against whichever folder was most recently activated instead of
+   * this query's own; and with more than one folder open,
+   * `McpCallerWorkspaceResolver` REFUSES an anonymous caller by name, so every
+   * `ptah_agent_*` call from a one-shot hard-failed — this query runs
+   * `bypassPermissions` and its `PTAH_CORE_SYSTEM_PROMPT` tells the model to
+   * spawn CLI agents.
+   *
+   * The grammar is spelled inline, as `SdkQueryOptionsBuilder.buildMcpServers`
+   * spells `/session/{id}` inline: the two helpers that own it —
+   * `ptahMcpServerUrl` (`cli-agent-runtime`) and `ptahMcpUrl`
+   * (`vscode-lm-tools`) — both live in libs that DEPEND on this one, so
+   * importing either would invert the dependency. `encodeURIComponent`, never
+   * hand-rolled escaping: a Windows root carries a colon and backslashes, and
+   * encoding every `/` as `%2F` is what keeps `inferTransportType` from
+   * reading a path containing `/sse` back as an SSE endpoint.
+   *
+   * `cwd` is `runOneShot`'s already-sanitized value (`resolveSafeCwd`, which
+   * never returns an empty string), so the URL declares the same directory the
+   * SDK is given as `options.cwd` and there is no anonymous branch to take.
+   */
   private buildOneShotMcpServers(
     mcpServerRunning: boolean,
-    mcpPort?: number,
+    mcpPort: number | undefined,
+    cwd: string,
   ): Record<string, McpHttpServerConfig> {
     if (!mcpServerRunning) {
       this.logger.warn(`${SERVICE_TAG} MCP disabled (server not running)`);
@@ -498,7 +527,7 @@ export class SdkQueryRunner {
     return {
       ptah: {
         type: 'http',
-        url: `http://localhost:${port}`,
+        url: `http://localhost:${port}/workspace/${encodeURIComponent(cwd)}`,
       },
     };
   }

--- a/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.service.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.service.ts
@@ -837,6 +837,25 @@ export class AgentProcessManager {
   }
 
   /**
+   * Every tracked agent, in EVERY workspace — the unscoped bookkeeping view.
+   *
+   * `getStatus()` is the caller-facing list and is scoped to the calling MCP
+   * request's workspace (TASK_2026_364). Internal bookkeeping must not use it.
+   * `sdk-callbacks.ts` did, and it runs on the chat SDK stream — outside
+   * `runWithMcpRequestContext` — so the resolver answered `undefined`, the scope
+   * fell back to the process-global active folder, and every agent belonging to
+   * the non-focused window was filtered out. Its parent-session remap then
+   * re-persisted nothing, leaving those references keyed to the pre-resolution
+   * tab id and unfindable by `chat:resume` (the TASK_2026_323 "agent went dark
+   * on resume" failure). This accessor exists so a bookkeeping consumer states
+   * "unscoped" explicitly instead of inheriting a caller scope it has no caller
+   * for. It must never be reachable from the MCP tool surface.
+   */
+  listTrackedAgents(): AgentProcessInfo[] {
+    return Array.from(this.agents.values()).map((t) => ({ ...t.info }));
+  }
+
+  /**
    * Read agent output (stdout + stderr).
    *
    * `lineCount` describes the STRINGS THIS CALL RETURNS, not the buffers behind

--- a/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.workspace-scope.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.workspace-scope.spec.ts
@@ -230,4 +230,45 @@ describe('AgentProcessManager workspace scoping (TASK_2026_364)', () => {
       expect(status.status).toBe('running');
     });
   });
+
+  /**
+   * The internal bookkeeping accessor (TASK_2026_364 blocker B1).
+   *
+   * `sdk-callbacks.ts` remaps parent session ids on the chat SDK stream, which
+   * is not an MCP request, so there is no caller to scope to and every scope it
+   * could inherit is the wrong one. Reading that list through `getStatus()`
+   * silently dropped the non-active workspace's agents and skipped their
+   * re-persist — see `wiring/sdk-callbacks.spec.ts`. This accessor is the way to
+   * say "unscoped" out loud; it must stay unscoped whatever the caller context.
+   */
+  describe('listTrackedAgents() — the unscoped bookkeeping view', () => {
+    it('returns agents from EVERY workspace, whatever the caller and provider say', () => {
+      const manager = makeManager({
+        providerRoot: ROOT_B,
+        resolver: { resolveCallerWorkspaceRoot: () => ROOT_A },
+      });
+      seedAgent(manager, 'agent-a', `${ROOT_A}\\sub`);
+      seedAgent(manager, 'agent-b', `${ROOT_B}\\sub`);
+
+      expect(manager.listTrackedAgents().map((a) => String(a.agentId))).toEqual(
+        ['agent-a', 'agent-b'],
+      );
+      // The caller-facing list is still scoped — the two views differ on
+      // purpose, which is the whole point of having both.
+      expect(
+        (manager.getStatus() as AgentProcessInfo[]).map((a) =>
+          String(a.agentId),
+        ),
+      ).toEqual(['agent-a']);
+    });
+
+    it('hands out copies, so a bookkeeping consumer cannot mutate tracked state', () => {
+      const manager = makeManager({ providerRoot: ROOT_A });
+      seedAgent(manager, 'agent-a', `${ROOT_A}\\sub`);
+
+      manager.listTrackedAgents()[0].parentSessionId = 'tampered';
+
+      expect(manager.listTrackedAgents()[0].parentSessionId).toBeUndefined();
+    });
+  });
 });

--- a/libs/backend/cli-agent-runtime/src/lib/wiring/sdk-callbacks.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/wiring/sdk-callbacks.spec.ts
@@ -19,8 +19,10 @@ import { createMockLogger } from '@ptah-extension/shared/testing';
 import type { Logger } from '@ptah-extension/vscode-core';
 import { TOKENS } from '@ptah-extension/vscode-core';
 import { SDK_TOKENS } from '@ptah-extension/agent-sdk';
-import type { AgentProcessInfo } from '@ptah-extension/shared';
+import type { IWorkspaceProvider } from '@ptah-extension/platform-core';
+import type { AgentId, AgentProcessInfo } from '@ptah-extension/shared';
 import type { DependencyContainer } from 'tsyringe';
+import { AgentProcessManager } from '../cli-agents/agent-process-manager.service';
 import { wireSdkCallbacks } from './sdk-callbacks';
 
 const TAB_ID = 'aaaaaaaa-bbbb-4ccc-8ddd-000000000001';
@@ -62,7 +64,7 @@ function buildHarness(options: {
   const agentProcessManager = {
     resolveParentSessionId: agentProcessManagerRemap,
     // No exited agents — the re-persist branch is covered by agent-events.spec.
-    getStatus: jest.fn().mockReturnValue([]),
+    listTrackedAgents: jest.fn().mockReturnValue([]),
   };
 
   const subagentRegistryRemap = jest.fn();
@@ -219,7 +221,7 @@ describe('wireSdkCallbacks — re-persist only what actually changed', () => {
           }
         }
       }),
-      getStatus: jest.fn(() => agents),
+      listTrackedAgents: jest.fn(() => agents),
       readOutputForPersistence: jest.fn().mockReturnValue(undefined),
     };
 
@@ -316,5 +318,145 @@ describe('wireSdkCallbacks — re-persist only what actually changed', () => {
     fire(REAL_SESSION_ID, REAL_SESSION_ID);
 
     expect(addCliSession).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * TASK_2026_364 blocker B1 — the remap reads the UNSCOPED registry.
+ *
+ * The two harnesses above hand `wireSdkCallbacks` a hand-rolled manager, so no
+ * test in them can see the workspace filter that TASK_2026_364 added to
+ * `getStatus()`. This one drives the REAL `AgentProcessManager`.
+ *
+ * The scenario is the one the task was filed to fix: two folders open, the
+ * platform provider points at folder B (the focused window), and a chat session
+ * whose CLI agents live in folder A resolves its tab id to a real SDK UUID.
+ * This callback runs on the chat SDK stream, never inside
+ * `runWithMcpRequestContext`, so there is no caller workspace and the scope
+ * falls back to the provider root — folder B. Reading the list through
+ * `getStatus()` therefore returned NOTHING, the remapped-id set was empty, and
+ * the re-persist loop never ran, leaving folder A's session references keyed to
+ * the pre-resolution tab id and unfindable by `chat:resume`.
+ */
+describe('wireSdkCallbacks — the remap is unscoped by construction', () => {
+  const ROOT_A = 'D:\\projects\\workspace-a';
+  const ROOT_B = 'D:\\projects\\workspace-b';
+
+  function makeManager(providerRoot: string): AgentProcessManager {
+    const workspaceProvider = {
+      getWorkspaceRoot: jest.fn().mockReturnValue(providerRoot),
+      getWorkspaceFolders: jest.fn().mockReturnValue([providerRoot]),
+      getConfiguration: jest.fn(
+        (_section: string, _key: string, dflt?: unknown) => dflt,
+      ),
+      setConfiguration: jest.fn(),
+      onDidChangeConfiguration: jest.fn(),
+      onDidChangeWorkspaceFolders: jest.fn(),
+    } as unknown as IWorkspaceProvider;
+
+    type Args = ConstructorParameters<typeof AgentProcessManager>;
+    return new AgentProcessManager(
+      createMockLogger() as unknown as Args[0],
+      { getAdapter: jest.fn() } as unknown as Args[1],
+      {
+        getRunningBySession: jest.fn().mockReturnValue([]),
+      } as unknown as Args[2],
+      workspaceProvider as unknown as Args[3],
+      { captureException: jest.fn() } as unknown as Args[4],
+      { effort: { get: jest.fn(() => '') } } as unknown as Args[5],
+      null,
+      null,
+      // No caller resolver: this host registers one, but the chat stream is not
+      // an MCP request, so it would answer `undefined` here anyway.
+      null,
+    );
+  }
+
+  function seedExitedAgent(
+    manager: AgentProcessManager,
+    agentId: string,
+    workingDirectory: string,
+  ): void {
+    const info: AgentProcessInfo = {
+      agentId: agentId as AgentId,
+      cli: 'codex',
+      task: 'work in the OTHER workspace',
+      workingDirectory,
+      status: 'completed',
+      startedAt: new Date(0).toISOString(),
+      parentSessionId: TAB_ID,
+      cliSessionId: `cli-${agentId}`,
+    };
+    (
+      manager as unknown as {
+        agents: Map<string, Record<string, unknown>>;
+      }
+    ).agents.set(agentId, {
+      info,
+      stdoutBuffer: '',
+      stderrBuffer: '',
+      accumulatedSegments: [],
+      accumulatedStreamEvents: [],
+    });
+  }
+
+  it('re-persists an exited agent living OUTSIDE the provider root (two folders open)', async () => {
+    const manager = makeManager(ROOT_B);
+    seedExitedAgent(manager, 'agent-in-a', `${ROOT_A}\\sub`);
+
+    const addCliSession = jest.fn().mockResolvedValue(undefined);
+    let captured: SessionIdResolvedCallback | undefined;
+
+    const registry = new Map<symbol, unknown>([
+      [
+        TOKENS.AGENT_ADAPTER,
+        {
+          setResultStatsCallback: jest.fn(),
+          setSessionIdResolvedCallback: jest.fn(
+            (cb: SessionIdResolvedCallback) => {
+              captured = cb;
+            },
+          ),
+          setCompactionStartCallback: jest.fn(),
+        },
+      ],
+      [
+        TOKENS.WEBVIEW_MANAGER,
+        { broadcastMessage: jest.fn().mockResolvedValue(undefined) },
+      ],
+      [TOKENS.AGENT_PROCESS_MANAGER, manager],
+      [
+        SDK_TOKENS.SDK_SESSION_METADATA_STORE,
+        {
+          addCliSession,
+          saveAgentOutput: jest.fn().mockResolvedValue(undefined),
+          markChildSession: jest.fn().mockResolvedValue(undefined),
+        },
+      ],
+    ]);
+
+    wireSdkCallbacks(
+      {
+        isRegistered: (token: symbol) => registry.has(token),
+        resolve: (token: symbol) => registry.get(token),
+      } as unknown as DependencyContainer,
+      {
+        logger: createMockLogger() as unknown as Logger,
+        platform: 'electron',
+      },
+    );
+    if (!captured) throw new Error('setSessionIdResolvedCallback never wired');
+
+    // Sanity: the caller-facing list really does hide this agent, so the
+    // assertion below is measuring the fix and not a vacuous case.
+    expect(manager.getStatus() as AgentProcessInfo[]).toHaveLength(0);
+
+    captured(TAB_ID, REAL_SESSION_ID);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(addCliSession).toHaveBeenCalledWith(
+      REAL_SESSION_ID,
+      expect.objectContaining({ cliSessionId: 'cli-agent-in-a' }),
+    );
   });
 });

--- a/libs/backend/cli-agent-runtime/src/lib/wiring/sdk-callbacks.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/wiring/sdk-callbacks.ts
@@ -16,7 +16,6 @@ import { TOKENS } from '@ptah-extension/vscode-core';
 import {
   MESSAGE_TYPES,
   retryWithBackoff,
-  type AgentProcessInfo,
   type IAgentAdapter,
   type ResultStatsPayload,
 } from '@ptah-extension/shared';
@@ -232,9 +231,17 @@ function remapAgentProcessManagerParents(
     TOKENS.AGENT_PROCESS_MANAGER,
   );
 
-  // Captured BEFORE the remap — afterwards the two ids are indistinguishable.
+  // `listTrackedAgents()`, NOT `getStatus()`. This callback fires on the chat
+  // SDK stream, never inside `runWithMcpRequestContext`, so the caller-workspace
+  // resolver answers `undefined` and `getStatus()` scopes on the process-global
+  // active folder instead. With two workspaces open that dropped every agent of
+  // the non-focused window from this set, the early return below fired, and
+  // their session references stayed keyed to the pre-resolution tab id —
+  // invisible to `chat:resume` (TASK_2026_364 blocker B1). Bookkeeping is
+  // unscoped by construction: there is no caller to scope it to.
   const remappedAgentIds = new Set(
-    (agentProcessManager.getStatus() as AgentProcessInfo[])
+    agentProcessManager
+      .listTrackedAgents()
       .filter((a) => a.parentSessionId === tabId)
       .map((a) => a.agentId),
   );
@@ -245,7 +252,7 @@ function remapAgentProcessManagerParents(
     return;
   }
 
-  const allAgents = agentProcessManager.getStatus() as AgentProcessInfo[];
+  const allAgents = agentProcessManager.listTrackedAgents();
   const exitedWithParent = allAgents.filter(
     (a) =>
       remappedAgentIds.has(a.agentId) &&

--- a/libs/backend/cli-engine/src/lib/platform/cli-platform-commands.spec.ts
+++ b/libs/backend/cli-engine/src/lib/platform/cli-platform-commands.spec.ts
@@ -60,10 +60,20 @@ describe('CliPlatformCommands', () => {
   // crosses first is a property of the host, not of the spec, so the ceiling is
   // raised for the file rather than for that one test.
   //
+  // Raised again 2026-09-08. The 30 s ceiling was calibrated against a 55.3 s
+  // file at `--parallel=4`; the GitHub runner ran the same file in 140.33 s at
+  // `--parallel=3` with coverage, and `extracts a device code and verification
+  // URL from the output` crossed first — a different one of the six, which is
+  // the property this comment already names. Every cli-engine suite on that run
+  // took 114-250 s, so the host, not the spec, moved. 120 s is deliberately far
+  // above the observed per-spec cost: a fourth calibration round is worth more
+  // than the seconds a tighter bound would save, and no spec here asserts a
+  // duration, so a generous ceiling forfeits no signal.
+  //
   // `jest.setTimeout` is file-scoped from the point it runs, and every describe
   // body runs during collection — placing it here rather than in the inner
   // describe is what the scope actually is.
-  jest.setTimeout(30_000);
+  jest.setTimeout(120_000);
 
   let stdoutSpy: jest.SpyInstance;
   let stderrSpy: jest.SpyInstance;

--- a/libs/frontend/chat-streaming/src/lib/streaming-handler.service.spec.ts
+++ b/libs/frontend/chat-streaming/src/lib/streaming-handler.service.spec.ts
@@ -670,6 +670,40 @@ describe('StreamingHandlerService', () => {
       expect(tabManager.markStreaming).not.toHaveBeenCalled();
     });
 
+    it('does NOT mint a StreamingState for a settled tab on agent_progress (TASK_2026_382 review B5)', () => {
+      // The latch: `agent_progress` writes nothing into `StreamingState`, but
+      // minting one for it left a settled tab holding an empty tree with a null
+      // `currentMessageId` — which `finalizeCurrentMessage` early-returns on,
+      // so nothing could ever clear it, and every busy predicate read it as a
+      // live turn. The tab could then neither send nor stop.
+      tabManager.isTabStreaming.mockReturnValue(false);
+      tabsSignal.set([makeTab({ status: 'loaded', streamingState: null })]);
+      tabManager.setStreamingState.mockClear();
+      batchedUpdate.scheduleUpdate.mockClear();
+
+      service.processStreamEvent(agentProgress(), TAB_ID);
+
+      // The store still gets the event — only the tab write is gone.
+      expect(agentMonitorStore.onAgentProgress).toHaveBeenCalled();
+      expect(tabManager.setStreamingState).not.toHaveBeenCalled();
+      expect(batchedUpdate.scheduleUpdate).not.toHaveBeenCalled();
+      expect(
+        tabsSignal().find((t) => t.id === TAB_ID)?.streamingState,
+      ).toBeNull();
+    });
+
+    it('still mints a StreamingState for an event that writes one (text_delta)', () => {
+      tabsSignal.set([makeTab({ status: 'streaming', streamingState: null })]);
+      tabManager.setStreamingState.mockClear();
+
+      service.processStreamEvent(textDelta(), TAB_ID);
+
+      expect(tabManager.setStreamingState).toHaveBeenCalled();
+      expect(
+        tabsSignal().find((t) => t.id === TAB_ID)?.streamingState,
+      ).not.toBeNull();
+    });
+
     it('binds the session on the fresh-tab hijack without writing status', () => {
       const freshTab = makeTab({
         claudeSessionId: undefined,

--- a/libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts
+++ b/libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts
@@ -41,6 +41,25 @@ import { TurnStateApplier } from './turn-state-applier.service';
 
 @Injectable({ providedIn: 'root' })
 export class StreamingHandlerService {
+  /**
+   * Event types the accumulator routes to a STORE and nowhere else — see the
+   * `background_agent_*` / `agent_*` arms of
+   * `StreamingAccumulatorCore.process`. None of them reads or writes
+   * `StreamingState`, so none may cause one to be created. `turn_state` is not
+   * listed because it is intercepted in `processStreamEvent` and never reaches
+   * the per-tab path at all.
+   */
+  private static readonly STORE_ONLY_EVENT_TYPES: ReadonlySet<string> = new Set(
+    [
+      'agent_progress',
+      'agent_status',
+      'agent_completed',
+      'background_agent_started',
+      'background_agent_completed',
+      'background_agent_stopped',
+    ],
+  );
+
   private readonly tabManager = inject(TabManagerService);
   private readonly sessionManager = inject(SessionManager);
 
@@ -244,7 +263,19 @@ export class StreamingHandlerService {
     if (sessionId && !targetTab.claudeSessionId) {
       this.tabManager.attachSession(targetTab.id, sessionId);
     }
-    if (!targetTab.streamingState) {
+    // An event that writes NOTHING into `StreamingState` must never create one.
+    // These six only touch the monitor / background-agent stores, and they all
+    // arrive after a turn ends as a matter of course (TASK_2026_360). Minting
+    // for them left a settled tab holding an empty tree that no finalize can
+    // clear — `finalizeCurrentMessage` early-returns on the null
+    // `currentMessageId` such a state carries — which every busy-predicate
+    // reader then saw as a live turn (TASK_2026_382 review B5). The accumulator
+    // still runs, on a scratch state it discards, so the stores are updated
+    // exactly as before.
+    const ephemeralState =
+      !targetTab.streamingState &&
+      StreamingHandlerService.STORE_ONLY_EVENT_TYPES.has(event.eventType);
+    if (!targetTab.streamingState && !ephemeralState) {
       this.tabManager.setStreamingState(
         targetTab.id,
         createEmptyStreamingState(),
@@ -257,7 +288,9 @@ export class StreamingHandlerService {
       }
     }
 
-    const state = targetTab.streamingState as StreamingState;
+    const state = ephemeralState
+      ? createEmptyStreamingState()
+      : (targetTab.streamingState as StreamingState);
 
     // Capture the SDK's real transcript UUID for the user's own turn — emitted
     // on the user `message_start` because `replay-user-messages` is enabled —
@@ -315,7 +348,7 @@ export class StreamingHandlerService {
         return { tabId: targetTab.id, queuedContent };
       }
     }
-    if (result.stateMutated) {
+    if (result.stateMutated && !ephemeralState) {
       // Content only. The spinner / `status` are NOT re-asserted from content
       // any more: a post-turn `agent_progress` used to re-light the stop
       // button with nothing left to clear it (TASK_2026_360, Defect 1). The

--- a/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.spec.ts
+++ b/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.spec.ts
@@ -81,13 +81,26 @@ describe('ChatInputComponent', () => {
     abortWithConfirmation: jest.fn().mockResolvedValue(true),
   };
 
-  const tabsSignal = signal<Array<{ id: string; status: string }>>([]);
+  const tabsSignal = signal<
+    Array<{
+      id: string;
+      status: string;
+      streamingState?: { currentMessageId: string | null } | null;
+    }>
+  >([]);
   const activeTabIdSignal = signal<string | null>(null);
   const mockTabManager = {
     isTabStreaming: jest.fn().mockReturnValue(false),
     tabs: tabsSignal,
     activeTabId: activeTabIdSignal,
     activeTabQueuedContent: signal<string | null>(null),
+    // Production resolves the Stop-button tab across workspaces, so a canvas
+    // tile or a background-workspace tab is found. The fake mirrors the shape
+    // (`{ tab, workspacePath }`), reading from the same tabs signal.
+    findTabByIdAcrossWorkspaces: jest.fn((id: string) => {
+      const tab = tabsSignal().find((t) => t.id === id);
+      return tab ? { tab, workspacePath: '/ws' } : null;
+    }),
   };
 
   const mockAutopilotState = {
@@ -740,6 +753,68 @@ describe('ChatInputComponent', () => {
       tabsSignal.set([]);
       activeTabIdSignal.set('missing');
       expect(component.inputEnabled()).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // STOP BUTTON — reads the same busy predicate the dispatcher queues on
+  // ============================================================================
+
+  describe('isActiveTabStreaming (Stop affordance, TASK_2026_382 review B5)', () => {
+    it('shows Stop while a live tree is unsettled even though the spinner set is clear', () => {
+      // Exactly the window `MessageDispatchService` queues in: `status` reads
+      // `loaded` and `_streamingTabIds` is empty, but the transcript is still
+      // rendering a bubble from `streamingState`. Gated on `isTabStreaming`
+      // alone the button was hidden here — so every send queued and the only
+      // drain outside a root turn-end (Stop) was unreachable.
+      mockTabManager.isTabStreaming.mockReturnValue(false);
+      tabsSignal.set([
+        {
+          id: 'tab-x',
+          status: 'loaded',
+          streamingState: { currentMessageId: 'msg-live' },
+        },
+      ]);
+      activeTabIdSignal.set('tab-x');
+
+      expect(component.isActiveTabStreaming()).toBe(true);
+    });
+
+    it('hides Stop once the tree is debris with no currentMessageId', () => {
+      // The bounded exit: the dispatcher sends in this state, so offering Stop
+      // would be an abort for a turn that is not running.
+      mockTabManager.isTabStreaming.mockReturnValue(false);
+      tabsSignal.set([
+        {
+          id: 'tab-x',
+          status: 'loaded',
+          streamingState: { currentMessageId: null },
+        },
+      ]);
+      activeTabIdSignal.set('tab-x');
+
+      expect(component.isActiveTabStreaming()).toBe(false);
+    });
+
+    it('still shows Stop on the spinner set alone', () => {
+      mockTabManager.isTabStreaming.mockReturnValue(true);
+      tabsSignal.set([{ id: 'tab-x', status: 'loaded', streamingState: null }]);
+      activeTabIdSignal.set('tab-x');
+
+      expect(component.isActiveTabStreaming()).toBe(true);
+    });
+
+    it('hides Stop for a settled tab', () => {
+      mockTabManager.isTabStreaming.mockReturnValue(false);
+      tabsSignal.set([{ id: 'tab-x', status: 'loaded', streamingState: null }]);
+      activeTabIdSignal.set('tab-x');
+
+      expect(component.isActiveTabStreaming()).toBe(false);
+    });
+
+    it('hides Stop when there is no active tab at all', () => {
+      activeTabIdSignal.set(null);
+      expect(component.isActiveTabStreaming()).toBe(false);
     });
   });
 });

--- a/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.ts
+++ b/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.ts
@@ -29,6 +29,7 @@ import {
   type EffortLevel,
 } from '@ptah-extension/shared';
 import { ChatStore } from '../../../services/chat.store';
+import { isTabBusyGenerating } from '../../../services/chat-store/message-dispatch.service';
 import { TabManagerService } from '@ptah-extension/chat-state';
 import { SESSION_CONTEXT } from '../../../tokens/session-context.token';
 import {
@@ -302,7 +303,8 @@ interface PastedImage {
         <!-- Button Stack: Stop (streaming only) + Send -->
         <div class="flex flex-col gap-1 pb-1">
           <!-- Stop Button (above send during streaming) -->
-          <!-- Use isActiveTabStreaming() which uses same signal as tab spinner -->
+          <!-- Gated on the same busy predicate the dispatcher queues on, so a
+               queued send always has a Stop to drain it -->
           @if (isActiveTabStreaming()) {
             <button
               class="btn btn-error btn-sm btn-square"
@@ -404,15 +406,29 @@ export class ChatInputComponent implements OnInit {
   readonly authMethodLabel = this.authState.authMethodLabel;
 
   /**
-   * Use the same streaming indicator as tab spinner.
-   * Previously, stop button used `chatStore.isStreaming()` which checks `tab.status`,
-   * while tab spinner used `tabManager.isTabStreaming()` which uses `_streamingTabIds`.
-   * These two signals could diverge, causing stop button to not appear even when
-   * tab shows streaming spinner. Now both use the visual streaming indicator.
+   * Stop-button visibility. Reads `isTabBusyGenerating` — the SAME predicate
+   * `MessageDispatchService` uses to decide send-vs-queue.
+   *
+   * This used to read `tabManager.isTabStreaming()` (the `_streamingTabIds`
+   * spinner set) alone, which is only one of that predicate's three sources.
+   * Whenever the other two said busy and the spinner set did not, every send
+   * was queued while Stop stayed hidden — and Stop is the only drain for a
+   * queue outside a root turn-end, so the tab was a dead end until reload
+   * (TASK_2026_382 review B5). Widening the busy predicate without widening the
+   * recovery affordance that reads the same state is what made that reachable;
+   * the two now cannot disagree by construction.
    */
   readonly isActiveTabStreaming = computed(() => {
     const tabId = this._sessionContext?.() ?? this.tabManager.activeTabId();
-    return tabId ? this.tabManager.isTabStreaming(tabId) : false;
+    if (!tabId) return false;
+    // Resolved across workspaces, like the dispatcher: a canvas tile or a tab
+    // parked in a background workspace is absent from `tabs()`.
+    const tab = this.tabManager.findTabByIdAcrossWorkspaces(tabId)?.tab ?? null;
+    return isTabBusyGenerating({
+      status: tab?.status,
+      streamingState: tab?.streamingState,
+      isStreamingTab: this.tabManager.isTabStreaming(tabId),
+    });
   });
 
   /**

--- a/libs/frontend/chat/src/lib/services/chat-store/message-dispatch.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/message-dispatch.service.spec.ts
@@ -14,16 +14,31 @@
  *   - sendQueuedMessage: on error, restores content to queue
  *   - sendQueuedMessage: calls continueExistingSessionForQueueFlush (not send / continueConversation)
  *   - sendQueuedMessage: warns and re-queues (no new conversation) when the tab has no claudeSessionId
+ *   - isTabBusyGenerating: the bounded exit — a tree with no currentMessageId
+ *     is debris nothing can finalize, so it is NOT busy
+ *   - Integration: the REAL StreamingHandler + MessageFinalization pair driven
+ *     through finalize → stray post-turn events → send, with no queueing
  */
 
 import { TestBed } from '@angular/core/testing';
-import { signal } from '@angular/core';
+import { computed, signal } from '@angular/core';
 import { AuthStateService } from '@ptah-extension/core';
-import { MessageDispatchService } from './message-dispatch.service';
+import { SessionId, type FlatStreamEventUnion } from '@ptah-extension/shared';
+import { createEmptyStreamingState } from '@ptah-extension/chat-types';
+import {
+  MessageDispatchService,
+  isTabBusyGenerating,
+} from './message-dispatch.service';
 import { TabManagerService } from '@ptah-extension/chat-state';
 import { MessageSenderService } from '../message-sender.service';
 import { ConversationService } from './conversation.service';
-import { PermissionHandlerService } from '@ptah-extension/chat-streaming';
+import {
+  AgentMonitorStore,
+  MessageFinalizationService,
+  PermissionHandlerService,
+  StreamingHandlerService,
+  TurnStateApplier,
+} from '@ptah-extension/chat-streaming';
 import type { TabState } from '@ptah-extension/chat-types';
 
 function makeTab(overrides: Partial<TabState> = {}): TabState {
@@ -342,6 +357,109 @@ describe('MessageDispatchService', () => {
         tabId: 'tab-bg',
       });
     });
+
+    it('SENDS when the tree left behind has no currentMessageId — that state is debris no finalize can clear (TASK_2026_382 review B5)', async () => {
+      // `StreamingHandlerService` mints an empty `StreamingState` for any event
+      // routed to a tab that has none, and only `message_start` ever sets
+      // `currentMessageId`. A late post-turn `agent_progress` /
+      // `agent_completed` / `message_complete` therefore leaves exactly this
+      // shape behind. `finalizeCurrentMessage` early-returns on a null
+      // `currentMessageId`, and nothing else nulls `streamingState`, so an
+      // unbounded `streamingState != null` check latched the tab into
+      // queue-only mode for good: status is `loaded` (input enabled), the tab
+      // is absent from `_streamingTabIds` (Stop hidden), and no drain can fire.
+      activeTabStatus.set('loaded');
+      isTabStreamingMock.mockReturnValue(false);
+      tabs = [
+        makeTab({
+          id: 'tab-1',
+          status: 'loaded',
+          streamingState: {
+            currentMessageId: null,
+          } as unknown as TabState['streamingState'],
+        }),
+      ];
+
+      await service.sendOrQueueMessage('after the stray event');
+
+      expect(queueOrAppendMock).not.toHaveBeenCalled();
+      expect(sendMock).toHaveBeenCalledWith('after the stray event', undefined);
+    });
+  });
+
+  describe('isTabBusyGenerating (the one predicate the Stop button shares)', () => {
+    const tree = {
+      currentMessageId: 'msg-live',
+    } as unknown as NonNullable<TabState['streamingState']>;
+    const debris = {
+      currentMessageId: null,
+    } as unknown as NonNullable<TabState['streamingState']>;
+
+    it('is busy while a tree with a currentMessageId is live under an idle status', () => {
+      expect(
+        isTabBusyGenerating({
+          status: 'loaded',
+          streamingState: tree,
+          isStreamingTab: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('is NOT busy for a tree with no currentMessageId — the bounded exit', () => {
+      expect(
+        isTabBusyGenerating({
+          status: 'loaded',
+          streamingState: debris,
+          isStreamingTab: false,
+        }),
+      ).toBe(false);
+    });
+
+    it.each(['awaiting-background', 'sleeping'] as const)(
+      'is NOT busy in %s even with a live tree — queuing there strands the message',
+      (status) => {
+        expect(
+          isTabBusyGenerating({
+            status,
+            streamingState: tree,
+            isStreamingTab: false,
+          }),
+        ).toBe(false);
+      },
+    );
+
+    it.each(['streaming', 'resuming'] as const)(
+      'is busy in %s with no tree at all',
+      (status) => {
+        expect(
+          isTabBusyGenerating({
+            status,
+            streamingState: null,
+            isStreamingTab: false,
+          }),
+        ).toBe(true);
+      },
+    );
+
+    it('is busy on the spinner set alone (the SDK pause/resume self-heal)', () => {
+      expect(
+        isTabBusyGenerating({
+          status: 'loaded',
+          streamingState: null,
+          isStreamingTab: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('is NOT busy for a settled tab', () => {
+      expect(
+        isTabBusyGenerating({
+          status: 'loaded',
+          streamingState: null,
+          isStreamingTab: false,
+        }),
+      ).toBe(false);
+    });
   });
 
   describe('sendQueuedMessage', () => {
@@ -414,5 +532,255 @@ describe('MessageDispatchService', () => {
       );
       errorSpy.mockRestore();
     });
+  });
+});
+
+/**
+ * End-to-end over the REAL streaming pair — no mock stands between the events
+ * and the predicate. `StreamingHandlerService` and `MessageFinalizationService`
+ * are the production classes (with their real accumulator, deduplication,
+ * batched-update and tree-builder collaborators); only the tab store, the
+ * sender and the conversation queue are test doubles, and the tab store
+ * reproduces the two-write `applyFinalizedTurn` that production performs.
+ *
+ * This is the loop the review found: finish a turn, let the routine late
+ * post-turn events land, then send again. Before the fix the send was queued
+ * with no drain and no Stop button — recoverable only by reload or /clear.
+ */
+describe('MessageDispatchService with the real StreamingHandler + MessageFinalization pair (TASK_2026_382 review B5)', () => {
+  const TAB_ID = 'tab-1';
+  const SESSION_ID = SessionId.create();
+  const MESSAGE_ID = 'msg-1';
+
+  let tabsSignal: ReturnType<typeof signal<TabState[]>>;
+  let activeTabIdSignal: ReturnType<typeof signal<string | null>>;
+  let visibleTabIdsSignal: ReturnType<typeof signal<Set<string>>>;
+  let streamingTabIdsSignal: ReturnType<typeof signal<Set<string>>>;
+  let dispatch: MessageDispatchService;
+  let streaming: StreamingHandlerService;
+  let finalization: MessageFinalizationService;
+  let sendMock: jest.Mock;
+  let queueOrAppendMock: jest.Mock;
+
+  function patchTab(id: string, changes: Partial<TabState>): void {
+    tabsSignal.update((all) =>
+      all.map((t) => (t.id === id ? ({ ...t, ...changes } as TabState) : t)),
+    );
+  }
+
+  function currentTab(): TabState {
+    const tab = tabsSignal().find((t) => t.id === TAB_ID);
+    if (!tab) throw new Error('tab vanished');
+    return tab;
+  }
+
+  /** Let `applyFinalizedTurn`'s second write (a microtask) land. */
+  const settle = (): Promise<void> =>
+    new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  beforeEach(() => {
+    tabsSignal = signal<TabState[]>([
+      {
+        id: TAB_ID,
+        title: 'Session',
+        name: 'Session',
+        status: 'streaming',
+        messages: [],
+        streamingState: createEmptyStreamingState(),
+        currentMessageId: null,
+        claudeSessionId: SESSION_ID,
+        queuedContent: null,
+        queuedOptions: null,
+      } as unknown as TabState,
+    ]);
+    activeTabIdSignal = signal<string | null>(TAB_ID);
+    visibleTabIdsSignal = signal<Set<string>>(new Set());
+    streamingTabIdsSignal = signal<Set<string>>(new Set());
+
+    const tabManagerFake = {
+      tabs: computed(() => tabsSignal()),
+      activeTabId: computed(() => activeTabIdSignal()),
+      activeTab: computed(
+        () => tabsSignal().find((t) => t.id === activeTabIdSignal()) ?? null,
+      ),
+      activeTabStatus: computed(
+        () =>
+          tabsSignal().find((t) => t.id === activeTabIdSignal())?.status ??
+          null,
+      ),
+      visibleTabIds: computed(() => visibleTabIdsSignal()),
+      isTabStreaming: (id: string) => streamingTabIdsSignal().has(id),
+      findTabByIdAcrossWorkspaces: (id: string) => {
+        const tab = tabsSignal().find((t) => t.id === id);
+        return tab ? { tab, workspacePath: '/ws' } : null;
+      },
+      findTabsBySessionId: (sid: string) =>
+        tabsSignal().filter((t) => t.claudeSessionId === sid),
+      findTabBySessionIdAcrossWorkspaces: () => null,
+      updateBackgroundTab: () => false,
+      attachSession: (id: string, sid: string) =>
+        patchTab(id, { claudeSessionId: sid } as Partial<TabState>),
+      setStreamingState: (id: string, state: TabState['streamingState']) =>
+        patchTab(id, { streamingState: state }),
+      setMessages: (id: string, messages: TabState['messages']) =>
+        patchTab(id, { messages }),
+      reconcileUserMessageNativeUuid: jest.fn(),
+      setQueuedContent: jest.fn(),
+      clearQueuedContentAndOptions: jest.fn(),
+      markTabIdle: jest.fn(),
+      markTabStreaming: jest.fn(),
+      markStreaming: jest.fn(),
+      applyFinalizedHistory: jest.fn(),
+      // Mirrors production: messages first, then a microtask that drops the
+      // streaming state and flips to `loaded`.
+      applyFinalizedTurn: (id: string, messages: TabState['messages']) => {
+        patchTab(id, { messages, currentMessageId: null });
+        queueMicrotask(() =>
+          patchTab(id, { streamingState: null, status: 'loaded' }),
+        );
+      },
+      clearStreamingForLoaded: (id: string) =>
+        patchTab(id, {
+          streamingState: null,
+          status: 'loaded',
+          currentMessageId: null,
+        }),
+    } as unknown as TabManagerService;
+
+    sendMock = jest.fn().mockResolvedValue(undefined);
+    queueOrAppendMock = jest.fn();
+
+    TestBed.configureTestingModule({
+      providers: [
+        MessageDispatchService,
+        { provide: TabManagerService, useValue: tabManagerFake },
+        // `turn_state` is never fed here; the applier would drag in the
+        // liveness registry for no coverage.
+        { provide: TurnStateApplier, useValue: { apply: jest.fn() } },
+        // The real store reaches for VSCodeService + the RPC client.
+        {
+          provide: AgentMonitorStore,
+          useValue: {
+            onAgentStart: jest.fn(),
+            onAgentProgress: jest.fn(),
+            onAgentStatus: jest.fn(),
+            onAgentCompleted: jest.fn(),
+            markAgentNodesResumed: jest.fn(),
+          },
+        },
+        {
+          provide: MessageSenderService,
+          useValue: { send: sendMock, continueExistingSessionForQueueFlush: jest.fn() },
+        },
+        {
+          provide: ConversationService,
+          useValue: { queueOrAppendMessage: queueOrAppendMock },
+        },
+        {
+          provide: AuthStateService,
+          useValue: {
+            persistedAuthMethod: () => 'apiKey',
+            isLoading: () => false,
+          },
+        },
+        {
+          provide: PermissionHandlerService,
+          useValue: {
+            permissionRequests: () => [],
+            handlePermissionResponse: jest.fn(),
+          },
+        },
+      ],
+    });
+
+    dispatch = TestBed.inject(MessageDispatchService);
+    streaming = TestBed.inject(StreamingHandlerService);
+    finalization = TestBed.inject(MessageFinalizationService);
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  function feed(event: FlatStreamEventUnion): void {
+    streaming.processStreamEvent(event, TAB_ID, SESSION_ID);
+  }
+
+  it('accepts the next send after a finished turn is followed by the routine late post-turn events', async () => {
+    // ----- A complete turn -------------------------------------------------
+    feed({
+      id: 'evt-start',
+      eventType: 'message_start',
+      timestamp: 1,
+      sessionId: SESSION_ID,
+      messageId: MESSAGE_ID,
+      role: 'assistant',
+      source: 'stream',
+    } as unknown as FlatStreamEventUnion);
+    feed({
+      id: 'evt-delta',
+      eventType: 'text_delta',
+      timestamp: 2,
+      sessionId: SESSION_ID,
+      messageId: MESSAGE_ID,
+      blockIndex: 0,
+      delta: 'done',
+      source: 'stream',
+    } as unknown as FlatStreamEventUnion);
+    feed({
+      id: 'evt-complete',
+      eventType: 'message_complete',
+      timestamp: 3,
+      sessionId: SESSION_ID,
+      messageId: MESSAGE_ID,
+      stopReason: 'end_turn',
+      tokenUsage: { input: 10, output: 20 },
+      source: 'stream',
+    } as unknown as FlatStreamEventUnion);
+
+    finalization.finalizeCurrentMessage(TAB_ID);
+    await settle();
+
+    expect(currentTab().streamingState).toBeNull();
+    expect(currentTab().status).toBe('loaded');
+
+    // ----- The late post-turn events TASK_2026_360 documents as routine ----
+    feed({
+      id: 'evt-progress',
+      eventType: 'agent_progress',
+      timestamp: 4,
+      sessionId: SESSION_ID,
+      parentToolUseId: 'toolu_1',
+      taskId: 'task-1',
+      description: 'still tidying up',
+      totalTokens: 12,
+      toolUses: 1,
+      durationMs: 400,
+      source: 'hook',
+    } as unknown as FlatStreamEventUnion);
+
+    // A store-only event must not RESURRECT a streaming state on a settled tab.
+    expect(currentTab().streamingState).toBeNull();
+
+    feed({
+      id: 'evt-late-complete',
+      eventType: 'message_complete',
+      timestamp: 5,
+      sessionId: SESSION_ID,
+      messageId: 'msg-late',
+      stopReason: 'end_turn',
+      source: 'stream',
+    } as unknown as FlatStreamEventUnion);
+
+    // This one legitimately writes into a state, so a state now exists — but it
+    // carries no `currentMessageId`, so no finalize can ever clear it. The
+    // predicate must read it as debris, not as a turn in flight.
+    expect(currentTab().streamingState?.currentMessageId ?? null).toBeNull();
+
+    // ----- The user sends again -------------------------------------------
+    await dispatch.sendOrQueueMessage('and now this');
+
+    expect(queueOrAppendMock).not.toHaveBeenCalled();
+    expect(sendMock).toHaveBeenCalledWith('and now this', undefined);
   });
 });

--- a/libs/frontend/chat/src/lib/services/chat-store/message-dispatch.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/message-dispatch.service.ts
@@ -3,9 +3,93 @@ import { AuthStateService } from '@ptah-extension/core';
 import { createExecutionChatMessage } from '@ptah-extension/shared';
 import { TabManagerService } from '@ptah-extension/chat-state';
 import { MessageSenderService } from '../message-sender.service';
-import type { SendMessageOptions } from '@ptah-extension/chat-types';
+import type {
+  SendMessageOptions,
+  SessionStatus,
+  StreamingState,
+} from '@ptah-extension/chat-types';
 import { ConversationService } from './conversation.service';
 import { PermissionHandlerService } from '@ptah-extension/chat-streaming';
+
+/**
+ * The ONE definition of "this tab is still generating".
+ *
+ * Two readers, and they must never disagree: `MessageDispatchService`, which
+ * decides send-vs-queue, and the chat input's Stop button, which is the only
+ * way out of the queue-only state this returns `true` for. Gate the affordance
+ * on a different signal than the gate that creates the state and you get a tab
+ * that can neither send nor stop (TASK_2026_382 review B5).
+ *
+ * Three sources, OR'd:
+ *
+ * 1. `status` — the root-turn phase written by the backend `turn_state` stream.
+ * 2. `isStreamingTab` — the `_streamingTabIds` spinner set, which the SDK's
+ *    pause/resume self-heal can leave set while `status` reverted to `loaded`.
+ *    Routing a follow-up to `send()` there spins up a fresh AbortController and
+ *    KILLS the in-flight stream.
+ * 3. An UNSETTLED TREE — the condition the user can actually see, because the
+ *    live bubble in the transcript is rendered from `streamingState`, not from
+ *    the phase the other two read. A writer that clears the turn flags without
+ *    settling the tree opens a window where the transcript shows a streaming
+ *    bubble while the predicate says idle.
+ *
+ * ## The tree condition has a BOUNDED EXIT, and that is load-bearing
+ *
+ * `streamingState != null` alone is a latch, not a predicate.
+ * `StreamingHandlerService` mints an empty `StreamingState` for events routed
+ * to a tab that has none, only `message_start` ever sets `currentMessageId`,
+ * and `MessageFinalizationService.finalizeCurrentMessage` early-returns on a
+ * null `currentMessageId`. So one stray post-turn event — the late
+ * `agent_progress` / `agent_completed` / `message_complete` that TASK_2026_360
+ * documents as routine — used to pin a `loaded` tab into queue-only mode with
+ * NO drain able to fire and no recovery short of a reload.
+ *
+ * A tree with no `currentMessageId` is a tree nothing can finalize, so it is
+ * not a turn in flight — it is debris. Treat it as idle. A real streaming
+ * window always has one: `message_start` sets it and it survives until
+ * `applyFinalizedTurn` / `clearStreamingForLoaded` clears the turn.
+ *
+ * ## The `awaiting-background` / `sleeping` exclusion is also load-bearing
+ *
+ * `chat-types.ts` defines both as "agent itself is idle, USER INPUT REMAINS
+ * ENABLED", with background tasks or session crons still running. A subagent's
+ * next `message_start` builds a fresh `streamingState` there, so the field is
+ * non-null while sending is correct by design — and queuing would strand the
+ * message, because neither drain fires: the root-turn flush
+ * (`streaming-handler.service.ts`) needs a `message_complete` with no
+ * `parentToolUseId` (the root turn already ended, and subagent completions all
+ * carry one), and `handleSessionStats` returns `null` whenever `streamingState`
+ * is present. Do not widen this back to an unconditional check.
+ *
+ * The rest of the `SessionStatus` union needs no exclusion: `streaming` /
+ * `resuming` are already caught by source 1; `fresh` / `draft` / `loaded` claim
+ * no live tree, so a tree present under them IS the accidental window this
+ * exists for; `switching` is a momentary UI transition during which a live tree
+ * still ends with a root `message_complete`, so the queue drains.
+ *
+ * This is NOT the deleted TASK_2026_360 self-heal. That heuristic lived in the
+ * streaming WRITE path and re-derived "the agent is busy" from event content,
+ * re-lighting the spinner with nothing left to clear it. This reads tab state
+ * that already exists and writes nothing.
+ */
+export function isTabBusyGenerating(input: {
+  status: SessionStatus | null | undefined;
+  streamingState: StreamingState | null | undefined;
+  isStreamingTab: boolean;
+}): boolean {
+  const { status, streamingState, isStreamingTab } = input;
+  const hasUnsettledTree =
+    streamingState != null &&
+    streamingState.currentMessageId != null &&
+    status !== 'awaiting-background' &&
+    status !== 'sleeping';
+  return (
+    status === 'streaming' ||
+    status === 'resuming' ||
+    hasUnsettledTree ||
+    isStreamingTab
+  );
+}
 
 /**
  * MessageDispatchService - Send-or-queue routing + slash-command guard.
@@ -72,68 +156,14 @@ export class MessageDispatchService {
     const status = targetTab?.status ?? this.tabManager.activeTabStatus();
     /** The tab the bubble will actually land on — see `isStreaming` below. */
     const dispatchTab = targetTab ?? this.tabManager.activeTab();
-    // Treat a tab as busy when it is actively generating — including the
-    // self-heal case where the SDK paused/resumed and `status` reverted to
-    // `loaded`/`awaiting-background` while `_streamingTabIds` (isTabStreaming)
-    // stays set. Routing a follow-up to `send()` in that window would spin up a
-    // fresh AbortController and KILL the in-flight stream. Queue instead — the
-    // queue drains on the real turn-end (when the controller is already
-    // cleared, so no abort).
-    //
-    // `streamingState != null` is the THIRD condition and the one the user can
-    // see: the live bubble in the transcript is rendered from `streamingState`
-    // (`chat-transcript.component.ts` `_streamingState` / `streamingMessages`),
-    // not from the root-turn phase these other two read. A writer that clears
-    // the turn flags without settling the tree opens a window where the
-    // transcript shows a streaming bubble while the predicate says idle, so the
-    // follow-up takes `send()`, appends its bubble ABOVE the live one and fires
-    // `chat:continue` mid-turn (TASK_2026_382).
-    //
-    // It is QUALIFIED on `awaiting-background` / `sleeping`, and that exclusion
-    // is load-bearing — do not widen this back to an unconditional check.
-    // Those two are not accidental windows: `chat-types.ts:443-448` defines
-    // both as "agent itself is idle, USER INPUT REMAINS ENABLED", with
-    // background tasks or session crons still running. A subagent's next
-    // `message_start` builds a fresh `streamingState` there, so the field is
-    // non-null while sending is correct by design.
-    //
-    // Queuing in that state STRANDS the message, because neither drain fires:
-    //   - `streaming-handler.service.ts:305-317` needs a `message_complete`
-    //     with NO `parentToolUseId` and `stopReason !== 'tool_use'` — a ROOT
-    //     turn end. The root turn already ended; subagent completions all carry
-    //     `parentToolUseId`.
-    //   - `handleSessionStats` (`streaming-handler.service.ts:475-493`) returns
-    //     `null` whenever `streamingState` is present — it stashes
-    //     `pendingStats` and defers to finalization.
-    // The only other drain is the user-abort path
-    // (`conversation.service.ts:213-218`). So the message would sit in
-    // `queuedContent` indefinitely: "renders in the wrong place" traded for
-    // "never sends", which is strictly worse. D1's time-ordered transcript is
-    // what puts the bubble in the right place in this window; this predicate
-    // covers genuine streaming windows only.
-    //
-    // The rest of the `SessionStatus` union needs no exclusion: `streaming` /
-    // `resuming` are already caught above; `fresh` / `draft` / `loaded` claim
-    // no live tree, so a tree present under them IS the accidental window this
-    // exists for; `switching` is a momentary UI transition during which a live
-    // tree still ends with a root `message_complete`, so the queue drains.
-    //
-    // This is NOT the deleted TASK_2026_360 self-heal. That heuristic lived in
-    // the streaming WRITE path and re-derived "the agent is busy" from event
-    // content, re-lighting the spinner with nothing left to clear it. This is
-    // the DISPATCH path reading tab state that already exists, it writes
-    // nothing, and its only effect is to queue instead of send. The backend
-    // `turn_state` stream remains the sole authority over `status` and the
-    // spinner set.
-    const hasUnsettledTree =
-      dispatchTab?.streamingState != null &&
-      status !== 'awaiting-background' &&
-      status !== 'sleeping';
-    const isStreaming =
-      status === 'streaming' ||
-      status === 'resuming' ||
-      hasUnsettledTree ||
-      (resolvedTabId != null && this.tabManager.isTabStreaming(resolvedTabId));
+    // One predicate, shared with the Stop button — see `isTabBusyGenerating`
+    // for why each source is here and why the tree condition is bounded.
+    const isStreaming = isTabBusyGenerating({
+      status,
+      streamingState: dispatchTab?.streamingState,
+      isStreamingTab:
+        resolvedTabId != null && this.tabManager.isTabStreaming(resolvedTabId),
+    });
 
     if (isStreaming) {
       const activePermissions = this.permissionHandler.permissionRequests();

--- a/libs/frontend/chat/src/lib/services/message-sender.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/message-sender.service.spec.ts
@@ -7,7 +7,9 @@
  *     there is no session, to continueConversation when one exists
  *   - startNewConversation (happy path): auto-name, chat:start RPC payload
  *     including effective model/effort, user message appended
- *   - startNewConversation (RPC failure): marks loaded + failSession()
+ *   - startNewConversation (RPC failure): marks loaded + failSession(), and
+ *     removes the tab from the streaming set on BOTH pre-stream failure exits
+ *     (structural rejection and throw) — TASK_2026_360 B1
  *   - startNewConversation (no workspace): still calls chat:start with
  *     workspacePath omitted so the backend can fall back to
  *     IWorkspaceProvider.getWorkspaceRoot() — fixes the bootstrap-restore
@@ -63,6 +65,7 @@ describe('MessageSenderService', () => {
     switchTab: jest.Mock;
     markTabStreaming: jest.Mock;
     markTabIdle: jest.Mock;
+    isTabStreaming: jest.Mock;
     // AbortController plumbing for tab-close → stream-cancel.
     createAbortController: jest.Mock;
     getAbortSignal: jest.Mock;
@@ -78,6 +81,14 @@ describe('MessageSenderService', () => {
   };
   /** Tabs parked in a NON-active workspace — absent from `tabs()` by design. */
   let backgroundTabsSignal: ReturnType<typeof signal<TabState[]>>;
+  /**
+   * Models `TabManagerService._streamingTabIds` (tab-manager.service.ts:157) —
+   * the spinner/send-vs-queue set. It is a SEPARATE store from `TabState.status`:
+   * `markLoaded` writes status alone (`:1104`) and only `markTabIdle` (`:2344`)
+   * or `applyTurnState` (`:1197`) removes a tab from it. Modelling it here lets
+   * the failure specs assert the set itself rather than a call count.
+   */
+  let streamingTabIds: Set<string>;
   let sessionManager: jest.Mocked<
     Pick<
       SessionManager,
@@ -97,6 +108,7 @@ describe('MessageSenderService', () => {
     tabsSignal = signal<TabState[]>([makeTab({ id: 'tab-1' })]);
     activeTabIdSignal = signal<string | null>('tab-1');
     backgroundTabsSignal = signal<TabState[]>([]);
+    streamingTabIds = new Set<string>();
 
     const applyPatch = (tabId: string, patch: Partial<TabState>): void => {
       if (backgroundTabsSignal().some((t) => t.id === tabId)) {
@@ -122,8 +134,13 @@ describe('MessageSenderService', () => {
       ),
       createTab: jest.fn(() => 'tab-new'),
       switchTab: jest.fn(),
-      markTabStreaming: jest.fn(),
-      markTabIdle: jest.fn(),
+      markTabStreaming: jest.fn((tabId: string) => {
+        streamingTabIds.add(tabId);
+      }),
+      markTabIdle: jest.fn((tabId: string) => {
+        streamingTabIds.delete(tabId);
+      }),
+      isTabStreaming: jest.fn((tabId: string) => streamingTabIds.has(tabId)),
       consumeFirstMessagePreamble: jest.fn(() => null),
       // Stub returns a real AbortSignal so the wireAbortDispatch listener
       // can attach without throwing.
@@ -430,6 +447,55 @@ describe('MessageSenderService', () => {
       await service.send('hello');
       expect(sessionManager.failSession).toHaveBeenCalled();
       expect(tabManager.markLoaded).toHaveBeenCalledWith('tab-1');
+    });
+
+    /**
+     * TASK_2026_360 B1 — the optimistic `markTabStreaming` at
+     * message-sender.service.ts:377 fires BEFORE `chat:start`. A pre-stream
+     * failure creates no broadcaster, so no backend `turn_state` and no
+     * CHAT_ERROR can ever repair the spinner set; Stop cannot heal it either
+     * (the tab never bound a `claudeSessionId`). The send path must therefore
+     * pair its own optimistic write with `markTabIdle` on BOTH failure exits,
+     * exactly as `continueConversation` already does (`:653`, `:669`).
+     *
+     * These assert the SET, not the call: `markLoaded` alone leaves the tab in
+     * `_streamingTabIds`, which lights Stop and silently queues every later
+     * message (`tab-manager.service.ts:150-156`, TASK_2026_382).
+     */
+    it('leaves no tab in the streaming set after a structural chat:start rejection', async () => {
+      rpcCall.mockResolvedValue({
+        success: true,
+        data: { success: false, error: 'AUTH_REQUIRED' },
+      });
+
+      await service.send('hello');
+
+      expect(tabManager.markTabStreaming).toHaveBeenCalledWith('tab-1');
+      expect(tabManager.markTabIdle).toHaveBeenCalledWith('tab-1');
+      expect(tabManager.isTabStreaming('tab-1')).toBe(false);
+    });
+
+    it('leaves no tab in the streaming set after a transport-level chat:start failure', async () => {
+      rpcCall.mockResolvedValue({ success: false, error: 'nope' });
+
+      await service.send('hello');
+
+      expect(tabManager.markTabIdle).toHaveBeenCalledWith('tab-1');
+      expect(tabManager.isTabStreaming('tab-1')).toBe(false);
+    });
+
+    it('leaves no tab in the streaming set when chat:start throws', async () => {
+      // AuthRequiredError raised inside sdkAdapter.startChatSession, before
+      // streamEventsToWebview — no broadcaster exists to emit a terminal
+      // turn_state. startNewConversation rethrows, so `send` rejects.
+      const authError = new Error('AUTH_REQUIRED');
+      rpcCall.mockRejectedValue(authError);
+
+      await expect(service.send('hello')).rejects.toThrow('AUTH_REQUIRED');
+
+      expect(tabManager.markTabStreaming).toHaveBeenCalledWith('tab-1');
+      expect(tabManager.markTabIdle).toHaveBeenCalledWith('tab-1');
+      expect(tabManager.isTabStreaming('tab-1')).toBe(false);
     });
 
     it('returns { success: true } on a started conversation (F-D2 contract)', async () => {

--- a/libs/frontend/chat/src/lib/services/message-sender.service.ts
+++ b/libs/frontend/chat/src/lib/services/message-sender.service.ts
@@ -429,6 +429,13 @@ export class MessageSenderService {
           result.data?.error ?? result.error,
         );
         this.tabManager.markLoaded(activeTabId);
+        // `markLoaded` writes `status` alone; the spinner/send-vs-queue set is a
+        // separate store that only `markTabIdle` or a backend `turn_state`
+        // clears. This turn never created a broadcaster, so no `turn_state` and
+        // no CHAT_ERROR will ever arrive to repair it — the optimistic
+        // `markTabStreaming` above must undo itself here, as
+        // `continueConversation` already does (TASK_2026_360).
+        this.tabManager.markTabIdle(activeTabId);
         this.sessionManager.setStatus('loaded');
         this.sessionManager.failSession();
         // Structural failure: transport succeeded but the backend rejected the
@@ -445,6 +452,11 @@ export class MessageSenderService {
 
       if (activeTabId) {
         this.tabManager.markLoaded(activeTabId);
+        // Same reason as the structural exit above: a throw before the stream
+        // starts (e.g. AuthRequiredError out of startChatSession) leaves nothing
+        // downstream able to clear the optimistic streaming flag
+        // (TASK_2026_360).
+        this.tabManager.markTabIdle(activeTabId);
       }
       this.sessionManager.setStatus('loaded');
       this.sessionManager.failSession();

--- a/libs/frontend/setup-wizard/src/lib/components/completion.component.spec.ts
+++ b/libs/frontend/setup-wizard/src/lib/components/completion.component.spec.ts
@@ -401,6 +401,30 @@ describe('CompletionComponent', () => {
       expect(tiles.length).toBe(1);
       expect(tiles[0].getAttribute('data-status')).toBe('written');
     });
+
+    it('shows the rejected-section count when validation rejected sections', () => {
+      completionData.set(
+        completion({ rejectedSections: 11, tailoredSections: 4 }),
+      );
+      fixture.detectChanges();
+
+      const badge = fixture.nativeElement.querySelector(
+        '[data-testid="rejected-sections-count"]',
+      );
+      expect(badge).toBeTruthy();
+      expect(badge.textContent).toContain('11 sections rejected');
+    });
+
+    it('renders no rejected-sections badge when nothing was rejected', () => {
+      completionData.set(completion({ rejectedSections: 0 }));
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="rejected-sections-count"]',
+        ),
+      ).toBeFalsy();
+    });
   });
 
   describe('Accessibility', () => {

--- a/libs/frontend/setup-wizard/src/lib/components/completion.component.ts
+++ b/libs/frontend/setup-wizard/src/lib/components/completion.component.ts
@@ -133,6 +133,14 @@ interface AgentOutcomeTile {
                   {{ data.failedCount }} failed
                 </span>
               }
+              @if (data.rejectedSections > 0) {
+                <span
+                  class="badge badge-warning badge-sm"
+                  data-testid="rejected-sections-count"
+                >
+                  {{ data.rejectedSections }} sections rejected
+                </span>
+              }
             </div>
             <div
               class="flex items-center gap-2 mb-4 text-xs text-base-content-muted"


### PR DESCRIPTION
## Summary

Fixes the eight blockers the Codex review gate confirmed against the five `in_review` BUGFIX tasks, and moves the five tasks that passed that gate to `done`.

- **TASK_2026_360** — both failure exits of `startNewConversation` skipped `markTabIdle`, so a pre-stream `chat:start` failure left a lit Stop button and queued every later message. Both exits now idle the tab.
- **TASK_2026_361** — a stale phase file satisfied the resume check; the completion screen never rendered `rejectedSections`. The resume check now snapshots the phase file before the run, and the badge is rendered.
- **TASK_2026_364** — the internal session remap read the workspace-scoped `getStatus()`, and the one-shot MCP URL was unscoped, so `ptah_agent_*` hard-failed in a two-folder window. An unscoped `listTrackedAgents` accessor and a `/workspace/{cwd}` scoped URL fix both halves.
- **TASK_2026_382** — `hasUnsettledTree` had no bounded exit, so one stray post-turn event latched the tab into queue-only mode with no Stop button. The predicate is now bounded on `currentMessageId`, store-only event types are guarded, and the Stop predicate in `chat-input` is aligned with it.
- **TASK_2026_376** — no code change. Its runtime gate now has an artefact (`runtime-gate.md`) recording what was proven and what still needs one human-driven Electron session.

Moved to `done`: TASK_2026_366, 367, 368, 371, 390 (gate passed), plus 360, 361, 364 and 382 (blockers closed).

**TASK_2026_376 stays at `in_review` on purpose.** Its gate asks for a live session with a background subagent and a mid-session compact. The engineering evidence is complete; the product evidence is absent.

`TASK_2026_391` is filed as the curator prose-reply follow-up, so gate blocker 1 no longer holds 376 hostage.

## Test plan

- [x] `nx run-many -t typecheck` — 7 projects pass.
- [x] `nx run-many -t lint` — 7 projects pass.
- [x] `nx run-many -t test` — 6 libs, 4842 tests pass.
- [x] `nx run ptah-electron-e2e:e2e` — 2 new specs pass: failed start leaves the tab idle (360), late post-turn event (382).

🤖 Generated with [Claude Code](https://claude.com/claude-code)










<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61679985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/ptah-orchestra/-/pull-requests/hive-academy/ptah-extension/468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because resumed phases can still lose valid output when stale-file deletion is unavailable and an identical rewrite retains the same timestamp.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Identical rewrites remain undetected** <a href="https://github.com/Hive-Academy/ptah-extension/pull/468#discussion_r3961697323">▶</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
libs/backend/agent-generation/src/lib/services/wizard/multi-phase-analysis.service.ts:434-438
When stale-file deletion fails and a resumed phase rewrites the file byte-for-byte without advancing its modification time, `fileWrittenThisRun` remains false, causing valid phase output to be overwritten with captured assistant text such as “Done.” or the phase to be falsely marked failed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Adds tab-idle cleanup and bounded unsettled-tree handling for chat failures and late events.
- Adds phase-file freshness tracking and rejected-section rendering to the setup wizard.
- Adds unscoped agent listing and workspace-scoped MCP routing for multi-root environments.
- Caps nested Jest workers in CI and records task-review evidence.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Resume phase] --> B[Snapshot prior file]
  B --> C{Delete stale file succeeds?}
  C -->|Yes| D[Run phase with clean path]
  C -->|No| E[Run phase with prior file retained]
  D --> F[Existing output proves current write]
  E --> G{Content changed or mtime advanced?}
  G -->|Yes| F
  G -->|No| H[Fallback replaces output or fails phase]
```
</details>

<!-- /greptile_comment -->