### PR TITLE
fix(git-ui): folder tree, closable diff tabs and a working split toggle

### DIFF
--- a/apps/ptah-electron-e2e/src/specs/git/git-dock.spec.ts
+++ b/apps/ptah-electron-e2e/src/specs/git/git-dock.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../../support/fixtures';
+import { gitDiffFileMock } from '../../support/git-diff-mock';
 
 /**
  * Git dock (TASK_2026_385 Batch 3.3).
@@ -116,6 +117,133 @@ test.describe('Git dock', () => {
     );
 
     // File count updates — the dock lists one row per changed file.
+    const changedFiles = page.getByRole('list', {
+      name: 'Changed files',
+      exact: true,
+    });
+    const changedSrc = changedFiles.getByRole('button', {
+      name: 'Toggle src folder',
+      exact: true,
+    });
+    await expect(changedSrc).toHaveAttribute('aria-expanded', 'false');
+    await changedSrc.click();
+    await expect(changedSrc).toHaveAttribute('aria-expanded', 'true');
+    await expect(
+      changedFiles.getByRole('button', { name: 'Open diff for a.ts' }),
+    ).toBeVisible();
+    await expect(
+      changedFiles.getByRole('button', { name: 'Open diff for c.ts' }),
+    ).toBeVisible();
+    expect(await ui.getObservedCalls('git:diffFile')).toEqual([]);
+    await expect(page.locator('ptah-diff-view')).toHaveCount(0);
+    await expect(page.locator('[data-testid="diff-error-overlay"]')).toHaveCount(
+      0,
+    );
+
+    await changedSrc.click();
+    await expect(changedSrc).toHaveAttribute('aria-expanded', 'false');
+    await expect(
+      changedFiles.getByRole('button', { name: 'Open diff for a.ts' }),
+    ).toHaveCount(0);
+
+    await changedSrc.click();
+    const stagedSrc = page
+      .getByRole('list', { name: 'Staged files', exact: true })
+      .getByRole('button', { name: 'Toggle src folder', exact: true });
+    await stagedSrc.click();
     await expect(page.locator('ptah-source-control-file')).toHaveCount(3);
+  });
+
+  test('opens, switches, and closes independent diff tabs', async ({ ui }) => {
+    await ui.goto('git');
+    const page = ui.page;
+
+    await ui.pushEvent({
+      type: 'git:status-update',
+      payload: {
+        branch: {
+          branch: 'main',
+          upstream: 'origin/main',
+          ahead: 0,
+          behind: 0,
+        },
+        files: [
+          { path: 'alpha.ts', status: 'M', staged: false, isDirectory: false },
+          { path: 'beta.ts', status: 'M', staged: false, isDirectory: false },
+        ],
+        isGitRepo: true,
+      },
+    });
+
+    const changedFiles = page.getByRole('list', {
+      name: 'Changed files',
+      exact: true,
+    });
+
+    await ui.mockRpc({
+      'git:diffFile': gitDiffFileMock({
+        path: 'alpha.ts',
+        comparison: 'worktree',
+        original: "export const value = 'alpha original';\n",
+        modified: "export const value = 'alpha modified';\n",
+        snapshotToken: 'alpha-snapshot',
+      }),
+    });
+    await changedFiles
+      .getByRole('button', { name: 'Open diff for alpha.ts', exact: true })
+      .click();
+
+    const alphaTab = page.getByRole('tab', {
+      name: 'alpha.ts (working tree)',
+      exact: true,
+    });
+    await expect(alphaTab).toBeVisible();
+    await expect(page.locator('ptah-diff-view .view-lines').last()).toContainText(
+      'alpha modified',
+    );
+
+    await ui.mockRpc({
+      'git:diffFile': gitDiffFileMock({
+        path: 'beta.ts',
+        comparison: 'worktree',
+        original: "export const value = 'beta original';\n",
+        modified: "export const value = 'beta modified';\n",
+        snapshotToken: 'beta-snapshot',
+      }),
+    });
+    await changedFiles
+      .getByRole('button', { name: 'Open diff for beta.ts', exact: true })
+      .click();
+
+    const betaTab = page.getByRole('tab', {
+      name: 'beta.ts (working tree)',
+      exact: true,
+    });
+    const diffTablist = page.getByRole('tablist', { name: 'Open diffs' });
+    await expect(diffTablist).toBeVisible();
+    await expect(diffTablist.getByRole('tab')).toHaveCount(2);
+    await expect(betaTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('ptah-diff-view .view-lines').last()).toContainText(
+      'beta modified',
+    );
+
+    await alphaTab.click();
+    await expect(alphaTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('ptah-diff-view .view-lines').last()).toContainText(
+      'alpha modified',
+    );
+
+    await page
+      .getByRole('button', {
+        name: 'Close diff for alpha.ts (working tree)',
+        exact: true,
+      })
+      .click();
+    await expect(alphaTab).toHaveCount(0);
+    await expect(diffTablist.getByRole('tab')).toHaveCount(1);
+    await expect(betaTab).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('ptah-diff-view .view-lines').last()).toContainText(
+      'beta modified',
+    );
   });
 });

--- a/apps/ptah-electron-e2e/src/specs/git/glyph-margin-visual.spec.ts
+++ b/apps/ptah-electron-e2e/src/specs/git/glyph-margin-visual.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import type { Page, TestInfo } from '@playwright/test';
 import { test, expect } from '../../support/real-rpc-fixtures';
 import { THREE_HUNK_FILE } from '../../support/git-scratch-repo';
+import { sourceControlFileButton } from '../../support/source-control';
 import {
   contrastRatio,
   decodePng,
@@ -62,8 +63,6 @@ const SCREENSHOT_DIR = path.resolve(
   'ptah-electron-e2e',
   'glyph-margin',
 );
-
-const FILE_NAME = THREE_HUNK_FILE.split('/').pop() as string;
 
 /**
  * WCAG 2.2 SC 1.4.11 — a graphical object needed to understand the content
@@ -432,9 +431,7 @@ test.describe('glyph-margin hunk markers, seen in three themes (TASK_2026_222)',
     // step that followed goto('editor') is gone.
     await ui.goto('git');
 
-    const changedRow = page.locator('[role="listitem"]', {
-      hasText: FILE_NAME,
-    });
+    const changedRow = await sourceControlFileButton(page, THREE_HUNK_FILE);
     await expect(changedRow).toBeVisible({ timeout: 20_000 });
     await changedRow.click();
 

--- a/apps/ptah-electron-e2e/src/specs/git/hunk-apply-real-rpc.spec.ts
+++ b/apps/ptah-electron-e2e/src/specs/git/hunk-apply-real-rpc.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../support/real-rpc-fixtures';
 import { THREE_HUNK_FILE } from '../../support/git-scratch-repo';
+import { sourceControlFileButton } from '../../support/source-control';
 
 /**
  * `git:applyHunks` end-to-end in Electron — TASK_2026_218.
@@ -17,8 +18,6 @@ import { THREE_HUNK_FILE } from '../../support/git-scratch-repo';
  * widget (TASK_2026_221) does not exist yet, and the glyph-margin markers
  * (TASK_2026_222) are checked separately in this same harness.
  */
