### PR TITLE
fix(chat): move activity notifications into a floating toast

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -47,6 +47,7 @@ permissions:
 env:
   NODE_VERSION: 22
   NX_TUI: 'false'
+  VSCODE_E2E_VERSION: '1.137.0'
 
 jobs:
   publish:
@@ -194,7 +195,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: apps/ptah-extension-vscode-e2e/.vscode-test
-          key: vscode-test-${{ runner.os }}-stable
+          key: vscode-test-${{ runner.os }}-${{ runner.arch }}-${{ env.VSCODE_E2E_VERSION }}
 
       - name: Run VS Code E2E gate against the packaged dist
         run: xvfb-run --auto-servernum node apps/ptah-extension-vscode-e2e/src/runner.mjs

--- a/.github/workflows/vscode-e2e.yml
+++ b/.github/workflows/vscode-e2e.yml
@@ -43,6 +43,7 @@ env:
   # The publish-* workflows stay on 22 deliberately -- they match release targets.
   NODE_VERSION: 24
   NX_TUI: false
+  VSCODE_E2E_VERSION: '1.137.0'
 
 jobs:
   vscode-e2e:
@@ -102,7 +103,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: apps/ptah-extension-vscode-e2e/.vscode-test
-          key: vscode-test-${{ runner.os }}-stable
+          key: vscode-test-${{ runner.os }}-${{ runner.arch }}-${{ env.VSCODE_E2E_VERSION }}
 
       - name: Set NX SHAs
         uses: nrwl/nx-set-shas@v4

--- a/.ptah/specs/TASK_2026_405/context.md
+++ b/.ptah/specs/TASK_2026_405/context.md
@@ -1,0 +1,29 @@
+# Context
+
+## User intent
+
+The notification in the Electron header must move out of the navbar. It must
+render as a floating toaster near the top-right corner, close to its present
+position, but not inside the navbar. The navbar must show no layout shift.
+
+## Current implementation
+
+- Host: `libs/frontend/chat/src/lib/components/templates/electron-shell.component.ts:215`
+  renders `<ptah-activity-ticker [items]="activity.recent()" [idle]="activity.isIdle()" (activate)="openThoth()" />`
+  inside the navbar action cluster (`:212-222`). The navbar row is at `:92-223`.
+- Presentation: `libs/frontend/chat-ui/src/lib/molecules/activity-ticker/activity-ticker.component.ts`
+  — level dot at `:66`, message line at `:69-77`, `rotateMs` default 4000 at `:117`,
+  rotation timer at `:158-162`.
+- State: `libs/frontend/core/src/lib/services/back-office-activity.service.ts`
+  — ring capacity 50 (`:71`), coalesce window 750 ms (`:74`), idle after 8000 ms (`:77`).
+- Message source example: `libs/backend/thoth-runtime/src/lib/start-thoth-cron.ts:202`.
+
+## Notes for the implementer
+
+- `libs/frontend/ui` has no toast or overlay host today. Do not build a general
+  toast system for this task. A fixed-position element inside the Electron shell
+  template is enough.
+- CDK Overlay is not usable in the webview sandbox. The repository uses
+  Floating UI based primitives in `libs/frontend/ui/src/lib/native/`.
+- Keep `ActivityTickerComponent` presentational. Position belongs to the shell.
+- Angular rules apply: standalone, signals, `OnPush`.

