### PR TITLE
fix(harness): stop Apply to Workspace aborting when no CLAUDE.md exists

### DIFF
--- a/libs/backend/rpc-handlers/src/lib/harness/config/harness-config-store.service.spec.ts
+++ b/libs/backend/rpc-handlers/src/lib/harness/config/harness-config-store.service.spec.ts
@@ -1,0 +1,152 @@
+import 'reflect-metadata';
+
+jest.mock('os', () => {
+  const actual = jest.requireActual<typeof import('os')>('os');
+  return {
+    ...actual,
+    homedir: jest.fn(actual.homedir),
+  };
+});
+
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import type { HarnessConfig } from '@ptah-extension/shared';
+import { createMockLogger } from '@ptah-extension/shared/testing';
+import type { Logger } from '@ptah-extension/vscode-core';
+
+import { HarnessPromptBuilderService } from './harness-prompt-builder.service';
+import { HarnessConfigStore } from './harness-config-store.service';
+
+function harnessConfig(): HarnessConfig {
+  return {
+    name: 'test-harness',
+    persona: { label: '', description: '', goals: [] },
+    agents: {
+      enabledAgents: {
+        reviewer: {
+          enabled: true,
+          modelTier: 'sonnet',
+          autoApprove: false,
+        },
+      },
+    },
+    skills: { selectedSkills: [], createdSkills: [] },
+    prompt: { systemPrompt: '', enhancedSections: {} },
+    mcp: { servers: [], enabledTools: {} },
+    claudeMd: {
+      generateProjectClaudeMd: true,
+      customSections: {},
+      previewContent: '# New project instructions',
+    },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('HarnessConfigStore', () => {
+  let root: string;
+  let logger: ReturnType<typeof createMockLogger>;
+  let service: HarnessConfigStore;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'harness-config-store-'),
+    );
+    jest.mocked(os.homedir).mockReturnValue(root);
+    logger = createMockLogger();
+    service = new HarnessConfigStore(
+      logger as unknown as Logger,
+      new HarnessPromptBuilderService(),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  describe('writeClaudeMdToWorkspace', () => {
+    it('writes CLAUDE.md without creating a backup when none exists', async () => {
+      const result = await service.writeClaudeMdToWorkspace(
+        root,
+        harnessConfig(),
+      );
+
+      const claudeMdPath = path.join(root, '.claude', 'CLAUDE.md');
+      expect(result).toEqual({ claudeMdPath });
+      expect(result.backupPath).toBeUndefined();
+      await expect(fs.readFile(claudeMdPath, 'utf-8')).resolves.toBe(
+        '# New project instructions',
+      );
+      await expect(fs.access(`${claudeMdPath}.bak`)).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Wrote CLAUDE.md to workspace',
+        expect.objectContaining({ backedUp: false }),
+      );
+    });
+
+    it('backs up an existing CLAUDE.md before writing the new content', async () => {
+      const claudeDir = path.join(root, '.claude');
+      const claudeMdPath = path.join(claudeDir, 'CLAUDE.md');
+      const backupPath = `${claudeMdPath}.bak`;
+      await fs.mkdir(claudeDir, { recursive: true });
+      await fs.writeFile(claudeMdPath, '# Old instructions', 'utf-8');
+
+      const result = await service.writeClaudeMdToWorkspace(
+        root,
+        harnessConfig(),
+      );
+
+      expect(result).toEqual({ claudeMdPath, backupPath });
+      await expect(fs.readFile(backupPath, 'utf-8')).resolves.toBe(
+        '# Old instructions',
+      );
+      await expect(fs.readFile(claudeMdPath, 'utf-8')).resolves.toBe(
+        '# New project instructions',
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Wrote CLAUDE.md to workspace',
+        expect.objectContaining({ backedUp: true }),
+      );
+    });
+  });
+
+  describe('updatePtahSettings', () => {
+    it('creates missing settings.json with the harness keys', async () => {
+      await expect(
+        service.updatePtahSettings(harnessConfig()),
+      ).resolves.toBeUndefined();
+
+      const raw = await fs.readFile(
+        path.join(root, '.ptah', 'settings.json'),
+        'utf-8',
+      );
+      const settings = JSON.parse(raw) as Record<string, unknown>;
+      expect(settings['harness.agents']).toEqual({
+        reviewer: {
+          enabled: true,
+          modelTier: 'sonnet',
+          autoApprove: false,
+        },
+      });
+      expect(settings['harness.lastApplied']).toBe('test-harness');
+      expect(settings['harness.lastAppliedAt']).toEqual(expect.any(String));
+    });
+
+    it('does not overwrite malformed settings.json', async () => {
+      const settingsDir = path.join(root, '.ptah');
+      const settingsPath = path.join(settingsDir, 'settings.json');
+      await fs.mkdir(settingsDir, { recursive: true });
+      await fs.writeFile(settingsPath, '{ malformed', 'utf-8');
+
+      await expect(
+        service.updatePtahSettings(harnessConfig()),
+      ).rejects.toBeInstanceOf(SyntaxError);
+      await expect(fs.readFile(settingsPath, 'utf-8')).resolves.toBe(
+        '{ malformed',
+      );
+    });
+  });
+});