-
-const FILE_NAME = THREE_HUNK_FILE.split('/').pop() as string;
 
 /**
  * How long the causation control holds before declaring the index untouched.
@@ -87,9 +86,7 @@ test.describe('git:applyHunks end-to-end in Electron (TASK_2026_218)', () => {
     // step that followed goto('editor') is gone.
     await ui.goto('git');
 
-    const changedRow = page.locator('[role="listitem"]', {
-      hasText: FILE_NAME,
-    });
+    const changedRow = await sourceControlFileButton(page, THREE_HUNK_FILE);
     await expect(changedRow).toBeVisible({ timeout: 20_000 });
     await changedRow.click();
 
@@ -161,9 +158,7 @@ test.describe('git:applyHunks end-to-end in Electron (TASK_2026_218)', () => {
     // step that followed goto('editor') is gone.
     await ui.goto('git');
 
-    const changedRow = page.locator('[role="listitem"]', {
-      hasText: FILE_NAME,
-    });
+    const changedRow = await sourceControlFileButton(page, THREE_HUNK_FILE);
     await expect(changedRow).toBeVisible({ timeout: 20_000 });
     await changedRow.click();
 

--- a/apps/ptah-electron-e2e/src/specs/git/hunk-revert-top-layer.spec.ts
+++ b/apps/ptah-electron-e2e/src/specs/git/hunk-revert-top-layer.spec.ts
@@ -4,6 +4,7 @@ import type { ElectronApplication, Locator, Page } from '@playwright/test';
 import { test, expect } from '../../support/real-rpc-fixtures';
 import { THREE_HUNK_FILE } from '../../support/git-scratch-repo';
 import { showCanvas } from '../../support/show-canvas';
+import { sourceControlFileButton } from '../../support/source-control';
 
 /**
  * The hunk revert confirmation, answered by MOUSE — TASK_2026_227.
@@ -45,8 +46,6 @@ const SCREENSHOT_DIR = path.resolve(
   'ptah-electron-e2e',
   'hunk-revert-top-layer',
 );
-
-const FILE_NAME = THREE_HUNK_FILE.split('/').pop() as string;
 
 interface HitTest {
   readonly tag: string;
@@ -156,9 +155,7 @@ test.describe('hunk revert dialog is answerable by mouse (TASK_2026_227)', () =>
     // goto('git') already opens it on the source-control panel, so the old
     // "click the Git tab" step is gone.
     await widenWindow(electronApp);
-    const changedRow = page.locator('[role="listitem"]', {
-      hasText: FILE_NAME,
-    });
+    const changedRow = await sourceControlFileButton(page, THREE_HUNK_FILE);
     await expect(changedRow).toBeVisible({ timeout: 20_000 });
     await changedRow.click();
 

--- a/apps/ptah-electron-e2e/src/specs/git/hunk-widget-mouse.spec.ts
+++ b/apps/ptah-electron-e2e/src/specs/git/hunk-widget-mouse.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import type { ElectronApplication } from '@playwright/test';
 import { test, expect } from '../../support/real-rpc-fixtures';
 import { THREE_HUNK_FILE } from '../../support/git-scratch-repo';
+import { sourceControlFileButton } from '../../support/source-control';
 
 /**
  * The in-editor hunk action widget, driven by the mouse — TASK_2026_221.
@@ -36,8 +37,6 @@ const SCREENSHOT_DIR = path.resolve(
   'ptah-electron-e2e',
   'hunk-widget',
 );
-
-const FILE_NAME = THREE_HUNK_FILE.split('/').pop() as string;
 
 /**
  * Widen the OS window so the git dock's diff pane clears its own vertical
@@ -109,9 +108,7 @@ test.describe('in-editor hunk action widget (TASK_2026_221)', () => {
     await ui.goto('git');
     await widenWindow(electronApp);
 
-    const changedRow = page.locator('[role="listitem"]', {
-      hasText: FILE_NAME,
-    });
+    const changedRow = await sourceControlFileButton(page, THREE_HUNK_FILE);
     await expect(changedRow).toBeVisible({ timeout: 20_000 });
     await changedRow.click();
 
@@ -222,9 +219,7 @@ test.describe('in-editor hunk action widget (TASK_2026_221)', () => {
     // step that followed goto('editor') is gone.
     await ui.goto('git');
     await widenWindow(electronApp);
-    const changedRow = page.locator('[role="listitem"]', {
-      hasText: FILE_NAME,
-    });
+    const changedRow = await sourceControlFileButton(page, THREE_HUNK_FILE);
     await expect(changedRow).toBeVisible({ timeout: 20_000 });
     await changedRow.click();
     await expect(page.locator('ptah-diff-view .view-lines').last()).toBeVisible(

--- a/apps/ptah-electron-e2e/src/support/source-control.ts
+++ b/apps/ptah-electron-e2e/src/support/source-control.ts
@@ -1,0 +1,39 @@
+import type { Locator, Page } from '@playwright/test';
+
+export type SourceControlSection = 'Changed files' | 'Staged files';
+
+/**
+ * Resolve a source-control file button through the folder disclosures that own
+ * it. File rows are intentionally absent from the accessibility tree while a
+ * parent folder is collapsed, so callers must navigate the same controls a
+ * user does before opening a diff.
+ */
+export async function sourceControlFileButton(
+  page: Page,
+  filePath: string,
+  section: SourceControlSection = 'Changed files',
+): Promise<Locator> {
+  const parts = filePath.replace(/\\/g, '/').split('/').filter(Boolean);
+  const fileName = parts.pop();
+  if (!fileName) {
+    throw new Error(`Cannot resolve an empty source-control path: "${filePath}"`);
+  }
+
+  let list = page.getByRole('list', { name: section, exact: true });
+  for (const folder of parts) {
+    const toggle = list.getByRole('button', {
+      name: `Toggle ${folder} folder`,
+      exact: true,
+    });
+    await toggle.waitFor({ state: 'visible' });
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+      await toggle.click();
+    }
+    list = toggle.locator('xpath=following-sibling::*[@role="list"][1]');
+  }
+
+  return list.getByRole('button', {
+    name: `Open diff for ${fileName}`,
+    exact: true,
+  });
+}