--- a/.ptah/specs/TASK_2026_405/task.md
+++ b/.ptah/specs/TASK_2026_405/task.md
@@ -1,0 +1,53 @@
+---
+id: TASK_2026_405
+status: in_review
+type: feature
+title: Move the activity ticker out of the navbar into a floating toast
+description: >-
+  The back-office activity ticker renders inside the Electron navbar and changes
+  the width of the header row when a message arrives. Move it into a floating
+  toast overlay anchored to the top-right corner, above the navbar, so that the
+  navbar layout stays fixed.
+---
+
+# TASK_2026_405 — Activity toast
+
+## Problem
+
+`ActivityTickerComponent` is embedded in the navbar action cluster of
+`electron-shell.component.ts:215`. Each new activity message changes the width
+of the inline element and moves the tab strip. This is a layout shift in the
+header.
+
+## Goal
+
+Show the same activity messages as a floating toast at the top right of the
+window. The toast must not occupy space in the navbar.
+
+## Scope
+
+- `libs/frontend/chat/src/lib/components/templates/electron-shell.component.ts`
+- `libs/frontend/chat-ui/src/lib/molecules/activity-ticker/activity-ticker.component.ts`
+- The specs of both components.
+- `libs/frontend/webview-e2e-harness/src/lib/scenarios/thoth/activity-ticker.e2e.spec.ts`
+
+## Out of scope
+
+- `BackOfficeActivityService` state model and coalescing rules.
+- `ActivityEventPayload` wire contract.
+- The `thoth-runtime` emitters.
+- A general toast system for other features.
+
+## Acceptance criteria
+
+1. The navbar contains no activity element. The tab strip position does not
+   change when an activity message arrives.
+2. The toast floats over the content, anchored to the top-right corner, below
+   the navbar row.
+3. The toast keeps the current content: level dot, truncated summary, and the
+   click target that opens Thoth.
+4. The toast hides itself when `isIdle()` is true, and appears again on the next
+   message.
+5. The toast does not block clicks on the elements under it when it is hidden.
+6. `data-testid="activity-ticker-line"` still identifies the message line.
+7. Unit specs and the e2e scenario pass.