--- a/libs/backend/rpc-handlers/src/lib/harness/config/harness-config-store.service.ts
+++ b/libs/backend/rpc-handlers/src/lib/harness/config/harness-config-store.service.ts
@@ -62,10 +62,18 @@ export class HarnessConfigStore {
 
     const claudeMdPath = path.join(claudeDir, 'CLAUDE.md');
 
-    await fs.access(claudeMdPath);
-    const backupPath = claudeMdPath + '.bak';
-    await fs.copyFile(claudeMdPath, backupPath);
-    this.logger.info('Backed up existing CLAUDE.md', { backupPath });
+    let backupPath: string | undefined;
+    try {
+      await fs.access(claudeMdPath);
+      const candidateBackupPath = claudeMdPath + '.bak';
+      await fs.copyFile(claudeMdPath, candidateBackupPath);
+      backupPath = candidateBackupPath;
+      this.logger.info('Backed up existing CLAUDE.md', { backupPath });
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
     const content = config.claudeMd.previewContent
       ? config.claudeMd.previewContent
       : this.promptBuilder.buildClaudeMdContent(config);
@@ -75,10 +83,13 @@ export class HarnessConfigStore {
     this.logger.debug('Wrote CLAUDE.md to workspace', {
       path: claudeMdPath,
       contentLength: content.length,
-      backedUp: !!backupPath,
+      backedUp: Boolean(backupPath),
     });
 
-    return { claudeMdPath, backupPath };
+    return {
+      claudeMdPath,
+      ...(backupPath ? { backupPath } : {}),
+    };
   }
 
   /**
@@ -92,8 +103,14 @@ export class HarnessConfigStore {
 
     let existingSettings: Record<string, unknown> = {};
 
-    const raw = await fs.readFile(settingsPath, 'utf-8');
-    existingSettings = JSON.parse(raw) as Record<string, unknown>;
+    try {
+      const raw = await fs.readFile(settingsPath, 'utf-8');
+      existingSettings = JSON.parse(raw) as Record<string, unknown>;
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
     const agentConfig: Record<string, unknown> = {};
     for (const [agentId, override] of Object.entries(
       config.agents.enabledAgents,


### PR DESCRIPTION
## Summary

Clicking **Apply to Workspace** in the AI Team Builder failed with `ENOENT: no such file or directory, access '<ws>\.claude\CLAUDE.md'` in any workspace that had no existing `.claude/CLAUDE.md`. The whole apply aborted, so nothing was written at all — no preset, no CLAUDE.md, no subagents, no MCP servers.

`writeClaudeMdToWorkspace` called `fs.access` + `fs.copyFile` unconditionally. Both the doc comment ("If an existing CLAUDE.md is found, backs it up") and the optional `backupPath` in the return type say the backup was always meant to be conditional; the guard that made it so was missing.

`updatePtahSettings` had the same unguarded read against `~/.ptah/settings.json`, even though it initialises `existingSettings` to `{}`. That one is caught by `registerApply` and downgraded to a warning, so it only turned a first-run apply into a spurious "Failed to update settings.json".

Both guards match `ENOENT` only and rethrow everything else, so a malformed `settings.json` still surfaces rather than being silently overwritten.

## Test plan

New `harness-config-store.service.spec.ts` (4 tests, `os.homedir` redirected to a temp dir so no spec touches the real home):

- no existing CLAUDE.md → file written, no `.bak`, `backupPath` undefined, `backedUp: false`
- existing CLAUDE.md → `.bak` holds the old content, new content written, `backupPath` returned
- missing `settings.json` → does not throw, writes the harness keys
- malformed `settings.json` → throws, file left untouched

Verified on this branch:

- `nx run-many -t test -p @ptah-extension/rpc-handlers` — 93 suites, 2698 passed, 31 skipped
- `nx run-many -t typecheck -p @ptah-extension/rpc-handlers` — pass
- `nx run-many -t lint -p @ptah-extension/rpc-handlers` — 0 errors (19 pre-existing warnings, none in the changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61844325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/ptah-orchestra/-/pull-requests/hive-academy/ptah-extension/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge with no actionable changed-code defects identified.

<details><summary><h3>Summary</h3></summary>

- Conditionally backs up an existing workspace CLAUDE.md before writing generated instructions.
- Initializes missing global settings with harness configuration.
- Adds tests for missing, existing, and malformed-file behavior.
</details>

<!-- /greptile_comment -->