--- a/libs/backend/vscode-core/src/services/git-info.service.spec.ts
+++ b/libs/backend/vscode-core/src/services/git-info.service.spec.ts
@@ -373,7 +373,7 @@ describe('GitInfoService — new git methods (TASK_2026_111)', () => {
   describe('isMutatingGitCommand()', () => {
     it.each([
       // Every read this service actually performs.
-      [['status', '--porcelain=v2', '--branch']],
+      [['status', '--porcelain=v2', '--branch', '--untracked-files=all']],
       [['status', '--porcelain', '--', 'a.ts']],
       [['for-each-ref', '--format=x', 'refs/heads/']],
       [['symbolic-ref', '--short', 'HEAD']],
@@ -1183,10 +1183,9 @@ describe('GitInfoService.diffFile()', () => {
     expect(reader.readFileBytes).not.toHaveBeenCalled();
   });
 
-  // An untracked *directory* row is clickable in Source Control, so this
-  // request really does reach the service. Its worktree side reads the
-  // directory itself: node answers `EISDIR`, the VS Code file-system port
-  // answers `FileIsADirectory`, and both used to land on `unknown`.
+  // The UI no longer routes folders here, but retain the boundary guard for
+  // stale clients and direct RPC callers. Node answers `EISDIR`, while the VS
+  // Code file-system port answers `FileIsADirectory`.
   it.each([['EISDIR'], ['FileIsADirectory']])(
     'classifies a directory read (%s) as error/is-a-directory',
     async (errnoCode) => {
@@ -1325,6 +1324,41 @@ describe('GitInfoService.parseFileStatus() — origPath (N3)', () => {
     const info = await service.getGitInfo(WS);
 
     expect(info.files[0].origPath).toBeUndefined();
+  });
+
+  it('requests and parses every untracked file instead of collapsed directories', async () => {
+    const status = [
+      '# branch.head main',
+      '? .github/workflows/ci.yml',
+      '? libs/new-lib/src/index.ts',
+      '',
+    ].join('\n');
+
+    queueSpawn([
+      { stdout: 'true\n', exitCode: 0 },
+      { stdout: status, exitCode: 0 },
+    ]);
+
+    const info = await service.getGitInfo(WS);
+
+    expect(mockSpawn.mock.calls[1][1]).toEqual([
+      'status',
+      '--porcelain=v2',
+      '--branch',
+      '--untracked-files=all',
+    ]);
+    expect(info.files).toEqual([
+      {
+        path: '.github/workflows/ci.yml',
+        status: '??',
+        staged: false,
+      },
+      {
+        path: 'libs/new-lib/src/index.ts',
+        status: '??',
+        staged: false,
+      },
+    ]);
   });
 });
 

--- a/libs/backend/vscode-core/src/services/git-info.service.ts
+++ b/libs/backend/vscode-core/src/services/git-info.service.ts
@@ -363,7 +363,7 @@ export class GitInfoService {
 
     try {
       const { stdout, exitCode } = await this.execGit(
-        ['status', '--porcelain=v2', '--branch'],
+        ['status', '--porcelain=v2', '--branch', '--untracked-files=all'],
         workspacePath,
       );
 

--- a/libs/frontend/git-ui/src/lib/diff-view/diff-view.component.spec.ts
+++ b/libs/frontend/git-ui/src/lib/diff-view/diff-view.component.spec.ts
@@ -39,6 +39,7 @@ import type {
   HunkApplyFn,
 } from '../types/diff-tab.types';
 import { diffTabKey } from '../types/diff-tab.types';
+import * as Core from '@ptah-extension/core';
 
 /**
  * jsdom implements no HTMLDialogElement methods, so the revert dialog's
@@ -970,11 +971,13 @@ describe('DiffViewComponent — editor lifecycle (B1, B2, D3)', () => {
     );
 
     expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    expect(editor.options['useInlineViewWhenSpaceIsLimited']).toBe(false);
 
     toggle.click();
     fixture.detectChanges();
 
     expect(editor.options['renderSideBySide']).toBe(false);
+    expect(editor.options['useInlineViewWhenSpaceIsLimited']).toBe(false);
     expect(toggle.getAttribute('aria-pressed')).toBe('true');
     expect(monaco.diffEditors).toHaveLength(1);
 
@@ -984,6 +987,35 @@ describe('DiffViewComponent — editor lifecycle (B1, B2, D3)', () => {
     expect(editor.options['renderSideBySide']).toBe(true);
     expect(toggle.getAttribute('aria-pressed')).toBe('false');
     expect(monaco.diffEditors).toHaveLength(1);
+  });
+
+  it('loads and persists the explicit layout choice through settings RPC', async () => {
+    const rpc = jest.spyOn(Core, 'rpcCall').mockImplementation(
+      async (_service, method) =>
+        method === 'settings:get'
+          ? { success: true, data: { value: false } }
+          : { success: true },
+    );
+
+    const { fixture, monaco } = await createLiveFixture();
+    expect(monaco.diffEditors[0].options['renderSideBySide']).toBe(false);
+    expect(rpc).toHaveBeenCalledWith(
+      expect.anything(),
+      'settings:get',
+      { key: 'diff.renderSideBySide' },
+    );
+
+    fixture.nativeElement
+      .querySelector<HTMLButtonElement>('[data-testid="diff-layout-toggle"]')
+      ?.click();
+    fixture.detectChanges();
+
+    expect(rpc).toHaveBeenCalledWith(
+      expect.anything(),
+      'settings:set',
+      { key: 'diff.renderSideBySide', value: true },
+    );
+    rpc.mockRestore();
   });
 
   it('preserves scroll position across a layout toggle (D3)', async () => {

--- a/libs/frontend/git-ui/src/lib/diff-view/diff-view.component.ts
+++ b/libs/frontend/git-ui/src/lib/diff-view/diff-view.component.ts
@@ -801,6 +801,8 @@ export class DiffViewComponent implements OnDestroy {
 
   /** D3: side-by-side (true) vs inline (false). Persisted per user. */
   protected readonly renderSideBySide = signal(true);
+  /** Prevent a late settings:get response from undoing a newer click. */
+  private layoutPreferenceChangedByUser = false;
 
   /** True once the Monaco diff editor exists; gates decoration rendering. */
   private readonly editorReady = signal(false);
@@ -1191,6 +1193,10 @@ export class DiffViewComponent implements OnDestroy {
         // built as decorations instead, so no accidental edit is possible.
         readOnly: true,
         renderSideBySide: this.renderSideBySide(),
+        // The dock is narrow enough that Monaco's default responsive fallback
+        // silently overrides renderSideBySide. The toolbar is an explicit user
+        // choice, so do not substitute inline mode behind it.
+        useInlineViewWhenSpaceIsLimited: false,
         scrollBeyondLastLine: false,
         renderIndicators: true,
         renderMarginRevertIcon: false,
@@ -1420,6 +1426,7 @@ export class DiffViewComponent implements OnDestroy {
 
   protected toggleRenderSideBySide(): void {
     const next = !this.renderSideBySide();
+    this.layoutPreferenceChangedByUser = true;
     this.renderSideBySide.set(next);
     void this.persistLayoutPreference(next);
   }
@@ -1429,7 +1436,10 @@ export class DiffViewComponent implements OnDestroy {
     const editor = this.editor;
     if (!editor) return;
     const state = editor.saveViewState();
-    editor.updateOptions({ renderSideBySide: sideBySide });
+    editor.updateOptions({
+      renderSideBySide: sideBySide,
+      useInlineViewWhenSpaceIsLimited: false,
+    });
     if (state) editor.restoreViewState(state);
     this.scheduleLayout();
   }
@@ -1442,7 +1452,11 @@ export class DiffViewComponent implements OnDestroy {
         { key: DIFF_LAYOUT_SETTING_KEY },
       );
       if (this.destroyed) return;
-      if (result.success && typeof result.data?.value === 'boolean') {
+      if (
+        !this.layoutPreferenceChangedByUser &&
+        result.success &&
+        typeof result.data?.value === 'boolean'
+      ) {
         this.renderSideBySide.set(result.data.value);
       }
     } catch {

--- a/libs/frontend/git-ui/src/lib/git-dock/git-dock.component.spec.ts
+++ b/libs/frontend/git-ui/src/lib/git-dock/git-dock.component.spec.ts
@@ -7,24 +7,25 @@
  * constructor arms both `GitStatusService` and `GitBranchesService`, and that
  * `destroyRef.onDestroy` (fired by `fixture.destroy()`) disarms both.
  *
- * Child components (`GitDockHeaderComponent`, `SourceControlPanelComponent`,
- * `DiffViewComponent`) are never instantiated in this suite — Angular only
- * creates them on the first `detectChanges()`, and this suite intentionally
- * never calls it, so the arming behaviour is exercised in isolation from
- * their own dependencies (`SourceControlService`, `WorktreeService`,
- * `MonacoLoaderService`, etc).
+ * Rendered tab-strip specs replace the three child surfaces with inert stubs,
+ * keeping the dock tests isolated from `SourceControlService`,
+ * `WorktreeService`, `MonacoLoaderService`, and their rendering concerns.
  *
  * `rpcCall` is mocked at the module boundary, matching the pattern in
  * `git-status.service.spec.ts` / `git-branches.service.spec.ts`.
  */
 
-import { signal } from '@angular/core';
+import { Component, computed, input, output, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { VSCodeService } from '@ptah-extension/core';
-import { GitDockComponent } from './git-dock.component';
+import type { GitFileStatus } from '@ptah-extension/shared';
 import { GitStatusService } from '../services/git-status.service';
 import { GitBranchesService } from '../services/git-branches.service';
 import { DiffTabsService } from '../services/diff-tabs.service';
+import type {
+  EditorTab,
+  HunkApplyFn,
+  OpenDiffRequest,
+} from '../types/diff-tab.types';
 
 const mockRpcCall = jest.fn();
 jest.mock('@ptah-extension/core', () => {
@@ -36,6 +37,10 @@ jest.mock('@ptah-extension/core', () => {
     rpcCall: (...args: unknown[]) => mockRpcCall(...args),
   };
 });
+const { VSCodeService } = jest.requireActual('@ptah-extension/core');
+const { GitDockComponent } = jest.requireActual(
+  './git-dock.component',
+) as typeof import('./git-dock.component');
 
 function makeVscodeStub() {
   const _config = signal({
@@ -79,16 +84,64 @@ function makeGitBranchesStub() {
 }
 
 function makeDiffTabsStub() {
+  const tabs = signal<EditorTab[]>([]);
+  const activeKey = signal<string | null>(null);
+  const activateDiff = jest.fn((key: string) => {
+    if (tabs().some((tab) => tab.filePath === key)) activeKey.set(key);
+  });
+  const closeDiff = jest.fn((key: string) => {
+    const remaining = tabs().filter((tab) => tab.filePath !== key);
+    if (remaining.length === tabs().length) return;
+    tabs.set(remaining);
+    if (activeKey() === key) activeKey.set(remaining.at(-1)?.filePath ?? null);
+  });
+
   return {
-    activeDiffTab: jest.fn(() => null),
-    openDiffKeys: jest.fn(() => []),
-    applyHunksFn: jest.fn(),
+    diffTabs: tabs.asReadonly(),
+    activeDiffKey: activeKey.asReadonly(),
+    activeDiffTab: computed(
+      () => tabs().find((tab) => tab.filePath === activeKey()) ?? null,
+    ),
+    openDiffKeys: computed(() => tabs().map((tab) => tab.filePath)),
+    applyHunksFn: jest.fn() as unknown as HunkApplyFn,
     openDiff: jest.fn(),
+    activateDiff,
+    closeDiff,
     refreshDiffTab: jest.fn(),
+    setTabs(nextTabs: EditorTab[], nextActiveKey: string | null): void {
+      tabs.set(nextTabs);
+      activeKey.set(nextActiveKey);
+    },
   };
 }
 
-describe('GitDockComponent — arm on construction, disarm on destroy', () => {
+function makeTab(filePath: string, fileName: string): EditorTab {
+  return { filePath, fileName, content: '', isDirty: false };
+}
+
+@Component({ selector: 'ptah-git-dock-header', standalone: true, template: '' })
+class GitDockHeaderStubComponent {}
+
+@Component({
+  selector: 'ptah-source-control-panel',
+  standalone: true,
+  template: '',
+})
+class SourceControlPanelStubComponent {
+  readonly files = input.required<GitFileStatus[]>();
+  readonly diffRequested = output<OpenDiffRequest>();
+  readonly fileClicked = output<string>();
+}
+
+@Component({ selector: 'ptah-diff-view', standalone: true, template: '' })
+class DiffViewStubComponent {
+  readonly diffTab = input.required<EditorTab>();
+  readonly openDiffKeys = input.required<readonly string[]>();
+  readonly applyHunks = input.required<HunkApplyFn>();
+  readonly retryRequested = output<string>();
+}
+
+describe('GitDockComponent', () => {
   let gitStatus: ReturnType<typeof makeGitStatusStub>;
   let gitBranches: ReturnType<typeof makeGitBranchesStub>;
   let diffTabs: ReturnType<typeof makeDiffTabsStub>;
@@ -111,6 +164,21 @@ describe('GitDockComponent — arm on construction, disarm on destroy', () => {
       ],
     });
   });
+
+  function createRenderedDock() {
+    TestBed.overrideComponent(GitDockComponent, {
+      set: {
+        imports: [
+          GitDockHeaderStubComponent,
+          SourceControlPanelStubComponent,
+          DiffViewStubComponent,
+        ],
+      },
+    });
+    const fixture = TestBed.createComponent(GitDockComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
 
   it('arms GitStatusService.startListening() on construction', () => {
     TestBed.createComponent(GitDockComponent);
@@ -157,5 +225,134 @@ describe('GitDockComponent — arm on construction, disarm on destroy', () => {
     expect(mockRpcCall).toHaveBeenCalledWith(expect.anything(), 'file:open', {
       path: 'src/a.ts',
     });
+  });
+
+  it('renders one accessible tab per open diff, in open order', () => {
+    diffTabs.setTabs(
+      [makeTab('first-key', 'first.ts'), makeTab('second-key', 'second.ts')],
+      'second-key',
+    );
+    const fixture = createRenderedDock();
+
+    const tablist = fixture.nativeElement.querySelector('[role="tablist"]');
+    const tabs = [
+      ...tablist.querySelectorAll<HTMLButtonElement>('[role="tab"]'),
+    ];
+    const panel = fixture.nativeElement.querySelector(
+      '[role="tabpanel"]',
+    ) as HTMLElement;
+    expect(tabs.map((tab) => tab.textContent?.trim())).toEqual([
+      'first.ts',
+      'second.ts',
+    ]);
+    expect(tabs.map((tab) => tab.getAttribute('aria-selected'))).toEqual([
+      'false',
+      'true',
+    ]);
+    expect(
+      tabs.every((tab) => tab.getAttribute('aria-controls') === panel.id),
+    ).toBe(true);
+    expect(panel.getAttribute('aria-labelledby')).toBe(tabs[1].id);
+  });
+
+  it('activates an inactive tab without opening or refreshing its diff', () => {
+    diffTabs.setTabs(
+      [makeTab('first-key', 'first.ts'), makeTab('second-key', 'second.ts')],
+      'second-key',
+    );
+    const fixture = createRenderedDock();
+
+    const firstTab = fixture.nativeElement.querySelector(
+      '[role="tab"]',
+    ) as HTMLButtonElement;
+    firstTab.click();
+    fixture.detectChanges();
+
+    expect(diffTabs.activateDiff).toHaveBeenCalledWith('first-key');
+    expect(diffTabs.openDiff).not.toHaveBeenCalled();
+    expect(diffTabs.refreshDiffTab).not.toHaveBeenCalled();
+    expect(firstTab.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('closes the tab whose sibling close button was clicked', () => {
+    diffTabs.setTabs(
+      [makeTab('first-key', 'first.ts'), makeTab('second-key', 'second.ts')],
+      'second-key',
+    );
+    const fixture = createRenderedDock();
+
+    const closeFirst = fixture.nativeElement.querySelector(
+      'button[aria-label="Close diff for first.ts"]',
+    ) as HTMLButtonElement;
+    const activationControl = closeFirst.parentElement?.querySelector(
+      '[role="tab"]',
+    ) as HTMLButtonElement;
+    expect(activationControl.contains(closeFirst)).toBe(false);
+    closeFirst.click();
+    fixture.detectChanges();
+
+    expect(diffTabs.closeDiff).toHaveBeenCalledWith('first-key');
+    expect(
+      [...fixture.nativeElement.querySelectorAll('[role="tab"]')].map((tab) =>
+        (tab as HTMLElement).textContent?.trim(),
+      ),
+    ).toEqual(['second.ts']);
+  });
+
+  it('falls back to the last remaining tab after closing the active tab', () => {
+    diffTabs.setTabs(
+      [makeTab('first-key', 'first.ts'), makeTab('second-key', 'second.ts')],
+      'second-key',
+    );
+    const fixture = createRenderedDock();
+
+    (
+      fixture.nativeElement.querySelector(
+        'button[aria-label="Close diff for second.ts"]',
+      ) as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+
+    const remaining = fixture.nativeElement.querySelector(
+      '[role="tab"]',
+    ) as HTMLButtonElement;
+    expect(diffTabs.activeDiffKey()).toBe('first-key');
+    expect(remaining.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('hides the tab strip and diff panel after closing the final tab', () => {
+    diffTabs.setTabs([makeTab('only-key', 'only.ts')], 'only-key');
+    const fixture = createRenderedDock();
+
+    (
+      fixture.nativeElement.querySelector(
+        'button[aria-label="Close diff for only.ts"]',
+      ) as HTMLButtonElement
+    ).click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('[role="tablist"]')).toBeNull();
+    expect(fixture.nativeElement.querySelector('[role="tabpanel"]')).toBeNull();
+  });
+
+  it('moves between tabs with arrow keys and closes one with Delete', () => {
+    diffTabs.setTabs(
+      [makeTab('first-key', 'first.ts'), makeTab('second-key', 'second.ts')],
+      'second-key',
+    );
+    const fixture = createRenderedDock();
+    const tabs =
+      fixture.nativeElement.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+
+    tabs[1].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+    );
+    expect(diffTabs.activateDiff).toHaveBeenCalledWith('first-key');
+    expect(document.activeElement).toBe(tabs[0]);
+
+    tabs[0].dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Delete', bubbles: true }),
+    );
+    expect(diffTabs.closeDiff).toHaveBeenCalledWith('first-key');
   });
 });

--- a/libs/frontend/git-ui/src/lib/git-dock/git-dock.component.ts
+++ b/libs/frontend/git-ui/src/lib/git-dock/git-dock.component.ts
@@ -58,14 +58,77 @@ import { GitDockHeaderComponent } from './git-dock-header.component';
           />
         </div>
 
-        @if (diffTabs.activeDiffTab()) {
-          <div class="flex-1 min-w-0 overflow-hidden">
-            <ptah-diff-view
-              [diffTab]="diffTabs.activeDiffTab()"
-              [openDiffKeys]="diffTabs.openDiffKeys()"
-              [applyHunks]="diffTabs.applyHunksFn"
-              (retryRequested)="diffTabs.refreshDiffTab($event)"
-            />
+        @if (diffTabs.activeDiffTab(); as activeDiffTab) {
+          <div class="flex-1 min-w-0 flex flex-col overflow-hidden">
+            <div
+              class="flex flex-shrink-0 overflow-x-auto border-b border-base-content/10 bg-base-200"
+              role="tablist"
+              aria-label="Open diffs"
+              aria-orientation="horizontal"
+            >
+              @for (
+                tab of diffTabs.diffTabs();
+                track tab.filePath;
+                let index = $index
+              ) {
+                <div
+                  class="flex items-center flex-shrink-0 border-r border-base-content/10"
+                >
+                  <button
+                    type="button"
+                    role="tab"
+                    class="px-2 py-1 text-xs max-w-48 truncate cursor-pointer
+                           focus-visible:outline focus-visible:outline-2
+                           focus-visible:outline-offset-[-2px]
+                           focus-visible:outline-[oklch(var(--s))]"
+                    [class.bg-base-100]="
+                      tab.filePath === diffTabs.activeDiffKey()
+                    "
+                    [class.font-semibold]="
+                      tab.filePath === diffTabs.activeDiffKey()
+                    "
+                    [id]="diffTabId(index)"
+                    [attr.aria-selected]="
+                      tab.filePath === diffTabs.activeDiffKey()
+                    "
+                    [attr.aria-controls]="diffPanelId"
+                    [attr.tabindex]="
+                      tab.filePath === diffTabs.activeDiffKey() ? 0 : -1
+                    "
+                    [title]="tab.fileName"
+                    (click)="diffTabs.activateDiff(tab.filePath)"
+                    (keydown)="onDiffTabKeydown($event, tab.filePath)"
+                  >
+                    {{ tab.fileName }}
+                  </button>
+                  <button
+                    type="button"
+                    class="px-1.5 py-1 text-xs opacity-60 hover:opacity-100 cursor-pointer
+                           focus-visible:outline focus-visible:outline-2
+                           focus-visible:outline-offset-[-2px]
+                           focus-visible:outline-[oklch(var(--s))]"
+                    [attr.aria-label]="'Close diff for ' + tab.fileName"
+                    (click)="diffTabs.closeDiff(tab.filePath)"
+                  >
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                </div>
+              }
+            </div>
+
+            <div
+              class="flex-1 min-h-0 overflow-hidden"
+              role="tabpanel"
+              [id]="diffPanelId"
+              [attr.aria-labelledby]="activeDiffTabId()"
+            >
+              <ptah-diff-view
+                [diffTab]="activeDiffTab"
+                [openDiffKeys]="diffTabs.openDiffKeys()"
+                [applyHunks]="diffTabs.applyHunksFn"
+                (retryRequested)="diffTabs.refreshDiffTab($event)"
+              />
+            </div>
           </div>
         }
       </div>
@@ -74,6 +137,10 @@ import { GitDockHeaderComponent } from './git-dock-header.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GitDockComponent {
+  private static instanceCount = 0;
+  private readonly instanceId = GitDockComponent.instanceCount++;
+  protected readonly diffPanelId = `git-diff-panel-${this.instanceId}`;
+
   protected readonly gitStatus = inject(GitStatusService);
   private readonly gitBranches = inject(GitBranchesService);
   protected readonly diffTabs = inject(DiffTabsService);
@@ -94,5 +161,41 @@ export class GitDockComponent {
   /** Route a file-name click from the source-control panel to the external editor. */
   protected onFileClicked(path: string): void {
     void rpcCall(this.vscodeService, 'file:open', { path });
+  }
+
+  protected diffTabId(index: number): string {
+    return `git-diff-tab-${this.instanceId}-${index}`;
+  }
+
+  protected activeDiffTabId(): string | null {
+    const activeKey = this.diffTabs.activeDiffKey();
+    const index = this.diffTabs
+      .diffTabs()
+      .findIndex((tab) => tab.filePath === activeKey);
+    return index >= 0 ? this.diffTabId(index) : null;
+  }
+
+  /** Automatic tab activation for the horizontal arrow-key navigation model. */
+  protected onDiffTabKeydown(event: KeyboardEvent, key: string): void {
+    if (event.key === 'Delete') {
+      event.preventDefault();
+      this.diffTabs.closeDiff(key);
+      return;
+    }
+    if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+
+    const tabs = this.diffTabs.diffTabs();
+    const currentIndex = tabs.findIndex((tab) => tab.filePath === key);
+    if (currentIndex < 0 || tabs.length < 2) return;
+
+    event.preventDefault();
+    const offset = event.key === 'ArrowLeft' ? -1 : 1;
+    const nextIndex = (currentIndex + offset + tabs.length) % tabs.length;
+    this.diffTabs.activateDiff(tabs[nextIndex].filePath);
+
+    const currentControl = event.currentTarget as HTMLElement | null;
+    const tablist = currentControl?.closest('[role="tablist"]');
+    const controls = tablist?.querySelectorAll<HTMLElement>('[role="tab"]');
+    controls?.item(nextIndex).focus();
   }
 }

--- a/libs/frontend/git-ui/src/lib/services/diff-tabs.service.spec.ts
+++ b/libs/frontend/git-ui/src/lib/services/diff-tabs.service.spec.ts
@@ -633,6 +633,60 @@ describe('DiffTabsService.onFileContentChanged', () => {
   });
 });
 
+describe('DiffTabsService tab selection and closing', () => {
+  async function openTwo(service: DiffTabsService): Promise<[string, string]> {
+    mockRpcCall
+      .mockResolvedValueOnce(ok(makeResult({ path: 'a.ts' })))
+      .mockResolvedValueOnce(ok(makeResult({ path: 'b.ts' })));
+    await openDiff(service, { path: 'a.ts' });
+    await openDiff(service, { path: 'b.ts' });
+    return [diffTabKey('worktree', 'a.ts'), diffTabKey('worktree', 'b.ts')];
+  }
+
+  it('activates an existing tab without re-fetching its diff', async () => {
+    const { service } = makeService();
+    const [firstKey, secondKey] = await openTwo(service);
+    expect(service.activeDiffKey()).toBe(secondKey);
+    mockRpcCall.mockClear();
+
+    service.activateDiff(firstKey);
+
+    expect(service.activeDiffKey()).toBe(firstKey);
+    expect(mockRpcCall).not.toHaveBeenCalled();
+  });
+
+  it('ignores activation for a key that is not open', async () => {
+    const { service } = makeService();
+    const [, secondKey] = await openTwo(service);
+
+    service.activateDiff('diff:worktree:missing.ts');
+
+    expect(service.activeDiffKey()).toBe(secondKey);
+  });
+
+  it('falls back to the last remaining tab when the active tab closes', async () => {
+    const { service } = makeService();
+    const [firstKey, secondKey] = await openTwo(service);
+
+    service.closeDiff(secondKey);
+
+    expect(service.openDiffKeys()).toEqual([firstKey]);
+    expect(service.activeDiffKey()).toBe(firstKey);
+  });
+
+  it('clears the active surface when the final tab closes', async () => {
+    const { service } = makeService();
+    const [firstKey, secondKey] = await openTwo(service);
+    service.closeDiff(secondKey);
+
+    service.closeDiff(firstKey);
+
+    expect(service.diffTabs()).toEqual([]);
+    expect(service.activeDiffKey()).toBeNull();
+    expect(service.activeDiffTab()).toBeNull();
+  });
+});
+
 // ============================================================================
 // Push routing. In the editor lib these two arrived through the coordinator's
 // `handleMessage`; here the service registers for them itself, so the routing

--- a/libs/frontend/git-ui/src/lib/services/diff-tabs.service.ts
+++ b/libs/frontend/git-ui/src/lib/services/diff-tabs.service.ts
@@ -232,6 +232,18 @@ export class DiffTabsService implements MessageHandler {
   }
 
   /**
+   * Show an already-open diff without re-reading it from git.
+   *
+   * File-row re-clicks intentionally go through {@link openDiff} so they
+   * revalidate. Tab-strip navigation must not: it only changes which cached
+   * tab is visible.
+   */
+  public activateDiff(key: string): void {
+    if (!this._diffTabs().some((tab) => tab.filePath === key)) return;
+    this._activeDiffKey.set(key);
+  }
+
+  /**
    * Close one diff tab. The dock falls back to the last remaining tab rather
    * than to nothing, so closing one of several does not empty the surface.
    */

--- a/libs/frontend/git-ui/src/lib/source-control/source-control-file.component.spec.ts
+++ b/libs/frontend/git-ui/src/lib/source-control/source-control-file.component.spec.ts
@@ -247,6 +247,44 @@ describe('SourceControlFileComponent — row actions are siblings, not nested (D
     expect(badge.closest('button')).toBeNull();
   });
 
+  it.each([
+    ['M', 'M', 'Modified'],
+    ['A', 'A', 'Added'],
+    ['D', 'D', 'Deleted'],
+    ['??', 'U', 'Untracked'],
+    ['R', 'R', 'Renamed'],
+    ['C', 'C', 'Copied'],
+  ])(
+    'renders %s as badge %s with the human-readable label %s',
+    (status, badgeText, label) => {
+      host.file.set({
+        path: 'src/a.ts',
+        status,
+        staged: false,
+      } as GitFileStatus);
+      fixture.detectChanges();
+
+      const badge = q<HTMLElement>('[role="listitem"] > span:last-child');
+      expect(badge.textContent?.trim()).toBe(badgeText);
+      expect(badge.getAttribute('title')).toBe(label);
+      expect(badge.getAttribute('aria-label')).toBe(label);
+    },
+  );
+
+  it('falls back to the raw status code for an unmapped badge', () => {
+    host.file.set({
+      path: 'src/a.ts',
+      status: 'X',
+      staged: false,
+    } as GitFileStatus);
+    fixture.detectChanges();
+
+    const badge = q<HTMLElement>('[role="listitem"] > span:last-child');
+    expect(badge.textContent?.trim()).toBe('X');
+    expect(badge.getAttribute('title')).toBe('X');
+    expect(badge.getAttribute('aria-label')).toBe('X');
+  });
+
   it('still carries the rename-aware row title (AC6)', () => {
     host.file.set({
       path: 'src/new.ts',

--- a/libs/frontend/git-ui/src/lib/source-control/source-control-file.component.spec.ts
+++ b/libs/frontend/git-ui/src/lib/source-control/source-control-file.component.spec.ts
@@ -169,6 +169,20 @@ describe('SourceControlFileComponent — row actions are siblings, not nested (D
     expect(host.discard).toEqual([]);
   });
 
+  it('does not emit a diff request for a directory-shaped legacy row', () => {
+    host.file.set({
+      path: '.github',
+      status: '??',
+      staged: false,
+      isDirectory: true,
+    } as GitFileStatus);
+    fixture.detectChanges();
+
+    clickReal(openDiffButton());
+
+    expect(host.openDiff).toEqual([]);
+  });
+
   // -- AC2/AC4/AC7 -----------------------------------------------------------
 
   it('gives every control a distinct label and independent keyboard focus (AC2, AC4)', () => {

--- a/libs/frontend/git-ui/src/lib/source-control/source-control-file.component.ts
+++ b/libs/frontend/git-ui/src/lib/source-control/source-control-file.component.ts
@@ -129,9 +129,12 @@ import type { OpenDiffRequest } from '../types/diff-tab.types';
       </span>
 
       <!-- Status badge -->
-      <span class="text-[10px] font-mono opacity-40 flex-shrink-0">{{
-        file().status
-      }}</span>
+      <span
+        class="text-[10px] font-mono opacity-40 flex-shrink-0"
+        [title]="statusLabel()"
+        [attr.aria-label]="statusLabel()"
+        >{{ statusBadge() }}</span
+      >
     </div>
   `,
   // The component HOST sits between the panel's role="list" and this row's
@@ -222,6 +225,30 @@ export class SourceControlFileComponent {
         return 'text-info';
       default:
         return 'opacity-60';
+    }
+  });
+
+  protected readonly statusBadge = computed(() =>
+    this.file().status === '??' ? 'U' : this.file().status,
+  );
+
+  protected readonly statusLabel = computed(() => {
+    const status = this.file().status;
+    switch (status) {
+      case 'M':
+        return 'Modified';
+      case 'A':
+        return 'Added';
+      case 'D':
+        return 'Deleted';
+      case '??':
+        return 'Untracked';
+      case 'R':
+        return 'Renamed';
+      case 'C':
+        return 'Copied';
+      default:
+        return status;
     }
   });
 

--- a/libs/frontend/git-ui/src/lib/source-control/source-control-file.component.ts
+++ b/libs/frontend/git-ui/src/lib/source-control/source-control-file.component.ts
@@ -56,7 +56,7 @@ import type { OpenDiffRequest } from '../types/diff-tab.types';
                focus-visible:outline-[oklch(var(--s))]"
         [title]="rowTitle()"
         [attr.aria-label]="'Open diff for ' + fileName()"
-        (click)="openDiff.emit(diffRequest())"
+        (click)="onOpenDiff()"
       >
         <!-- Status icon -->
         <lucide-angular
@@ -68,7 +68,7 @@ import type { OpenDiffRequest } from '../types/diff-tab.types';
         <!-- File name + parent dir -->
         <span class="flex items-center gap-1 min-w-0 flex-1">
           <span class="font-medium truncate">{{ fileName() }}</span>
-          @if (parentDir()) {
+          @if (showParentDir() && parentDir()) {
             <span class="opacity-40 text-[10px] truncate">{{
               parentDir()
             }}</span>
@@ -143,6 +143,7 @@ import type { OpenDiffRequest } from '../types/diff-tab.types';
 export class SourceControlFileComponent {
   readonly file = input.required<GitFileStatus>();
   readonly staged = input.required<boolean>();
+  readonly showParentDir = input(true);
 
   readonly stage = output<string>();
   readonly unstage = output<string>();
@@ -223,6 +224,12 @@ export class SourceControlFileComponent {
         return 'opacity-60';
     }
   });
+
+  /** Directory-shaped legacy rows are never valid diff targets. */
+  protected onOpenDiff(): void {
+    if (this.file().isDirectory) return;
+    this.openDiff.emit(this.diffRequest());
+  }
 
   /**
    * Inline row action. Takes no event: the three action buttons are SIBLINGS

--- a/libs/frontend/git-ui/src/lib/source-control/source-control-panel.component.spec.ts
+++ b/libs/frontend/git-ui/src/lib/source-control/source-control-panel.component.spec.ts
@@ -15,6 +15,7 @@
 
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { NgTemplateOutlet } from '@angular/common';
 import { LucideAngularModule } from 'lucide-angular';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { GitFileStatus } from '@ptah-extension/shared';
@@ -54,13 +55,17 @@ function makeSourceControlStub() {
 @Component({
   standalone: true,
   imports: [SourceControlPanelComponent],
-  template: `<ptah-source-control-panel [files]="files()" />`,
+  template: `<ptah-source-control-panel
+    [files]="files()"
+    (diffRequested)="diffRequested.push($event)"
+  />`,
 })
 class HostComponent {
   readonly files = signal<GitFileStatus[]>([
     { path: 'src/a.ts', status: 'M', staged: true } as GitFileStatus,
     { path: 'src/b.ts', status: 'A', staged: false } as GitFileStatus,
   ]);
+  readonly diffRequested: unknown[] = [];
 }
 
 describe('SourceControlPanelComponent — header controls are siblings, not nested (D1)', () => {
@@ -98,6 +103,7 @@ describe('SourceControlPanelComponent — header controls are siblings, not nest
       set: {
         imports: [
           FormsModule,
+          NgTemplateOutlet,
           LucideAngularModule,
           SourceControlFileComponent,
           StubWorktreeSectionComponent,
@@ -407,6 +413,78 @@ describe('SourceControlPanelComponent — header controls are siblings, not nest
     expect(regions[0].children[0].getAttribute('role')).toBe('listitem');
     expect((regions[0].textContent ?? '').trim()).toBe('No staged changes');
     expect(unownedChildren(regions[1])).toEqual([]);
+  });
+
+  it('renders paths as collapsible nested lists and folders never request a diff', () => {
+    fixture.componentInstance.files.set([
+      {
+        path: '.github/workflows/ci.yml',
+        status: '??',
+        staged: false,
+      } as GitFileStatus,
+      {
+        path: '.github/ISSUE_TEMPLATE/bug.md',
+        status: '??',
+        staged: false,
+      } as GitFileStatus,
+    ]);
+    fixture.detectChanges();
+
+    const github = q<HTMLButtonElement>(
+      'button[aria-label="Toggle .github folder"]',
+    );
+    expect(github.getAttribute('aria-expanded')).toBe('false');
+    expect(
+      fixture.nativeElement.querySelector('button[aria-label="Open diff for ci.yml"]'),
+    ).toBeNull();
+
+    clickReal(github);
+    fixture.detectChanges();
+
+    expect(github.getAttribute('aria-expanded')).toBe('true');
+    expect(fixture.componentInstance.diffRequested).toEqual([]);
+    const workflows = q<HTMLButtonElement>(
+      'button[aria-label="Toggle workflows folder"]',
+    );
+    expect(workflows.getAttribute('aria-expanded')).toBe('false');
+    expect(github.getAttribute('aria-controls')).toBe(
+      workflows.closest('[role="list"]')?.id,
+    );
+
+    clickReal(workflows);
+    fixture.detectChanges();
+    clickReal(
+      q<HTMLButtonElement>('button[aria-label="Open diff for ci.yml"]'),
+    );
+
+    expect(fixture.componentInstance.diffRequested).toEqual([
+      { path: '.github/workflows/ci.yml', comparison: 'worktree' },
+    ]);
+    for (const region of lists()) {
+      expect(unownedChildren(region)).toEqual([]);
+    }
+  });
+
+  it('turns a legacy directory status row into a folder control, never a file row', () => {
+    fixture.componentInstance.files.set([
+      {
+        path: '.github',
+        status: '??',
+        staged: false,
+        isDirectory: true,
+      } as GitFileStatus,
+    ]);
+    fixture.detectChanges();
+
+    clickReal(
+      q<HTMLButtonElement>('button[aria-label="Toggle .github folder"]'),
+    );
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.diffRequested).toEqual([]);
+    expect(
+      fixture.nativeElement.querySelector('button[aria-label^="Open diff for"]'),
+    ).toBeNull();
   });
 
   it('hides each bulk action when its section is empty (AC6)', () => {

--- a/libs/frontend/git-ui/src/lib/source-control/source-control-panel.component.ts
+++ b/libs/frontend/git-ui/src/lib/source-control/source-control-panel.component.ts
@@ -7,6 +7,7 @@ import {
   computed,
   ChangeDetectionStrategy,
 } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {
   LucideAngularModule,
@@ -20,6 +21,68 @@ import type { OpenDiffRequest } from '../types/diff-tab.types';
 import { SourceControlService } from '../services/source-control.service';
 import { SourceControlFileComponent } from './source-control-file.component';
 import { WorktreeSectionComponent } from '../worktree/worktree-section.component';
+
+interface GitFileTreeFileNode {
+  readonly kind: 'file';
+  readonly key: string;
+  readonly file: GitFileStatus;
+}
+
+interface GitFileTreeFolderNode {
+  readonly kind: 'folder';
+  readonly key: string;
+  readonly name: string;
+  readonly path: string;
+  readonly children: GitFileTreeNode[];
+}
+
+type GitFileTreeNode = GitFileTreeFileNode | GitFileTreeFolderNode;
+
+interface GitFileTreeFolderBuilder extends GitFileTreeFolderNode {
+  readonly foldersByName: Map<string, GitFileTreeFolderBuilder>;
+}
+
+/** Build the presentation tree in one pass while preserving Git's row order. */
+function buildFileTree(files: readonly GitFileStatus[]): GitFileTreeNode[] {
+  const root: GitFileTreeNode[] = [];
+  const rootFolders = new Map<string, GitFileTreeFolderBuilder>();
+
+  for (const file of files) {
+    const parts = file.path.replace(/\\/g, '/').split('/').filter(Boolean);
+    if (parts.length === 0) continue;
+
+    const folderParts = file.isDirectory ? parts : parts.slice(0, -1);
+    let children = root;
+    let foldersByName = rootFolders;
+    let parentPath = '';
+
+    for (const name of folderParts) {
+      const path = parentPath ? `${parentPath}/${name}` : name;
+      let folder = foldersByName.get(name);
+      if (!folder) {
+        folder = {
+          kind: 'folder',
+          key: `folder:${path}`,
+          name,
+          path,
+          children: [],
+          foldersByName: new Map<string, GitFileTreeFolderBuilder>(),
+        };
+        foldersByName.set(name, folder);
+        children.push(folder);
+      }
+      children = folder.children;
+      foldersByName = folder.foldersByName;
+      parentPath = path;
+    }
+
+    if (!file.isDirectory) {
+      children.push({ kind: 'file', key: `file:${file.path}`, file });
+    }
+  }
+
+  return root;
+}
 
 /**
  * SourceControlPanelComponent - Main source control panel with commit UI and file groups.
@@ -40,6 +103,7 @@ import { WorktreeSectionComponent } from '../worktree/worktree-section.component
   standalone: true,
   imports: [
     FormsModule,
+    NgTemplateOutlet,
     LucideAngularModule,
     SourceControlFileComponent,
     WorktreeSectionComponent,
@@ -128,16 +192,14 @@ import { WorktreeSectionComponent } from '../worktree/worktree-section.component
         </div>
         @if (stagedExpanded()) {
           <div [id]="stagedListId" role="list" aria-label="Staged files">
-            @for (file of stagedFiles(); track file.path) {
-              <ptah-source-control-file
-                [file]="file"
-                [staged]="true"
-                (unstage)="onUnstageFile($event)"
-                (discard)="onDiscardFile($event)"
-                (openDiff)="diffRequested.emit($event)"
-                (openFile)="fileClicked.emit($event)"
-              />
-            }
+            <ng-container
+              [ngTemplateOutlet]="treeNodes"
+              [ngTemplateOutletContext]="{
+                $implicit: stagedTree(),
+                staged: true,
+                section: 'staged',
+              }"
+            />
             <!-- role="listitem" is load-bearing, not decoration. This div is a
                  CHILD of the role="list" region above, and the list role
                  declares listitem as its required owned role — so a plain
@@ -199,16 +261,14 @@ import { WorktreeSectionComponent } from '../worktree/worktree-section.component
         </div>
         @if (unstagedExpanded()) {
           <div [id]="unstagedListId" role="list" aria-label="Changed files">
-            @for (file of unstagedFiles(); track file.path) {
-              <ptah-source-control-file
-                [file]="file"
-                [staged]="false"
-                (stage)="onStageFile($event)"
-                (discard)="onDiscardFile($event)"
-                (openDiff)="diffRequested.emit($event)"
-                (openFile)="fileClicked.emit($event)"
-              />
-            }
+            <ng-container
+              [ngTemplateOutlet]="treeNodes"
+              [ngTemplateOutletContext]="{
+                $implicit: unstagedTree(),
+                staged: false,
+                section: 'unstaged',
+              }"
+            />
             <!-- role="listitem" for the same reason as the staged empty state
                  above — see that comment (TASK_2026_211). -->
             @if (unstagedFiles().length === 0) {
@@ -225,6 +285,71 @@ import { WorktreeSectionComponent } from '../worktree/worktree-section.component
 
       <!-- Worktrees section (collapsible, below Changes) -->
       <ptah-worktree-section />
+
+      <ng-template
+        #treeNodes
+        let-nodes
+        let-staged="staged"
+        let-section="section"
+      >
+        @for (node of nodes; track trackTreeNode($index, node)) {
+          @if (node.kind === 'folder') {
+            <div role="listitem">
+              <button
+                type="button"
+                class="flex items-center gap-1.5 w-full px-2 py-0.5 text-left text-xs
+                       hover:bg-base-content/10 transition-colors cursor-pointer
+                       focus-visible:outline focus-visible:outline-2
+                       focus-visible:outline-offset-[-2px]
+                       focus-visible:outline-[oklch(var(--s))]"
+                [attr.aria-expanded]="isFolderExpanded(section, node.path)"
+                [attr.aria-controls]="folderListId(section, node.path)"
+                [attr.aria-label]="folderToggleLabel(node.name)"
+                (click)="toggleFolder(section, node.path)"
+              >
+                <lucide-angular
+                  [img]="
+                    isFolderExpanded(section, node.path)
+                      ? ChevronDownIcon
+                      : ChevronRightIcon
+                  "
+                  class="w-3.5 h-3.5 flex-shrink-0"
+                  aria-hidden="true"
+                />
+                <span class="font-medium truncate">{{ node.name }}</span>
+              </button>
+              @if (isFolderExpanded(section, node.path)) {
+                <div
+                  [id]="folderListId(section, node.path)"
+                  role="list"
+                  [attr.aria-label]="node.name + ' folder'"
+                  class="ml-3 border-l border-base-300/60"
+                >
+                  <ng-container
+                    [ngTemplateOutlet]="treeNodes"
+                    [ngTemplateOutletContext]="{
+                      $implicit: node.children,
+                      staged: staged,
+                      section: section,
+                    }"
+                  />
+                </div>
+              }
+            </div>
+          } @else {
+            <ptah-source-control-file
+              [file]="node.file"
+              [staged]="staged"
+              [showParentDir]="false"
+              (stage)="onStageFile($event)"
+              (unstage)="onUnstageFile($event)"
+              (discard)="onDiscardFile($event)"
+              (openDiff)="diffRequested.emit($event)"
+              (openFile)="fileClicked.emit($event)"
+            />
+          }
+        }
+      </ng-template>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -241,6 +366,7 @@ export class SourceControlPanelComponent {
   protected readonly isCommitting = signal(false);
   protected readonly stagedExpanded = signal(true);
   protected readonly unstagedExpanded = signal(true);
+  private readonly expandedFolders = signal<ReadonlySet<string>>(new Set());
 
   /**
    * Per-instance ids for the two `role="list"` regions, so each disclosure
@@ -262,6 +388,40 @@ export class SourceControlPanelComponent {
   protected readonly unstagedFiles = computed(() =>
     this.files().filter((f) => !f.staged),
   );
+
+  protected readonly stagedTree = computed(() =>
+    buildFileTree(this.stagedFiles()),
+  );
+
+  protected readonly unstagedTree = computed(() =>
+    buildFileTree(this.unstagedFiles()),
+  );
+
+  protected readonly trackTreeNode = (
+    _index: number,
+    node: GitFileTreeNode,
+  ): string => node.key;
+
+  protected isFolderExpanded(section: string, path: string): boolean {
+    return this.expandedFolders().has(`${section}:${path}`);
+  }
+
+  protected toggleFolder(section: string, path: string): void {
+    const key = `${section}:${path}`;
+    const next = new Set(this.expandedFolders());
+    if (next.has(key)) next.delete(key);
+    else next.add(key);
+    this.expandedFolders.set(next);
+  }
+
+  protected folderListId(section: string, path: string): string {
+    const listId = section === 'staged' ? this.stagedListId : this.unstagedListId;
+    return `${listId}-folder-${encodeURIComponent(path)}`;
+  }
+
+  protected folderToggleLabel(name: string): string {
+    return `Toggle ${name} folder`;
+  }
 
   /**
    * Whether the commit button should be enabled.


### PR DESCRIPTION
## Summary

Repairs five defects reported against the git dock that replaced the editor surface.

1. **No folder hierarchy.** `git status --porcelain=v2` collapses an untracked directory into one row, so `.github`, `apps` and `libs` appeared as single `??` entries. The status call now enumerates untracked files, and the source-control panel renders a collapsible folder tree.
2. **Clicking a folder produced an error.** A directory row reached the diff path and the backend refused it with `is-a-directory`. A folder node now only expands or collapses.
3. **The split icon did nothing.** The diff view now honors the explicit layout choice, and the choice persists through `settings:get` / `settings:set`.
4. **Only one diff could be viewed, and none could be closed.** `DiffTabsService` already kept a tab list and a working `closeDiff`, but nothing in the app called it and the dock rendered only the active tab. The dock now has a tab strip with per-tab close buttons. Switching tabs activates without refetching.
5. **The `??` badge was unreadable.** It renders as `U`, and every status code carries a human-readable title.

## Test plan

- `npx nx run-many -t test -p @ptah-extension/git-ui @ptah-extension/vscode-core --skip-nx-cache` — 40 suites, 726 tests, all passing.
- `npx nx run-many -t test lint typecheck -p @ptah-extension/git-ui --skip-nx-cache` — all three targets green.

## Not yet done

Nobody has run the Electron app against this branch. Every defect was visual, so a manual check of the git dock is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61838946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/ptah-orchestra/-/pull-requests/hive-academy/ptah-extension/476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because the previously reported null-session compaction reload failure remains outstanding.

<details><summary><h3>Summary</h3></summary>

- Requests individual untracked files and renders them in collapsible folder trees.
- Adds selectable and closable diff tabs with keyboard navigation.
- Persists the side-by-side layout preference and prevents Monaco’s responsive override.
- Updates unit and Electron end-to-end coverage for the revised UI.
</details>

<!-- /greptile_comment -->