### PR TITLE
fix(ci): pass --repo so the uptime probe works without a checkout

### DIFF
--- a/.github/workflows/uptime-probe.yml
+++ b/.github/workflows/uptime-probe.yml
@@ -34,6 +34,15 @@ jobs:
       # that is the whole point. It exercises DNS, TLS, the caddy port bind and
       # the app's database connection the same way a paying customer does. Give
       # it droplet access and it starts proving something weaker.
+      #
+      # Having no checkout is why every `gh` call below passes an explicit
+      # `--repo "${GITHUB_REPOSITORY}"`. `gh` otherwise infers the target from
+      # the git remote in the working directory and dies with
+      # `failed to run git: fatal: not a git repository`. That is what the first
+      # two scheduled runs on main did (2026-09-08 21:42 and 23:41) — the health
+      # probe passed and the job still went red. Adding `actions/checkout` would
+      # also fix it and is the wrong trade: a clone per run, every 15 minutes,
+      # to recover one value already in the environment.
       - name: Probe the public health endpoint
         id: probe
         run: |
@@ -117,7 +126,7 @@ jobs:
           # recovery path below while the step reported success. Under
           # `set -e` a command substitution assignment does propagate.
           open_issues="$(
-            gh issue list --state open --limit 1000 --json number,title \
+            gh issue list --repo "${GITHUB_REPOSITORY}" --state open --limit 1000 --json number,title \
               --template '{{range .}}{{printf "%d\t%s\n" .number .title}}{{end}}'
           )"
 
@@ -133,18 +142,18 @@ jobs:
 
           if (( ${#matching_issues[@]} == 0 )); then
             issue_url="$(
-              gh issue create --title "${ISSUE_TITLE}" --body-file "${body_file}"
+              gh issue create --repo "${GITHUB_REPOSITORY}" --title "${ISSUE_TITLE}" --body-file "${body_file}"
             )"
             keeper_number="${issue_url##*/}"
           else
             keeper_number="${matching_issues[0]}"
-            gh issue edit "${keeper_number}" \
+            gh issue edit --repo "${GITHUB_REPOSITORY}" "${keeper_number}" \
               --title "${ISSUE_TITLE}" \
               --body-file "${body_file}"
           fi
 
           for duplicate_number in "${matching_issues[@]:1}"; do
-            gh issue close "${duplicate_number}" --reason 'not planned'
+            gh issue close --repo "${GITHUB_REPOSITORY}" "${duplicate_number}" --reason 'not planned'
           done
 
           echo "Outage recorded in issue #${keeper_number}."
@@ -159,7 +168,7 @@ jobs:
           # step above: a failed listing must fail this step, not read as
           # "nothing to close" and leave the outage issue open forever.
           open_issues="$(
-            gh issue list --state open --limit 1000 --json number,title \
+            gh issue list --repo "${GITHUB_REPOSITORY}" --state open --limit 1000 --json number,title \
               --template '{{range .}}{{printf "%d\t%s\n" .number .title}}{{end}}'
           )"
 
@@ -176,12 +185,12 @@ jobs:
           # Comment before closing so the issue keeps the recovery timestamp —
           # the gap between the open and this comment IS the outage duration.
           for issue_number in "${matching_issues[@]}"; do
-            gh issue comment "${issue_number}" --body "$(
+            gh issue comment --repo "${GITHUB_REPOSITORY}" "${issue_number}" --body "$(
               printf 'Recovered: `%s` returned `status: ok` / `database: connected` at %s.\n\nRun: %s/%s/actions/runs/%s' \
                 "${HEALTH_URL}" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
                 "${GITHUB_SERVER_URL}" "${GITHUB_REPOSITORY}" "${GITHUB_RUN_ID}"
             )"
-            gh issue close "${issue_number}" --reason 'completed'
+            gh issue close --repo "${GITHUB_REPOSITORY}" "${issue_number}" --reason 'completed'
             echo "Closed recovered outage issue #${issue_number}."
           done
 


### PR DESCRIPTION
The probe has run twice on main since it merged and failed both times, while api.ptah.live was healthy the whole while:

  failed to run git: fatal: not a git repository

The workflow deliberately has no actions/checkout — it is meant to be an unauthenticated external client. But `gh` infers its target repository from the git remote in the working directory, so with no clone every `gh issue` call dies. All seven now pass --repo "${GITHUB_REPOSITORY}".

Reproduced and verified outside a git repository: without --repo, gh prints the error above; with it, gh exits 0 and returns the listing, cross-checked against the REST API for the same count.

Adding actions/checkout would also fix it and is the wrong trade: a clone every 15 minutes to recover one value already in the environment.

Two things this did NOT break, worth recording. The health check itself works — the job reached the recovery step, which only runs when the API reports healthy. And the errexit hardening from the review round did its job: the step failed loudly instead of reporting success on an empty listing. Without it this monitor would have looked green while being completely blind, which is the exact failure it exists to prevent.

Refs TASK_2026_392

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=61889674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/ptah-orchestra/-/pull-requests/hive-academy/ptah-extension/481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge; the explicit repository flag fixes the checkout-free workflow’s GitHub CLI calls without changing probe or issue-management semantics.

<details><summary><h3>Summary</h3></summary>

- Adds `--repo "${GITHUB_REPOSITORY}"` to all outage and recovery issue commands.
- Documents why the workflow intentionally avoids checkout and requires explicit repository targeting.
</details>

<!-- /greptile_comment -->