--- a/apps/ptah-extension-vscode-e2e/src/runner.mjs
+++ b/apps/ptah-extension-vscode-e2e/src/runner.mjs
@@ -14,6 +14,9 @@ import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const vscodeCachePath = path.resolve(__dirname, '..', '.vscode-test');
+const vscodeVersion = process.env.VSCODE_E2E_VERSION ?? 'stable';
+const vscodeDownloadTimeoutMs = 120_000;
 
 async function main() {
   const repoRoot = path.resolve(__dirname, '..', '..', '..');
@@ -71,6 +74,11 @@ async function main() {
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
+      version: vscodeVersion,
+      cachePath: vscodeCachePath,
+      // Idle timeout, not total download time. GitHub-hosted runners can take
+      // longer than the package default (15s) to receive the first CDN byte.
+      timeout: vscodeDownloadTimeoutMs,
       // PTAH_E2E=1 does two things inside the extension host:
       //   1. bootstrap.ts seeds a previousUserContext into (in-memory)
       //      globalState so activation takes the community path instead of

--- a/libs/frontend/chat-ui/src/lib/molecules/activity-ticker/activity-ticker.component.ts
+++ b/libs/frontend/chat-ui/src/lib/molecules/activity-ticker/activity-ticker.component.ts
@@ -13,8 +13,14 @@ import {
 import type { ActivityItem } from '@ptah-extension/core';
 
 /**
- * ActivityTickerComponent — the Electron header's back-office news line
- * (TASK_2026_380, component 14e).
+ * ActivityTickerComponent — the back-office news line (TASK_2026_380,
+ * component 14e).
+ *
+ * Purely presentational and unpositioned: it renders wherever its host puts
+ * it. Since TASK_2026_405 that host is the floating toast in
+ * `ElectronShellComponent`, not the navbar action cluster — the toast owns
+ * `position`, `z-index` and pointer-event handling, this component owns none
+ * of it.
  *
  * Shows one {@link ActivityItem} at a time and rotates through the list on a
  * timer, so a burst of background work reads as a sentence rather than a
@@ -27,8 +33,9 @@ import type { ActivityItem } from '@ptah-extension/core';
  * stylesheet rather than in TypeScript.
  *
  * When `idle()` is true the component collapses to a muted dot that is STILL a
- * click target and still in the DOM, so the fixed-height header never reflows
- * between busy and quiet.
+ * click target and still in the DOM. The toast host additionally drops the
+ * whole element while idle; this collapse is what a host that wants to keep
+ * the ticker mounted gets instead.
  */
 
 /** Human labels for the fallback when an emitter sent an empty summary. */

--- a/libs/frontend/chat/src/lib/components/templates/electron-shell.activity-toast.spec.ts
+++ b/libs/frontend/chat/src/lib/components/templates/electron-shell.activity-toast.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * ElectronShellComponent — activity-toast placement spec (TASK_2026_405).
+ *
+ * Pins the four things the move out of the navbar has to keep true, none of
+ * which `ActivityTickerComponent`'s own spec can see because that component is
+ * handed its inputs directly and knows nothing about where it is mounted:
+ *
+ * 1. no activity element inside the navbar row;
+ * 2. the toast is mounted outside that row, fixed and top-right;
+ * 3. the pass-through layer never takes pointer events, the card does;
+ * 4. idle removes the card and the next message brings it back.
+ *
+ * Testing strategy mirrors `chat-view.component.spec.ts`: stub `ngx-markdown`
+ * before the component import, then render the real template with every child
+ * except `ActivityTickerComponent` left as an unknown element
+ * (`CUSTOM_ELEMENTS_SCHEMA`). The ticker stays real because point 4 is about
+ * what it actually renders inside the card; instantiating the chat panel, the
+ * workspace sidebar or the git dock would only add failure modes.
+ */
+
+import {
+  Component,
+  Input,
+  NgModule,
+  ChangeDetectionStrategy,
+  CUSTOM_ELEMENTS_SCHEMA,
+  signal,
+} from '@angular/core';
+
+// Stub ngx-markdown (ESM-only bundle) BEFORE any component import.
+jest.mock('ngx-markdown', () => {
+  @Component({
+    // eslint-disable-next-line @angular-eslint/component-selector
+    selector: 'markdown',
+    standalone: true,
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    template: `<div data-test="markdown-stub">{{ data }}</div>`,
+  })
+  class MarkdownStubComponent {
+    @Input() data: string | null | undefined = '';
+  }
+
+  @NgModule({
+    imports: [MarkdownStubComponent],
+    exports: [MarkdownStubComponent],
+  })
+  class MarkdownModule {}
+
+  return {
+    MarkdownModule,
+    MarkdownComponent: MarkdownStubComponent,
+    provideMarkdown: () => [],
+    MARKED_OPTIONS: 'MARKED_OPTIONS',
+    CLIPBOARD_OPTIONS: 'CLIPBOARD_OPTIONS',
+    MARKED_EXTENSIONS: 'MARKED_EXTENSIONS',
+    MERMAID_OPTIONS: 'MERMAID_OPTIONS',
+    SANITIZE: 'SANITIZE',
+  };
+});
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  AppStateManager,
+  BackOfficeActivityService,
+  ElectronLayoutService,
+  VSCodeService,
+  type ActivityItem,
+} from '@ptah-extension/core';
+import { ActivityTickerComponent } from '@ptah-extension/chat-ui';
+import { ElectronShellComponent } from './electron-shell.component';
+
+function activityItem(id: string, summary: string): ActivityItem {
+  return {
+    id,
+    source: 'cron',
+    kind: 'cron-run',
+    summary,
+    timestamp: 1,
+    level: 'info',
+  };
+}
+
+describe('ElectronShellComponent — activity toast', () => {
+  let fixture: ComponentFixture<ElectronShellComponent>;
+  const items = signal<readonly ActivityItem[]>([]);
+  const idle = signal(true);
+
+  const layoutStub = {
+    hasWorkspaceFolders: () => true,
+    workspaceSidebarVisible: () => false,
+    workspaceSidebarWidth: () => 240,
+    editorPanelVisible: () => false,
+    editorPanelWidth: () => 320,
+    toggleWorkspaceSidebar: jest.fn(),
+    toggleEditorPanel: jest.fn(),
+    setSidebarDragging: jest.fn(),
+    setEditorDragging: jest.fn(),
+    setWorkspaceSidebarWidth: jest.fn(),
+    setEditorPanelWidth: jest.fn(),
+  };
+
+  const appStateStub = {
+    currentView: () => 'chat',
+    thothFirstRunDismissed: () => true,
+    setLayoutMode: jest.fn(),
+    setCurrentView: jest.fn(),
+    dismissThothFirstRun: jest.fn(),
+  };
+
+  const vscodeStub = {
+    getPtahIconUri: () => 'icon.png',
+    config: () => ({ platform: 'win32' }),
+  };
+
+  function navbar(): HTMLElement {
+    // The navbar row is the first child of the shell's flex column.
+    const row = fixture.nativeElement.querySelector('.h-10');
+    expect(row).toBeTruthy();
+    return row as HTMLElement;
+  }
+
+  function layer(): HTMLElement | null {
+    return fixture.nativeElement.querySelector(
+      '[data-testid="activity-toast-layer"]',
+    );
+  }
+
+  function card(): HTMLElement | null {
+    return fixture.nativeElement.querySelector('[data-testid="activity-toast"]');
+  }
+
+  beforeEach(async () => {
+    items.set([]);
+    idle.set(true);
+    appStateStub.setCurrentView.mockClear();
+
+    await TestBed.configureTestingModule({
+      imports: [ElectronShellComponent],
+      providers: [
+        { provide: ElectronLayoutService, useValue: layoutStub },
+        { provide: AppStateManager, useValue: appStateStub },
+        { provide: VSCodeService, useValue: vscodeStub },
+        {
+          provide: BackOfficeActivityService,
+          useValue: { recent: items, isIdle: idle },
+        },
+      ],
+    })
+      .overrideComponent(ElectronShellComponent, {
+        set: {
+          imports: [ActivityTickerComponent],
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ElectronShellComponent);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => fixture.destroy());
+
+  it('keeps every activity element out of the navbar row', () => {
+    idle.set(false);
+    items.set([activityItem('a', 'Backup finished')]);
+    fixture.detectChanges();
+
+    expect(card()).toBeTruthy();
+    expect(navbar().querySelector('ptah-activity-ticker')).toBeNull();
+    expect(
+      navbar().querySelector('[data-testid="activity-toast-layer"]'),
+    ).toBeNull();
+    expect(navbar().querySelector('[data-testid="activity-toast"]')).toBeNull();
+  });
+
+  it('anchors the toast top-right, fixed and above the content', () => {
+    const classes = layer()?.getAttribute('class') ?? '';
+
+    expect(classes).toContain('fixed');
+    expect(classes).toContain('top-11');
+    expect(classes).toContain('right-3');
+    expect(classes).toContain('z-50');
+  });
+
+  it('never lets the pass-through layer take clicks, but keeps the card clickable', () => {
+    // Idle: layer present, card gone — nothing under the corner is blocked.
+    expect(layer()?.getAttribute('class')).toContain('pointer-events-none');
+    expect(card()).toBeNull();
+
+    idle.set(false);
+    items.set([activityItem('a', 'Backup finished')]);
+    fixture.detectChanges();
+
+    // Busy: the layer is STILL pointer-events-none; only the card opts in.
+    expect(layer()?.getAttribute('class')).toContain('pointer-events-none');
+    expect(card()?.getAttribute('class')).toContain('pointer-events-auto');
+  });
+
+  it('hides the toast when idle and shows it again on the next message', () => {
+    expect(card()).toBeNull();
+
+    idle.set(false);
+    items.set([activityItem('a', 'Backup finished')]);
+    fixture.detectChanges();
+    expect(card()).toBeTruthy();
+
+    idle.set(true);
+    fixture.detectChanges();
+    expect(card()).toBeNull();
+
+    idle.set(false);
+    items.set([activityItem('b', 'Indexing 80%'), activityItem('a', 'Backup')]);
+    fixture.detectChanges();
+    expect(card()).toBeTruthy();
+  });
+
+  it('renders the ticker line inside the toast and opens Thoth when it is clicked', () => {
+    idle.set(false);
+    items.set([activityItem('a', 'Backup finished')]);
+    fixture.detectChanges();
+
+    const line = card()?.querySelector('[data-testid="activity-ticker-line"]');
+    expect(line?.textContent?.trim()).toBe('Backup finished');
+
+    card()?.querySelector('button')?.click();
+    expect(appStateStub.setCurrentView).toHaveBeenCalledWith('thoth');
+  });
+});

--- a/libs/frontend/chat/src/lib/components/templates/electron-shell.component.ts
+++ b/libs/frontend/chat/src/lib/components/templates/electron-shell.component.ts
@@ -85,6 +85,28 @@ import {
     .no-drag {
       -webkit-app-region: no-drag;
     }
+
+    /* Toast entry only — the ticker owns the per-line transition. */
+    .activity-toast {
+      animation: activityToastIn 160ms ease-out both;
+    }
+
+    @keyframes activityToastIn {
+      from {
+        opacity: 0;
+        transform: translateY(-6px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .activity-toast {
+        animation: none !important;
+      }
+    }
   `,
   template: `
     <div class="flex flex-col h-screen w-screen bg-base-100">
@@ -208,18 +230,45 @@ import {
         <!-- Spacer (right) -->
         <div class="flex-1"></div>
 
-        <!-- Global actions — theme only (navigation moved to pills) -->
+        <!-- Global actions — theme only (navigation moved to pills).
+             The back-office activity ticker used to sit here; it moved to the
+             floating toast below so an arriving message stops resizing this
+             cluster and shifting the tab strip (TASK_2026_405). -->
         <div class="flex items-center gap-0.5 no-drag">
-          <!-- Back-office activity. Before the toggle on purpose, so the
-               toggle keeps its far-right position. -->
-          <ptah-activity-ticker
-            [items]="activity.recent()"
-            [idle]="activity.isIdle()"
-            (activate)="openThoth()"
-          />
           <!-- Theme toggle (always available) -->
           <ptah-theme-toggle />
         </div>
+      </div>
+
+      <!--
+        Back-office activity toast (TASK_2026_405).
+
+        Fixed and out of flow, so the navbar row above keeps a constant width
+        no matter how long the current activity summary is. The outer layer is
+        the full-time click pass-through: it is pointer-events-none and stays
+        that way, so nothing under the top-right corner is ever blocked. Only
+        the rendered card opts back in with pointer-events-auto, which keeps
+        the ticker's own button clickable.
+
+        top-11 clears the h-10 navbar row by 4px. Positioning lives here, not
+        in ActivityTickerComponent, which stays presentational.
+      -->
+      <div
+        class="pointer-events-none fixed top-11 right-3 z-50 no-drag"
+        data-testid="activity-toast-layer"
+      >
+        @if (!activity.isIdle()) {
+          <div
+            class="activity-toast pointer-events-auto rounded-lg border border-base-content/10 bg-base-200/95 shadow-lg backdrop-blur-sm px-1 py-0.5"
+            data-testid="activity-toast"
+          >
+            <ptah-activity-ticker
+              [items]="activity.recent()"
+              [idle]="activity.isIdle()"
+              (activate)="openThoth()"
+            />
+          </div>
+        }
       </div>
 
       <!-- Content: Workspace gate → 3-panel layout -->
@@ -314,7 +363,7 @@ export class ElectronShellComponent {
   protected readonly layout = inject(ElectronLayoutService);
   private readonly vscodeService = inject(VSCodeService);
   protected readonly appState = inject(AppStateManager);
-  /** The header ticker's only source of items (TASK_2026_380). */
+  /** The floating activity toast's only source of items (TASK_2026_380). */
   protected readonly activity = inject(BackOfficeActivityService);
 
   /** Lazily loaded GitDockComponent — keeps xterm/monaco out of the initial bundle. */

--- a/libs/frontend/webview-e2e-harness/src/lib/scenarios/thoth/activity-ticker.e2e.spec.ts
+++ b/libs/frontend/webview-e2e-harness/src/lib/scenarios/thoth/activity-ticker.e2e.spec.ts
@@ -1,5 +1,5 @@
 /**
- * E2E: the back-office activity ticker in the Electron shell header
+ * E2E: the back-office activity ticker in the Electron shell
  * (TASK_2026_380, Task 5.1 — the second of the two cases Batch 4 deferred,
  * D-6 in `batch-4-report.md`).
  *
@@ -8,9 +8,14 @@
  * tests (component 14e) pin the rotation/idle-collapse behaviour against
  * inputs it is handed directly. Neither proves the wiring in
  * `electron-shell.component.ts` — the service injected and
- * `<ptah-activity-ticker>` placed in the header immediately before
- * `<ptah-theme-toggle />` — actually carries a real `activity:event` push
- * from the message router into the rendered ticker line.
+ * `<ptah-activity-ticker>` mounted in the floating toast — actually carries a
+ * real `activity:event` push from the message router into the rendered
+ * ticker line.
+ *
+ * Since TASK_2026_405 the ticker is NOT in the navbar: it renders inside the
+ * fixed `[data-testid="activity-toast"]` card, and the whole toast is absent
+ * from the DOM while the service reports idle. The assertions below therefore
+ * check both the line text and that the navbar row holds no activity element.
  *
  * Uses the REAL `ptah-extension-webview` Angular bundle, following the
  * pattern (and the `isElectron: true` `ptahConfig` justification) in
@@ -116,12 +121,17 @@ test.describe('webview > thoth > activity ticker', () => {
     await installRpcAutoResponder(page, RPC_FIXTURES);
     await page.goto(fixtureServer.url);
 
-    // Idle by default (empty ring) — the ticker collapses to the muted dot
-    // and the line itself is not rendered until an item exists
-    // (`activity-ticker.component.ts` idle collapse).
+    // Idle by default (empty ring) — the toast is not in the DOM at all, so
+    // neither the card nor the line exists yet (TASK_2026_405).
+    await expect(page.locator('[data-testid="activity-toast"]')).toHaveCount(0);
     await expect(
       page.locator('[data-testid="activity-ticker-line"]'),
     ).toHaveCount(0);
+
+    // The pass-through layer is always mounted and never takes clicks.
+    const layer = page.locator('[data-testid="activity-toast-layer"]');
+    await expect(layer).toHaveCount(1);
+    await expect(layer).toHaveCSS('pointer-events', 'none');
 
     await bridge.inject({
       type: 'activity:event',
@@ -136,5 +146,35 @@ test.describe('webview > thoth > activity ticker', () => {
     const line = page.locator('[data-testid="activity-ticker-line"]');
     await expect(line).toBeVisible();
     await expect(line).toContainText('Backup finished');
+
+    // The visible card opts back into pointer events, so it stays clickable.
+    await expect(page.locator('[data-testid="activity-toast"]')).toHaveCSS(
+      'pointer-events',
+      'auto',
+    );
+
+    // AC 1: the ticker no longer lives inside the navbar row, so the tab
+    // strip cannot be pushed by a long summary.
+    await expect(
+      page.locator('[role="tablist"] [data-testid="activity-ticker-line"]'),
+    ).toHaveCount(0);
+    const tabStrip = page.locator('[role="tablist"]');
+    const beforeBox = await tabStrip.boundingBox();
+
+    await bridge.inject({
+      type: 'activity:event',
+      payload: {
+        source: 'cron',
+        kind: 'backup:daily',
+        summary:
+          'A considerably longer activity summary that would previously have widened the navbar action cluster',
+        timestamp: Date.now(),
+      },
+    });
+    await expect(line).toContainText('considerably longer');
+
+    const afterBox = await tabStrip.boundingBox();
+    expect(afterBox?.x).toBe(beforeBox?.x);
+    expect(afterBox?.width).toBe(beforeBox?.width);
   });
 });

--- a/libs/frontend/webview-e2e-harness/src/lib/scenarios/thoth/activity-ticker.e2e.spec.ts
+++ b/libs/frontend/webview-e2e-harness/src/lib/scenarios/thoth/activity-ticker.e2e.spec.ts
@@ -158,7 +158,7 @@ test.describe('webview > thoth > activity ticker', () => {
     await expect(
       page.locator('[role="tablist"] [data-testid="activity-ticker-line"]'),
     ).toHaveCount(0);
-    const tabStrip = page.locator('[role="tablist"]');
+    const tabStrip = page.locator('[role="tablist"].electron-tabs');
     const beforeBox = await tabStrip.boundingBox();
 
     await bridge.inject({


### PR DESCRIPTION
## Summary
- Move the Electron activity ticker out of the navbar into a fixed top-right toast below the header, preventing messages from shifting navigation.
- Preserve ticker content, rotation, and click-to-open-Thoth behavior; hide the card while idle and keep the surrounding layer click-through.
- Add reduced-motion support, five shell unit tests, browser layout assertions, and TASK_2026_405 documentation.

## Test plan
- [x] Chat and chat-ui unit suites passed using Nx run-many (both projects); chat: 66 suites, 1,035 passed, 2 skipped; chat-ui: 25 suites, 152 passed.
- [x] Typecheck passed for chat and chat-ui (implementation agent run).
- [x] Lint passed for affected projects (implementation agent run; existing warnings remain).
- [x] git diff --check passed.
- [ ] Run updated Playwright scenario / visual verification. Webview build prerequisite failed on daisyui/prismjs style imports; browser assertions have not been executed.

The unit-test rerun emitted a worker teardown warning despite passing; its cause has not been established. Task remains in_review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves Electron activity notifications from the navbar into a fixed, click-through toast while retaining ticker content and navigation behavior.
- Adds conditional toast mounting, entry animation, and reduced-motion handling.
- Adds shell unit coverage and updates browser layout assertions.
- Pins the VS Code E2E runtime and versions its download cache key.
- Documents the activity-toast task and acceptance criteria.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/frontend/chat/src/lib/components/templates/electron-shell.component.ts | Relocates the activity ticker into a conditionally rendered fixed toast with click-through layering and reduced-motion support. |
| libs/frontend/chat/src/lib/components/templates/electron-shell.activity-toast.spec.ts | Covers placement outside the navbar, pointer-event behavior, idle visibility, ticker content, and navigation activation. |
| libs/frontend/webview-e2e-harness/src/lib/scenarios/thoth/activity-ticker.e2e.spec.ts | Updates browser assertions for toast visibility, click handling, and stable navbar geometry. |
| apps/ptah-extension-vscode-e2e/src/runner.mjs | Configures an explicit VS Code version, cache path, and download timeout for the E2E runner. |
| .github/workflows/vscode-e2e.yml | Pins the E2E VS Code version and scopes the cached runtime by platform architecture and version. |
| .github/workflows/publish-extension.yml | Applies the same pinned E2E runtime and versioned cache policy to the release gate. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Host as Activity event source
  participant Service as BackOfficeActivityService
  participant Shell as ElectronShellComponent
  participant Toast as Activity toast
  participant Thoth as Thoth view
  Host->>Service: activity:event
  Service-->>Shell: recent() and isIdle() update
  alt Activity is active
    Shell->>Toast: Mount fixed top-right ticker
    Toast-->>Toast: Rotate recent activity lines
    Toast->>Thoth: Open on activation
  else Activity is idle
    Shell->>Toast: Remove toast card
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): prevent VS Code E2E download ti..."](https://github.com/hive-academy/ptah-extension/commit/1fa224c63b7979f38a48a34c119f36d742b6fbb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62111132)</sub>

<!-- /greptile_comment -->