### PR TITLE
fix(worktrees): keep agent checkouts in the background

### DIFF
--- a/.claude/agents/backend-developer.md
+++ b/.claude/agents/backend-developer.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/code-logic-reviewer.md
+++ b/.claude/agents/code-logic-reviewer.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/code-style-reviewer.md
+++ b/.claude/agents/code-style-reviewer.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/frontend-developer.md
+++ b/.claude/agents/frontend-developer.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/modernization-detector.md
+++ b/.claude/agents/modernization-detector.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/project-manager.md
+++ b/.claude/agents/project-manager.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/researcher-expert.md
+++ b/.claude/agents/researcher-expert.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/senior-tester.md
+++ b/.claude/agents/senior-tester.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/software-architect.md
+++ b/.claude/agents/software-architect.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/team-leader.md
+++ b/.claude/agents/team-leader.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/technical-content-writer.md
+++ b/.claude/agents/technical-content-writer.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/ui-ux-designer.md
+++ b/.claude/agents/ui-ux-designer.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/video-director.md
+++ b/.claude/agents/video-director.md
@@ -45,9 +45,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.claude/agents/visual-reviewer.md
+++ b/.claude/agents/visual-reviewer.md
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/backend-developer.toml
+++ b/.codex/agents/backend-developer.toml
@@ -43,9 +43,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/code-logic-reviewer.toml
+++ b/.codex/agents/code-logic-reviewer.toml
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/code-style-reviewer.toml
+++ b/.codex/agents/code-style-reviewer.toml
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/devops-engineer.toml
+++ b/.codex/agents/devops-engineer.toml
@@ -43,9 +43,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/frontend-developer.toml
+++ b/.codex/agents/frontend-developer.toml
@@ -36,12 +36,13 @@ Stop before writing if the plan or handoff leaves two or more materially differe
 
 Otherwise, proceed — a question you can answer by reading code is work, not a blocker.
 
-## Task specs folder (`TASK_YYYY_NNN/`)
+## Task specs folder (`TASK_YYYY_NNN_xxxx/`)
 
 - `task.md` carries frontmatter (`status`, `type`, `title`) and a pointer. Folder name is the canonical ID.
 - To change status, `Edit` only the `status:` line. Never `Write` the whole file — Ptah co-writes it.
 - `description` and any `title` with a colon MUST use `>-` block scalar syntax, else the file becomes unparseable and the task vanishes.
 - `context.md` holds narrative and intent. `batches.md` holds the implementation breakdown — different file from `task.md`.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`, then `git ls-tree`), every path from `git worktree list`, and the local folder. Take the highest `NNN` for the current year, add one, zero-pad to at least three digits, and append an underscore plus four random lowercase hex characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive, fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md` — it is generated and can be stale. Never rename an existing folder.
 
 ## Code discipline
 

--- a/.codex/agents/modernization-detector.toml
+++ b/.codex/agents/modernization-detector.toml
@@ -43,9 +43,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/project-manager.toml
+++ b/.codex/agents/project-manager.toml
@@ -43,9 +43,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/researcher-expert.toml
+++ b/.codex/agents/researcher-expert.toml
@@ -43,9 +43,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/senior-tester.toml
+++ b/.codex/agents/senior-tester.toml
@@ -43,9 +43,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/software-architect.toml
+++ b/.codex/agents/software-architect.toml
@@ -43,9 +43,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/team-leader.toml
+++ b/.codex/agents/team-leader.toml
@@ -43,9 +43,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/technical-content-writer.toml
+++ b/.codex/agents/technical-content-writer.toml
@@ -43,9 +43,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/ui-ux-designer.toml
+++ b/.codex/agents/ui-ux-designer.toml
@@ -43,9 +43,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/video-director.toml
+++ b/.codex/agents/video-director.toml
@@ -43,9 +43,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.codex/agents/visual-reviewer.toml
+++ b/.codex/agents/visual-reviewer.toml
@@ -44,9 +44,13 @@ empty when you do.
 - `description` (and any `title` containing a colon) MUST be a `>-` block
   scalar. A plain YAML scalar ends at the first colon-space, so one quoted code
   snippet makes the carrier unparseable and the task vanishes from the board.
-- Allocate a new id by scanning `.ptah/specs/TASK_*` on disk: highest `NNN`
-  for the current year, plus one, zero-padded to three digits. Never read the id
-  from `registry.md` — it is generated and can be stale.
+- Allocate a new id by scanning `.ptah/specs` on `origin/main` (run `git fetch`,
+  then `git ls-tree`), every path from `git worktree list`, and the local folder.
+  Take the highest `NNN` for the current year, add one, zero-pad to at least
+  three digits, and append an underscore plus four random lowercase hex
+  characters (`TASK_YYYY_NNN_xxxx`). Claim the folder with an exclusive,
+  fail-if-exists `mkdir`; it is the lock. Never read the id from `registry.md`
+  — it is generated and can be stale. Never rename an existing folder.
 - Only these documents are read from a task folder: `context.md`, `task-description.md`, `implementation-plan.md`, `batches.md`, `test-report.md`, `testing-infrastructure-escalation.md`, `code-style-review.md`, `code-logic-review.md`, `visual-review.md`, `visual-design-specification.md`, `design-handoff.md`, `design-assets-inventory.md`, `content-specification.md`, `research-report.md`, `future-enhancements.md`, plus `tasks.md`. Any other name is not picked up.
 
 ## Clarifications: return them, do not ask

--- a/.ptah/specs/TASK_2026_397/task.md
+++ b/.ptah/specs/TASK_2026_397/task.md
@@ -1,5 +1,5 @@
 ---
-status: in_review
+status: done
 type: bugfix
 title: 'A ptah-cli resume discards the user typed follow-up message'
 description: >-
@@ -18,9 +18,7 @@ description: >-
 
 ```ts
 const isResume = !!options?.resumeSessionId;
-const effectivePrompt = isResume
-  ? 'Continue working on the previous task. Pick up where you left off.'
-  : task;
+const effectivePrompt = isResume ? 'Continue working on the previous task. Pick up where you left off.' : task;
 ```
 
 `effectivePrompt` reaches `createPromptMailbox` at line 688 and the SDK `query`
@@ -59,11 +57,11 @@ disagreement they caused is the useful part.
 There is no empty-task case. `task` is non-empty on every path that can reach
 `PtahCliRegistry.spawnAgent`:
 
-| Entry point | Guard |
-| ----------- | ----- |
-| `agent:resumeCliSession` RPC | `agent-rpc.schema.ts` — `task: z.string().min(1)` |
-| MCP `ptah_agent_spawn` | `mcp-stdio/agent-tool.dispatcher.ts:48` — `task: z.string().min(1).max(MAX_TASK_LENGTH)` |
-| The follow-up box itself | `agent-continue-input.component.ts:166` — `submit()` returns on `message.length === 0` |
+| Entry point                  | Guard                                                                                    |
+| ---------------------------- | ---------------------------------------------------------------------------------------- |
+| `agent:resumeCliSession` RPC | `agent-rpc.schema.ts` — `task: z.string().min(1)`                                        |
+| MCP `ptah_agent_spawn`       | `mcp-stdio/agent-tool.dispatcher.ts:48` — `task: z.string().min(1).max(MAX_TASK_LENGTH)` |
+| The follow-up box itself     | `agent-continue-input.component.ts:166` — `submit()` returns on `message.length === 0`   |
 
 `spawnAgent` is an internal method behind two validated boundaries, so an
 empty-string fallback would be exactly the defensive branch the repo standard

--- a/.ptah/specs/TASK_2026_399/task.md
+++ b/.ptah/specs/TASK_2026_399/task.md
@@ -1,5 +1,5 @@
 ---
-status: in_review
+status: done
 type: bugfix
 title: 'The follow-up box hides on continuation support when resume would serve'
 description: >-
@@ -28,15 +28,15 @@ capabilities and the box conflates them.
 
 ## Capability by adapter
 
-| CLI | `supportsContinuation` | source | resume mechanism |
-| --- | ---------------------- | ------ | ---------------- |
-| codex | `() => true` | `codex-cli.adapter.ts:737` | `codex.resumeThread` |
-| cursor | `() => true` | `cursor-cli.adapter.ts:386` | `sdk.Agent.resume` |
-| ptah-cli | `() => true` | `ptah-cli-registry.ts:821` | SDK `resume` option |
-| copilot | `() => capturedSessionId != null` | `copilot-sdk.adapter.ts:453` | `--resume=<id>` |
-| pi | `() => capturedSessionId != null` | `pi-cli.adapter.ts:505` | `--session <id>` |
-| **antigravity** | **never declared** | — | `--conversation <id>` (`antigravity-cli.adapter.ts:462`) |
-| **opencode** | **never declared** | — | `--session <id>` (`opencode-cli.adapter.ts:411`) |
+| CLI             | `supportsContinuation`            | source                       | resume mechanism                                         |
+| --------------- | --------------------------------- | ---------------------------- | -------------------------------------------------------- |
+| codex           | `() => true`                      | `codex-cli.adapter.ts:737`   | `codex.resumeThread`                                     |
+| cursor          | `() => true`                      | `cursor-cli.adapter.ts:386`  | `sdk.Agent.resume`                                       |
+| ptah-cli        | `() => true`                      | `ptah-cli-registry.ts:821`   | SDK `resume` option                                      |
+| copilot         | `() => capturedSessionId != null` | `copilot-sdk.adapter.ts:453` | `--resume=<id>`                                          |
+| pi              | `() => capturedSessionId != null` | `pi-cli.adapter.ts:505`      | `--session <id>`                                         |
+| **antigravity** | **never declared**                | —                            | `--conversation <id>` (`antigravity-cli.adapter.ts:462`) |
+| **opencode**    | **never declared**                | —                            | `--session <id>` (`opencode-cli.adapter.ts:411`)         |
 
 Every adapter accepts a resume id. Two of them can never show a follow-up box.
 Two more hide it whenever their session id was not captured.

--- a/.ptah/specs/TASK_2026_400/agent-output-backend.md
+++ b/.ptah/specs/TASK_2026_400/agent-output-backend.md
@@ -1,0 +1,88 @@
+## Backend implementation — `TASK_2026_391`, batch 5 review remediation
+
+**Tasks completed**: Replaced the rejected per-model context field with one dedicated resume-level `contextSnapshot`, aligned its token formula with live streaming, and isolated it from aggregate-cost ranking and agent usage.
+
+**Files**:
+
+- MODIFIED `D:/projects/ptah-extension/libs/backend/agent-sdk/src/lib/session-history-reader.service.ts` — returns the globally latest valid post-boundary main-session assistant context snapshot.
+- MODIFIED `D:/projects/ptah-extension/libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts` — proves latest-model selection, agent isolation, post-compaction selection, and output-token exclusion.
+- MODIFIED `D:/projects/ptah-extension/libs/shared/src/lib/types/rpc/rpc-chat.types.ts` — declares optional `stats.contextSnapshot: { model; contextTokens }` and removes the rejected `modelUsageList.lastTurnContextTokens` field.
+
+### Root cause and corrected contract
+
+Before Batch 5, `chat:resume` returned aggregate token/cost data only. The first implementation attached `lastTurnContextTokens` to every `modelUsageList` entry. Review correctly rejected that shape because `modelUsageList` is cost-ranked aggregate data: selecting its first entry can select an older or agent-heavy model rather than the globally latest root-session context.
+
+The remediated contract is a separate optional `stats.contextSnapshot` at `rpc-chat.types.ts:268-271`. `SessionHistoryReaderService` declares the same result shape at lines 150-153 and 671-674 and emits it at line 882. The old per-model field is absent from all three owned files.
+
+`aggregateUsageStats()` starts from the existing post-last-`compact_boundary` main-message slice. While walking those main messages in transcript order, each valid assistant usage frame replaces the prior snapshot (`session-history-reader.service.ts:786-793`). Its model uses the same resolved model key as per-model accounting. The formula matches live `StreamTransformer` semantics exactly:
+
+```text
+contextTokens = input + cacheRead + cacheCreation
+```
+
+Output tokens are intentionally excluded. Agent-session loops continue contributing to aggregate tokens, cost, and `modelUsageList`, but never read or write `contextSnapshot`. If no valid post-boundary main assistant frame with a model exists, the optional snapshot is omitted so the frontend can render an honest unknown state.
+
+All cumulative aggregate behavior remains on its original paths: top-level token totals, per-model input/output totals, costs, primary-model selection, message count, and agent-session count are unchanged.
+
+### Red then green evidence
+
+Tests were changed before production code. The initial runtime-red focused run was:
+
+```text
+npx nx test @ptah-extension/agent-sdk --runInBand --testPathPattern=session-history-reader.service.spec.ts
+Test Suites: 1 failed, 1 skipped, 85 passed, 86 of 87 total
+Tests:       2 failed, 2 skipped, 1439 passed, 1443 total
+```
+
+Both new assertions failed because `contextSnapshot` was absent. The received payload also demonstrated why the rejected design was unsafe: `modelUsageList[0]` was `gpt-4o` due to dominant aggregate cost while the globally latest main turn used `gpt-4o-mini`; the old fields included output in context (`11,400` instead of the required `11,000`, and `11,016` instead of `10,816`). No pre-existing test was weakened.
+
+The final independent regression cases are:
+
+- `uses the globally latest main-session model for the context snapshot regardless of aggregate cost` (`session-history-reader.service.spec.ts:332`)
+- `never lets agent usage select or overwrite the main-session context snapshot` (`session-history-reader.service.spec.ts:402`)
+- `uses the live input plus cache formula for the latest post-compaction context snapshot` (`session-history-reader.service.spec.ts:473`)
+
+The final focused run was green:
+
+```text
+NX   Successfully ran target test for project @ptah-extension/agent-sdk
+Test Suites: 1 skipped, 86 passed, 86 of 87 total
+Tests:       2 skipped, 1442 passed, 1444 total
+Snapshots:   0 total
+```
+
+### Verification
+
+```text
+npx nx run-many -t typecheck -p @ptah-extension/agent-sdk @ptah-extension/shared
+NX   Running target typecheck for 2 projects:
+- @ptah-extension/agent-sdk
+- @ptah-extension/shared
+NX   Successfully ran target typecheck for 2 projects
+```
+
+```text
+npx nx run-many -t lint -p @ptah-extension/agent-sdk @ptah-extension/shared --parallel=2
+NX   Running target lint for 2 projects:
+- @ptah-extension/agent-sdk
+- @ptah-extension/shared
+NX   Successfully ran target lint for 2 projects
+```
+
+Lint produced zero errors and only repository-pre-existing warnings (38 in `agent-sdk`, 2 in `shared`); none point to the changed files.
+
+```text
+npx nx test @ptah-extension/shared --runInBand
+NX   Successfully ran target test for project @ptah-extension/shared
+Test Suites: 55 passed, 55 total
+Tests:       1310 passed, 1310 total
+Snapshots:   0 total
+```
+
+The initial combined `npx nx run-many -t test lint ...` attempt reached the 180-second command timeout without returning target output, so it was not reported as a result; the targets were rerun separately as shown above. `git diff --check` passed.
+
+**Stack observed**: TypeScript 5.9 strict, Nx 22.6, tsyringe backend services, shared compile-time RPC contracts, and existing SDK JSONL usage extraction. Sources: root `package.json`, root `CLAUDE.md`, and `libs/backend/agent-sdk/CLAUDE.md`.
+
+**Plan deviations**: The review remediation intentionally supersedes the first per-model design. No RPC method or namespace changed, so `ALLOWED_METHOD_PREFIXES` remains untouched.
+
+**Out-of-scope observations**: Existing lint warnings, Jest ESM-config warnings, and the combined-run timeout were not caused by these files. No frontend or non-resume session-stats contract was edited.

--- a/.ptah/specs/TASK_2026_400/agent-output-frontend-developer.md
+++ b/.ptah/specs/TASK_2026_400/agent-output-frontend-developer.md
@@ -1,0 +1,286 @@
+# TASK_2026_391 Batch 4 — frontend developer report
+
+## Outcome
+
+Fixed and reproduced the remaining Electron in-place compaction reload race.
+The Batch 1 tab target was correct. The target still retained an older
+pending/deferred `BatchedUpdateService` write from the live `/compact` stream.
+`finalizeSessionHistory()` flushed that queue after replay, allowing the stale
+two-user-message state to replace the newer replay state immediately before
+the finalizer read it.
+
+The minimal production fix clears queued writes for the exact resolved target
+tab before `applyResumingSession`. Untargeted close/reopen behavior is
+unchanged. Batch 1 targeting, pair-keyed in-flight identity, `fanOut: false`,
+and all `[compaction-diag]` logging remain intact.
+
+## Root cause and line evidence
+
+- Live event mutations go through the real batching queue in
+  `libs/frontend/chat-streaming/src/lib/batched-update.service.ts:84-93`.
+  Hidden/non-visible target writes are retained in `deferredTabUpdates`.
+- `applyCompactionComplete` clears the tab's visible transcript/state at
+  `libs/frontend/chat-state/src/lib/tab-manager.service.ts:1730`, but it does
+  not own or clear the streaming library's queue.
+- The targeted reload installs a fresh empty replay state through
+  `applyResumingSession` at
+  `libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts:591`.
+  Replay still writes to the explicit primary tab through
+  `StreamingHandlerService.processEventForTab` at
+  `libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts:184`;
+  `fanOut: false` only suppresses siblings at line 191.
+- `MessageFinalizationService.finalizeSessionHistory` calls the unscoped
+  `flushSync()` before reading the tab at
+  `libs/frontend/chat-streaming/src/lib/message-finalization.service.ts:210`.
+  `flushSync` moves deferred entries into `pendingTabUpdates` at
+  `batched-update.service.ts:186-196`. For the same tab ID, the old deferred
+  live state overwrites the newer replay pending state. The finalizer therefore
+  sees only the two compaction user stubs and has no assistant tree to promote.
+- Close/reopen renders because `StreamRouter` already invokes
+  `clearPendingUpdates(evt.tabId)` at
+  `libs/frontend/chat-routing/src/lib/stream-router.service.ts:955` before the
+  later untargeted load. An in-place reload does not pass through close
+  teardown.
+- The fix exposes the same target-scoped deletion through
+  `StreamingHandlerService.clearPendingUpdates` at
+  `libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts:76-77`
+  and calls it only when `targetTabId` exists at
+  `session-loader.service.ts:588-590`, immediately before resume
+  initialization.
+
+## Required path audit
+
+- The targeted path does call `applyResumingSession`; it was not skipped.
+- The explicit target is processed as `primaryTab` even with `fanOut: false`.
+- The `session:compactionComplete` push only stamps completion/marker state;
+  it does not invoke a second reload. The in-stream `compaction_complete`
+  result is the reload trigger.
+- Stream-exit `markTabIdle` clears spinner/abort state, not transcript
+  messages. It does not overwrite the replay. The overwrite occurs earlier in
+  the frontend batching flush.
+- The untargeted path works because closing the tile clears its queued writes;
+  the targeted in-place path previously omitted that teardown step.
+
+## Genuine composed regression: RED then GREEN
+
+The regression is at
+`libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts:1221`.
+It uses the real `SessionLoaderService`, `TabManagerService`,
+`BatchedUpdateService`, `StreamingHandlerService`,
+`StreamingAccumulatorCore`, `EventDeduplicationService`,
+`MessageFinalizationService`, and `SessionManager`. Only peripheral RPC/UI
+dependencies and the execution-tree builder are deterministic doubles.
+
+The test processes the exact two stub user messages through the real streaming
+handler while the document is hidden, proving an actual deferred target entry
+exists with `hasPendingUpdates(targetTabId)`. It then makes the document visible
+without firing the queue's drain event, executes the actual
+`switchSession(sessionId, { reason: 'compaction', targetTabId })`, replays valid
+user and assistant events, and asserts the real target `TabState.messages`
+contains the restored assistant text and neither stub.
+
+The earlier local-boolean/local-map test rejected by independent review was
+deleted. It was a Batch 4 test, not a Batch 1 test. No Batch 1 test or assertion
+was weakened or removed.
+
+### RED — production cleanup removed only
+
+Command:
+
+```text
+npx nx test @ptah-extension/chat --runInBand --testPathPatterns=session-loader.service.spec.ts
+```
+
+Verbatim failure:
+
+```text
+FAIL chat libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts
+  ● SessionLoaderService targeted replay with the real streaming state pipeline › discards a deferred live compaction state before replaying assistant history into that exact tab
+
+    expect(received).toEqual(expected) // deep equality
+
+    - Expected  - 1
+    + Received  + 1
+
+      Array [
+        "user",
+    -   "assistant",
+    +   "user",
+      ]
+
+      1376 |
+      1377 |     const target = tabManager.tabs().find((tab) => tab.id === targetTabId);
+    > 1378 |     expect(target?.messages.map((message) => message.role)).toEqual([
+           |                                                             ^
+      1379 |       'user',
+      1380 |       'assistant',
+      1381 |     ]);
+
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 2 skipped, 33 passed, 36 total
+Snapshots:   0 total
+Time:        4.149 s
+Ran all test suites matching session-loader.service.spec.ts.
+```
+
+This is the real failure mode: after actual replay and actual finalization, the
+target contains two users (the two stale stubs) and no assistant.
+
+### GREEN — target cleanup restored
+
+Command:
+
+```text
+npx nx test @ptah-extension/chat --runInBand --testPathPatterns=session-loader.service.spec.ts --skipNxCache
+```
+
+Verbatim result:
+
+```text
+NX   Successfully ran target test for project @ptah-extension/chat
+
+Test Suites: 1 passed, 1 total
+Tests:       2 skipped, 34 passed, 36 total
+Snapshots:   0 total
+Time:        4.033 s
+Ran all test suites matching session-loader.service.spec.ts.
+```
+
+## Production/test files
+
+- `libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts`
+  — target-only queue cleanup immediately before resume reset.
+- `libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts`
+  — facade for the existing target-scoped batching cleanup.
+- `libs/frontend/chat-streaming/src/lib/streaming-handler.service.spec.ts`
+  — facade delegation coverage (absorbed into shared HEAD externally).
+- `libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts`
+  — genuine composed queue/replay/finalization regression; removed the
+  constructed local-map test.
+- `.ptah/specs/TASK_2026_391/agent-output-frontend-developer.md` — this report.
+
+`libs/frontend/chat-streaming/src/lib/agent-monitor.store.ts` was not touched.
+
+## Secondary CTX status
+
+Not changed because it is not the same root cause. The batching queue contains
+only `StreamingState`; it cannot change lifetime `preloadedStats.tokens` or the
+context gauge source. `TOKENS 896.3k` is lifetime/cumulative data, while CTX
+must use a post-compaction context snapshot. Fixing that needs a separate
+ordering regression spanning session stats, compaction marker state, and resume
+stats. Blanket zeroing of lifetime tokens was not reintroduced.
+
+## Adjacent findings deliberately not fixed
+
+Independent logic review found two separate pre-existing issues:
+
+1. A conversation-bound fan-out tab with `claudeSessionId === null` can be
+   selected by lifecycle fallback and then rejected by the loader's strict
+   ownership check (`compaction-lifecycle.service.ts:388-415` versus
+   `session-loader.service.ts:740-747`).
+2. If `session:load` or `chat:resume` fails after the lifecycle clears the tab,
+   the catch logs the failure but does not roll back the transcript or expose
+   an in-UI retry (`compaction-lifecycle.service.ts:381-421`).
+
+Per revision scope, neither issue was changed in this batch.
+
+## Required verification gates
+
+All commands ran against the final working tree, returned exit code 0, and each
+Nx header explicitly said `for 3 projects`. ANSI color bytes and repeated
+per-worker `NO_COLOR` warnings are omitted below; the command/result text is
+otherwise verbatim.
+
+### Tests
+
+```text
+NX   Running target test for 3 projects:
+
+- @ptah-extension/chat
+- @ptah-extension/chat-state
+- @ptah-extension/chat-streaming
+
+> nx run @ptah-extension/chat-state:test  [existing outputs match the cache, left as is]
+
+Test Suites: 15 passed, 15 total
+Tests:       338 passed, 338 total
+Snapshots:   0 total
+Time:        30.606 s
+Ran all test suites.
+
+> nx run @ptah-extension/chat-streaming:test  [existing outputs match the cache, left as is]
+
+Test Suites: 22 passed, 22 total
+Tests:       1 skipped, 450 passed, 451 total
+Snapshots:   0 total
+Time:        36.953 s
+Ran all test suites.
+
+> nx run @ptah-extension/chat:test
+
+Test Suites: 65 passed, 65 total
+Tests:       2 skipped, 1000 passed, 1002 total
+Snapshots:   0 total
+Time:        22.54 s
+Ran all test suites.
+
+NX   Successfully ran target test for 3 projects
+
+Nx read the output from the cache instead of running the command for 2 out of 3 tasks.
+```
+
+### Typecheck
+
+```text
+NX   Running target typecheck for 3 projects:
+
+- @ptah-extension/chat
+- @ptah-extension/chat-state
+- @ptah-extension/chat-streaming
+
+> nx run @ptah-extension/chat-state:typecheck
+> npx ngc --noEmit --project libs/frontend/chat-state/tsconfig.lib.json
+
+> nx run @ptah-extension/chat-streaming:typecheck
+> npx ngc --noEmit --project libs/frontend/chat-streaming/tsconfig.lib.json
+
+> nx run @ptah-extension/chat:typecheck
+> npx ngc --noEmit --project libs/frontend/chat/tsconfig.lib.json
+
+NX   Successfully ran target typecheck for 3 projects
+```
+
+### Lint
+
+```text
+NX   Running target lint for 3 projects:
+
+- @ptah-extension/chat
+- @ptah-extension/chat-state
+- @ptah-extension/chat-streaming
+
+> nx run @ptah-extension/chat-state:lint  [existing outputs match the cache, left as is]
+✖ 3 problems (0 errors, 3 warnings)
+
+> nx run @ptah-extension/chat-streaming:lint  [existing outputs match the cache, left as is]
+✖ 2 problems (0 errors, 2 warnings)
+
+> nx run @ptah-extension/chat:lint
+✖ 17 problems (0 errors, 17 warnings)
+
+NX   Successfully ran target lint for 3 projects
+
+Nx read the output from the cache instead of running the command for 2 out of 3 tasks.
+```
+
+The warnings are existing repository warnings; the new regression has no lint
+warning. The test gate repeated the suite's existing forced-worker-exit warning.
+
+## Worktree / commit status
+
+I did not commit, stage, push, reset, or rewrite history. During the earlier
+shared-worktree run, another process advanced HEAD through `e405a2e42`, which
+absorbed the initial production facade/fix, and then through unrelated commit
+`0a7f59fef` and `bf16def22`. I followed the orchestrator instruction to preserve
+that history. The final revision remains in the aggregate working tree. The
+index is empty; no task file is staged by this agent.

--- a/.ptah/specs/TASK_2026_400/agent-output-frontend.md
+++ b/.ptah/specs/TASK_2026_400/agent-output-frontend.md
@@ -1,0 +1,99 @@
+# TASK_2026_391 Batch 5 — frontend remediation notes
+
+## Root cause
+
+The original resume path preserved intended lifetime totals through
+`applyLoadedSessionStats`, then independently summed those cumulative totals
+and published them as `liveModelStats`. That produced the measured 89.6% gauge
+from 896,300 lifetime tokens despite a post-compaction context near 11,016.
+
+The first Batch 5 fix still coupled CTX provenance to entries in the cumulative
+`modelUsageList` and passed `hasCompacted: true` as a sentinel. Review also
+identified a second resume consumer:
+`refreshResumableSubagentsForSession` restored renderer state through
+`chat:resume` but did not apply the returned stats, so a persisted stale CTX
+could survive an ordinary app/webview restoration.
+
+## Remediated implementation
+
+`SessionLoaderService.applyResumeStats` now owns all frontend resume-stat
+application:
+
+- `applyLoadedSessionStats` receives aggregate stats unchanged, preserving
+  lifetime TOKENS and cost.
+- `modelUsageList` remains cumulative and gains only locally derived context
+  windows for display.
+- CTX comes exclusively from the dedicated
+  `stats.contextSnapshot { model, contextTokens }` payload. The snapshot model
+  therefore wins over aggregate `stats.model` and `modelUsageList` selection.
+- When the snapshot is absent, `setLiveModelStats(tabId, null)` honestly clears
+  the stale gauge.
+
+Both `switchSession` and the renderer-restoration
+`refreshResumableSubagentsForSession` consumer call the helper. The loader no
+longer imports `deriveLiveModelStats`, consumes per-model
+`lastTurnContextTokens`, or uses the false `hasCompacted` sentinel. The old
+resume-local `cumulativeExceedsWindow` guard remains removed because cumulative
+totals no longer participate in resume CTX calculation.
+
+`[compaction-diag]` logging is unchanged.
+
+The restored path now converts the legacy string-typed `activeTabId` signal at
+its boundary with `TabId.from(...)`; the refresh method and stats helper carry
+only branded `TabId` values. After the asynchronous RPC returns successfully,
+the loader revalidates that the tab still exists and still owns the captured
+session before any tab-scoped write. A successful response with null/absent
+stats clears preloaded, live, and model-usage state; an unsuccessful RPC
+returns before clearing, preserving the prior display.
+
+## Regression proof
+
+Before the production remediation:
+
+```text
+npx nx test @ptah-extension/chat --runInBand --testPathPatterns=session-loader.service.spec.ts --testNamePattern="replaces a restored loaded tab stale stats|uses the dedicated context snapshot model"
+```
+
+The run failed red with two failures:
+
+```text
+restoreCliSessionsForSession › replaces a restored loaded tab stale stats from the resume snapshot
+Expected applyLoadedSessionStats(...)
+Number of calls: 0
+
+tab-targeted compaction reload › uses the dedicated context snapshot model instead of aggregate resume stats for the gauge
+Expected: { model: "claude-opus-5", contextUsed: 11016, contextWindow: 1000000, contextPercent: 1.1 }
+Received: null
+
+Test Suites: 1 failed, 1 total
+Tests:       2 failed, 36 skipped, 38 total
+```
+
+Two additional regressions pin successful-null clearing and a deferred response
+whose tab is rebound to another session. After remediation, the complete
+focused service spec passed green:
+
+```text
+npx nx test @ptah-extension/chat --runInBand --testPathPatterns=session-loader.service.spec.ts
+NX   Successfully ran target test for project @ptah-extension/chat
+Test Suites: 1 passed, 1 total
+Tests:       2 skipped, 38 passed, 40 total
+```
+
+No existing test was weakened. The prior Batch 5 regression was updated from
+the superseded per-model `lastTurnContextTokens` contract to the reviewed
+dedicated `contextSnapshot` contract.
+
+## Focused verification
+
+```text
+npx nx run @ptah-extension/chat:typecheck
+NX   Successfully ran target typecheck for project @ptah-extension/chat
+
+npx nx run @ptah-extension/chat:lint
+NX   Successfully ran target lint for project @ptah-extension/chat
+17 problems (0 errors, 17 warnings)
+```
+
+The warnings are pre-existing. The touched service's only warning remains the
+existing empty `createNewSession` method.

--- a/.ptah/specs/TASK_2026_400/agent-output-root.md
+++ b/.ptah/specs/TASK_2026_400/agent-output-root.md
@@ -1,0 +1,509 @@
+# TASK_2026_391 Batch 4 — final report
+
+## Verdict
+
+**APPROVED / PASS.** Independent logic review scored the scoped change 8/10
+with no blocking, serious, or moderate issues. Independent testing passed the
+composed regression and all required three-project gates.
+
+The remaining Electron compaction reload defect was a frontend queue-ordering
+race, not tab targeting and not backend data loss.
+
+## Root cause
+
+A live `/compact` event could leave the target tab's old two-user-stub
+`StreamingState` in `BatchedUpdateService.deferredTabUpdates`
+(`libs/frontend/chat-streaming/src/lib/batched-update.service.ts:84-93`).
+Compaction cleared the visible tab state, and the targeted reload installed a
+fresh replay state through `applyResumingSession`
+(`libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts:591-596`).
+
+Replay then queued the newer state for the same `TabId`. However,
+`MessageFinalizationService.finalizeSessionHistory` begins with an unscoped
+`flushSync()` before reading the target tab
+(`libs/frontend/chat-streaming/src/lib/message-finalization.service.ts:206-216`).
+That flush promotes deferred entries into `pendingTabUpdates`
+(`batched-update.service.ts:181-196`). Because both entries have the same tab
+key, the older deferred live state overwrote the newer pending replay state.
+Finalization consequently built only:
+
+- `Continued from previous conversation (compacted)`
+- `/compact compact`
+
+There was no assistant tree left to promote into `TabState.messages`.
+
+The fix deletes pending, deferred, and pending-flush records for the exact
+target through `BatchedUpdateService.clearPendingUpdates`
+(`batched-update.service.ts:205-209`). The streaming facade is at
+`libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts:76-77`.
+The loader calls it only when `targetTabId` is present and immediately before
+resume initialization
+(`libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts:588-596`).
+
+## Why untargeted reopen rendered but targeted reload did not
+
+Both paths call the same replay loop and `applyResumingSession`. The targeted
+path did not skip resume initialization. An explicit target still resolves as
+`primaryTab` and always reaches `processEventForTab`
+(`streaming-handler.service.ts:130-145,184-205`); `fanOut: false` suppresses
+only sibling fan-out.
+
+The discriminator is teardown. Closing a tile routes through
+`StreamRouter`, which already calls
+`batchedUpdate.clearPendingUpdates(evt.tabId)`
+(`libs/frontend/chat-routing/src/lib/stream-router.service.ts:955`). Reopening
+therefore starts with no stale live queue entry. The in-place targeted reload
+did not close the tile, so it previously retained that entry.
+
+The separate `session:compactionComplete` push only stamps marker metadata;
+it does not invoke a second reload
+(`compaction-lifecycle.service.ts:444-479`). The later stream-exit
+`markTabIdle` changes liveness controls, not transcript content. Neither is
+the overwrite source.
+
+## Genuine composed RED then GREEN
+
+The regression at
+`libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts:1221-1383`
+uses real `SessionLoaderService`, `TabManagerService`,
+`BatchedUpdateService`, `StreamingHandlerService`,
+`StreamingAccumulatorCore`, `EventDeduplicationService`,
+`MessageFinalizationService`, and `SessionManager`. Only unrelated external
+edges and the deterministic execution-tree projection are doubled.
+
+It sends the exact two stale user bubbles through the real streaming handler
+while the document is hidden, confirms a real queued target entry using
+`hasPendingUpdates(targetTabId)`, makes the document visible without firing a
+drain, performs the actual targeted `switchSession`, replays valid user and
+assistant events, then asserts the real target `TabState.messages` contains
+the restored assistant content and neither stale stub.
+
+### RED — only the production cleanup removed
+
+Command:
+
+```text
+npx nx test @ptah-extension/chat --runInBand --testPathPatterns=session-loader.service.spec.ts
+```
+
+Verbatim failure:
+
+```text
+FAIL chat libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts
+  ● SessionLoaderService targeted replay with the real streaming state pipeline › discards a deferred live compaction state before replaying assistant history into that exact tab
+
+    expect(received).toEqual(expected) // deep equality
+
+    - Expected  - 1
+    + Received  + 1
+
+      Array [
+        "user",
+    -   "assistant",
+    +   "user",
+      ]
+
+      1376 |
+      1377 |     const target = tabManager.tabs().find((tab) => tab.id === targetTabId);
+    > 1378 |     expect(target?.messages.map((message) => message.role)).toEqual([
+           |                                                             ^
+      1379 |       'user',
+      1380 |       'assistant',
+      1381 |     ]);
+
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 2 skipped, 33 passed, 36 total
+Snapshots:   0 total
+Time:        4.149 s
+Ran all test suites matching session-loader.service.spec.ts.
+```
+
+The actual target ended with `["user", "user"]` rather than
+`["user", "assistant"]`, reproducing the real two-stub symptom.
+
+### GREEN — target-only cleanup restored
+
+Independent re-verification command:
+
+```text
+npx nx test @ptah-extension/chat --testPathPatterns=session-loader.service.spec.ts --testNamePattern="discards a deferred live compaction state before replaying assistant history into that exact tab" --runInBand
+```
+
+Verbatim outcome from the passing independent test report:
+
+```text
+NX   Successfully ran target test for project @ptah-extension/chat
+
+Your AI agent configuration is outdated. Run "nx configure-ai-agents" to update.
+
+(node:44868) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+Test Suites: 1 passed, 1 total
+Tests:       35 skipped, 1 passed, 36 total
+Snapshots:   0 total
+Time:        1.882 s, estimated 6 s
+Ran all test suites matching session-loader.service.spec.ts with tests matching "discards a deferred live compaction state before replaying assistant history into that exact tab".
+```
+
+The earlier constructed local-boolean/local-map Batch 4 test was removed and
+replaced by this composed test. It was not a Batch 1 test. No Batch 1 assertion
+was weakened or removed.
+
+## Effective changed state
+
+The effective aggregate HEAD plus worktree contains:
+
+- `libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts`:
+  target-scoped queue-cleanup facade. This is present in HEAD via external
+  concurrent commit `e405a2e42`.
+- `libs/frontend/chat-streaming/src/lib/streaming-handler.service.spec.ts`:
+  facade delegation coverage, also present in that effective HEAD.
+- `libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts`:
+  worktree refinement guards cleanup with `if (targetTabId)`, preserving
+  ordinary untargeted reopen behavior.
+- `libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts`:
+  the constructed test is replaced by the genuine composed queue/replay/
+  finalization regression; existing targeted Batch 1 coverage remains.
+- `libs/frontend/chat/src/lib/services/chat-store/session-loader.cli-restore.spec.ts`:
+  removes the now-unneeded cleanup method from an untargeted test double.
+- Task reports under `.ptah/specs/TASK_2026_391/`.
+
+`libs/frontend/chat-streaming/src/lib/agent-monitor.store.ts` was not edited by
+this work.
+
+All three `[compaction-diag]` sites remain:
+`compaction-lifecycle.service.ts:331`,
+`compaction-lifecycle.service.ts:395`, and
+`session-loader.service.ts:574`.
+
+## Required gates
+
+The complete captured outputs below are copied verbatim from the updated independent test report. Every Nx header explicitly says **3 projects**.
+
+### Test gate
+
+- Command run: `npx nx run-many -t test -p @ptah-extension/chat @ptah-extension/chat-state @ptah-extension/chat-streaming`
+- Header confirmation: `Running target test for 3 projects`.
+- Result: 1,788 passed, 0 failed, 3 skipped.
+
+```text
+NX   Running target test for 3 projects:
+
+- @ptah-extension/chat
+- @ptah-extension/chat-state
+- @ptah-extension/chat-streaming
+
+> nx run @ptah-extension/chat-state:test  [existing outputs match the cache, left as is]
+
+A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
+
+Test Suites: 15 passed, 15 total
+Tests:       338 passed, 338 total
+Snapshots:   0 total
+Time:        23.977 s
+Ran all test suites.
+
+> nx run @ptah-extension/chat-streaming:test  [existing outputs match the cache, left as is]
+
+(node:25524) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:32444) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:33352) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:18896) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:13508) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:26348) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:51884) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:40964) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:44128) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:26272) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:6904) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:19120) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:42344) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:49640) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:32288) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:43804) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
+
+Test Suites: 22 passed, 22 total
+Tests:       1 skipped, 450 passed, 451 total
+Snapshots:   0 total
+Time:        34.007 s
+Ran all test suites.
+
+> nx run @ptah-extension/chat:test  [local cache]
+
+(node:2400) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:40112) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:36300) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:1260) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:39968) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:18636) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:28896) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:17188) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:45096) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:41428) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:15136) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:9916) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:4580) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:34056) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:40784) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:38744) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
+
+Test Suites: 65 passed, 65 total
+Tests:       2 skipped, 1000 passed, 1002 total
+Snapshots:   0 total
+Time:        28.532 s, estimated 34 s
+Ran all test suites.
+
+NX   Successfully ran target test for 3 projects
+
+Nx read the output from the cache instead of running the command for 3 out of 3 tasks.
+
+Your AI agent configuration is outdated. Run "nx configure-ai-agents" to update.
+```
+
+Latest re-run confirmation (verbatim terminal summary):
+
+```text
+NX   Running target test for 3 projects:
+
+- @ptah-extension/chat
+- @ptah-extension/chat-state
+- @ptah-extension/chat-streaming
+
+Test Suites: 15 passed, 15 total
+Tests:       338 passed, 338 total
+
+Test Suites: 22 passed, 22 total
+Tests:       1 skipped, 450 passed, 451 total
+
+Test Suites: 65 passed, 65 total
+Tests:       2 skipped, 1000 passed, 1002 total
+
+NX   Successfully ran target test for 3 projects
+
+Nx read the output from the cache instead of running the command for 3 out of 3 tasks.
+```
+
+### Typecheck gate
+
+- Command run: `npx nx run-many -t typecheck -p @ptah-extension/chat @ptah-extension/chat-state @ptah-extension/chat-streaming`
+- Header confirmation: `Running target typecheck for 3 projects`.
+- Result: all 3 passed.
+
+```text
+NX   Running target typecheck for 3 projects:
+
+- @ptah-extension/chat
+- @ptah-extension/chat-state
+- @ptah-extension/chat-streaming
+
+> nx run @ptah-extension/chat-state:typecheck
+
+> npx ngc --noEmit --project libs/frontend/chat-state/tsconfig.lib.json
+
+(node:39844) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:2556) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+
+> nx run @ptah-extension/chat-streaming:typecheck
+
+> npx ngc --noEmit --project libs/frontend/chat-streaming/tsconfig.lib.json
+
+(node:28608) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:31808) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+
+> nx run @ptah-extension/chat:typecheck
+
+> npx ngc --noEmit --project libs/frontend/chat/tsconfig.lib.json
+
+(node:38068) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+(node:12756) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+
+NX   Successfully ran target typecheck for 3 projects
+
+Your AI agent configuration is outdated. Run "nx configure-ai-agents" to update.
+```
+
+Latest re-run confirmation (verbatim terminal summary):
+
+```text
+NX   Running target typecheck for 3 projects:
+
+- @ptah-extension/chat
+- @ptah-extension/chat-state
+- @ptah-extension/chat-streaming
+
+NX   Successfully ran target typecheck for 3 projects
+```
+
+### Lint gate
+
+- Command run: `npx nx run-many -t lint -p @ptah-extension/chat @ptah-extension/chat-state @ptah-extension/chat-streaming`
+- Header confirmation: `Running target lint for 3 projects`.
+- Result: all 3 passed; 0 errors and 22 warnings.
+
+```text
+NX   Running target lint for 3 projects:
+
+- @ptah-extension/chat
+- @ptah-extension/chat-state
+- @ptah-extension/chat-streaming
+
+> nx run @ptah-extension/chat-state:lint  [existing outputs match the cache, left as is]
+
+Linting "@ptah-extension/chat-state"...
+D:\projects\ptah-extension\libs\frontend\chat-state\src\lib\tab-manager.cross-workspace.spec.ts
+  115:29  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
+D:\projects\ptah-extension\libs\frontend\chat-state\src\lib\tab-manager.service.ts
+    40:10  warning  'ClaudeSessionId' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+  1513:1   warning  File has too many lines (1190). Maximum allowed is 700                             max-lines
+âœ– 3 problems (0 errors, 3 warnings)
+
+> nx run @ptah-extension/chat-streaming:lint  [existing outputs match the cache, left as is]
+
+(node:33348) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+
+Linting "@ptah-extension/chat-streaming"...
+D:\projects\ptah-extension\libs\frontend\chat-streaming\src\lib\agent-monitor.store.ts
+  1155:1  warning  File has too many lines (1057). Maximum allowed is 700  max-lines
+D:\projects\ptah-extension\libs\frontend\chat-streaming\src\lib\streaming-event-cascade-clean.spec.ts
+  8:11  warning  'SeedTextDelta' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+âœ– 2 problems (0 errors, 2 warnings)
+
+> nx run @ptah-extension/chat:lint  [existing outputs match the cache, left as is]
+
+(node:11864) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(Use `node --trace-warnings ...` to show where the warning was created)
+
+Linting "@ptah-extension/chat"...
+D:\projects\ptah-extension\libs\frontend\chat\src\lib\components\molecules\chat-input\chat-input.component.ts
+  885:1  warning  File has too many lines (978). Maximum allowed is 700  max-lines
+D:\projects\ptah-extension\libs\frontend\chat\src\lib\components\organisms\execution\inline-agent-bubble.component.spec.ts
+  253:7  warning  Unused eslint-disable directive (no problems were reported from '@typescript-eslint/dot-notation')
+D:\projects\ptah-extension\libs\frontend\chat\src\lib\components\organisms\execution\inline-agent-bubble.component.ts
+  807:1   warning  File has too many lines (932). Maximum allowed is 700  max-lines
+  936:37  warning  Forbidden non-null assertion                           @typescript-eslint/no-non-null-assertion
+D:\projects\ptah-extension\libs\frontend\chat\src\lib\components\templates\app-shell.component.ts
+   70:35  warning  'SessionId' is defined but never used. Allowed unused vars must match /^_/u  @typescript-eslint/no-unused-vars
+  369:22  warning  Unexpected empty arrow function                                              @typescript-eslint/no-empty-function
+D:\projects\ptah-extension\libs\frontend\chat\src\lib\components\templates\chat-view.component.spec.ts
+  1045:5  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
+D:\projects\ptah-extension\libs\frontend\chat\src\lib\components\templates\chat-view.component.ts
+  1062:1  warning  File has too many lines (906). Maximum allowed is 700  max-lines
+D:\projects\ptah-extension\libs\frontend\chat\src\lib\components\templates\chat-view.keepalive.spec.ts
+  200:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
+  212:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
+  213:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
+  221:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
+D:\projects\ptah-extension\libs\frontend\chat\src\lib\services\chat-store\session-loader.service.ts
+  926:43  warning  Unexpected empty async method 'createNewSession'  @typescript-eslint/no-empty-function
+D:\projects\ptah-extension\libs\frontend\chat\src\lib\settings\ptah-ai\agent-orchestration-config.component.ts
+  739:1  warning  File has too many lines (988). Maximum allowed is 700  max-lines
+D:\projects\ptah-extension\libs\frontend\chat\src\lib\settings\ptah-ai\ptah-cli-config.component.ts
+   787:49  warning  Unexpected empty arrow function                         @typescript-eslint/no-empty-function
+   789:1   warning  File has too many lines (1034). Maximum allowed is 700  max-lines
+  1014:49  warning  Unexpected empty arrow function                         @typescript-eslint/no-empty-function
+âœ– 17 problems (0 errors, 17 warnings)
+
+  0 errors and 1 warning are potentially fixable with the `--fix` option.
+
+NX   Successfully ran target lint for 3 projects
+
+Nx read the output from the cache instead of running the command for 3 out of 3 tasks.
+
+Your AI agent configuration is outdated. Run "nx configure-ai-agents" to update.
+```
+
+Latest re-run confirmation (verbatim terminal summary):
+
+```text
+NX   Running target lint for 3 projects:
+
+- @ptah-extension/chat
+- @ptah-extension/chat-state
+- @ptah-extension/chat-streaming
+
+NX   Successfully ran target lint for 3 projects
+
+Nx read the output from the cache instead of running the command for 3 out of 3 tasks.
+```
+
+## Secondary CTX defect
+
+Not fixed because it is genuinely separate. The batching queue stores only
+`StreamingState`; it does not own `preloadedStats.tokens` or the context
+gauge source. Lifetime `TOKENS 896.3k` may remain cumulative, while CTX must
+come from a post-compaction context snapshot. Correcting this requires a
+separate ordering regression across session stats, compaction marker state,
+and resume stats. Blanket zeroing of lifetime token/cost statistics was not
+reintroduced.
+
+## Adjacent findings — reported only
+
+Independent review identified two pre-existing paths outside this fix:
+
+1. A conversation-bound fan-out tab with `claudeSessionId === null` may be
+   selected by lifecycle fallback and then rejected by the loader's strict
+   ownership check (`compaction-lifecycle.service.ts:388-415` versus
+   `session-loader.service.ts:740-747`).
+2. If `session:load` or `chat:resume` fails after lifecycle clearing, the
+   failure is logged without transcript rollback or an in-UI retry
+   (`compaction-lifecycle.service.ts:381-421`;
+   `session-loader.service.ts:551-557,720-734`).
+
+Neither was changed or worsened by the target-only cleanup.
+
+## Shared-tree history / no-commit caveat
+
+No agent performing this Batch 4 work ran `git commit`, staged files, reset
+the tree, or rewrote history. However, the shared branch advanced concurrently
+through external commits:
+
+- `e405a2e42 fix(chat): drop queued tab writes before an in-place session reload`
+  absorbed the initial queue facade, loader fix, and initial test into HEAD.
+- `0a7f59fef fix(chat): let every agent card stay expanded at once` advanced
+  HEAD again with unrelated work.
+
+After the documented `0a7f59fef` advance, HEAD continued to move
+concurrently; the last orchestrator observation during handoff was
+`bf16def22`. This report describes the effective aggregate HEAD plus worktree
+and does not claim that Git history remained unchanged.

--- a/.ptah/specs/TASK_2026_404_6fcd/agent-output-researcher-expert.md
+++ b/.ptah/specs/TASK_2026_404_6fcd/agent-output-researcher-expert.md
@@ -1,0 +1,181 @@
+# Orchestra Canvas Technical Investigation
+
+Branch verified: `fix/task-401-agent-status-durability` on 2026-09-09. This is a static code investigation, not a runtime profile. Counts labeled **measured** follow directly from constants/templates; costs labeled **inference** need browser profiling. No product code was changed.
+
+## Decision summary
+
+- The current nine-tile experience is defensible, but the principal retained-memory cost is larger than nine tiles: the app shell always mounts the canvas and single-chat surfaces, while the canvas retains up to four workspace grids. At the configured caps that is up to **36 full tile `ChatViewComponent` trees**, plus the main `ChatViewComponent`, whose own LRU can retain up to eight transcript trees. The resulting static ceiling is **37 chat surfaces and 44 transcript component trees** before considering tribunal/pop-out surfaces.
+- The current branch preserves the previously documented mitigations: retained canvas workspaces are capped at four; hidden tiles deregister from visible streaming flushes and freeze their transcript view-model; transcript messages are windowed with persistent lightweight slots, a 2,000 px observer margin, and a six-message always-mounted tail. These reduce update/layout work, but do not detach full hidden tile subtrees.
+- Add zoom with a small **viewport/world CSS transform layer**, not by redefining Gridstack cells and not by replacing Gridstack. Gridstack 12.6.0 explicitly measures ancestor transforms and compensates drag and resize coordinates. The implementation still needs a browser proof for nested scrolling and embedded editors, scroll/world-bound compensation and transformed hit testing.
+- Do not raise `MAX_TILES` directly to 25 or 50. Geometry computation itself is cheap; full chat surfaces, session state, observers, effects, streaming/RPC work, and Gridstack's per-node collision path dominate. Add lightweight/off-screen tile modes and pages or clusters first.
+
+## Constraints that any design must preserve
+
+- Angular 21, standalone components, `ChangeDetectionStrategy.OnPush`, signals, `inject()`, and zoneless-safe behavior are mandatory.
+- Geometry is derived, never stored. `CanvasTile` remains intent only: `{ tabId, order, weight }`. Do not reintroduce `x/y/w/h` into it (`canvas.store.ts:6-13`; `canvas-layout.service.ts:29-38`).
+- Only `CanvasWorkspaceGridComponent` may call Gridstack APIs. `CanvasLayoutService` must remain independent of Gridstack.
+- Public `TileLayout` remains exactly `{ x, y, w, h }` (`canvas-layout.service.ts:40-45`). `libs/frontend/tribunal-panel/src/lib/types/tribunal-ui.types.ts:2,87` and `services/tribunal-state.service.ts:19,273,490` consume it; changing the shape is a cross-library break.
+- Frontend libraries must not import backend libraries.
+
+## Evidence table
+
+| Finding | Current file:line evidence | Status |
+|---|---|---|
+| Store intent contains only tab/order/weight | `canvas-layout.service.ts:29-38`; `canvas.store.ts:6-13` | Verified |
+| Nine tiles per workspace | `canvas.store.ts:62-69,131,155,172,319` | Verified |
+| Four workspace grids retained | `canvas.store.ts:25-32,79-88,441-474` | Verified |
+| Tile intent survives workspace-grid eviction | `canvas.store.ts:276-330,465-470` | Verified |
+| Parent mounts every retained grid and CSS-hides inactive ones | `orchestra-canvas.component.ts:67-79`; `canvas-workspace-grid.component.ts:47-55` | Verified |
+| Every mounted tile creates a child injector and full dynamic chat view | `canvas-tile.component.ts:106-114,203-215,235-246` | Verified |
+| Hidden tile chat views are not destroyed | `canvas-workspace-grid.component.ts:64-75`; `canvas-tile.component.ts:249-252` | Verified by template/lifecycle |
+| App shell keeps grid and single layouts mounted | `chat/src/lib/components/templates/app-shell.component.html:681-712` | Verified |
+| Main chat retains up to eight transcript trees | `chat/src/lib/services/transcript-retention.service.ts:14-18,102-130`; `chat-view.component.ts:497-525` | Verified |
+| Tile chat renders exactly one transcript | `chat-view.component.ts:503-525` | Verified |
+| Hidden tile transcript freezes | `canvas-tile.component.ts:128-134,185-200`; `chat-view.component.ts:527-543` | Verified |
+| Transcript bubbles are windowed, wrappers remain | `chat-transcript.component.html:7-30`; `transcript-render-window.ts:4-24,113-139`; `chat-transcript.component.css:35-61` | Verified |
+| ResizeObserver coalesces to the latest RAF | `canvas-layout.service.ts:72-86` | Verified |
+| Layout sorts and walks all tiles | `canvas-layout.service.ts:105-142` | Verified; O(n log n) due to sort |
+| Active projection calls `grid.update()` once per engine node inside a batch | `canvas-workspace-grid.component.ts:162-197` | Verified |
+| Angular item options setter independently calls `grid.update()` | `canvas-workspace-grid.component.ts:64-65,130-145`; `node_modules/gridstack/dist/angular/src/gridstack-item.component.ts:89-97` | Verified |
+| Grid options setter calls `updateOptions()` after init | `canvas-workspace-grid.component.ts:58-60`; `node_modules/gridstack/dist/angular/src/gridstack.component.ts:112-118` | Verified; current `gsOptions` identity is stable |
+| Gridstack update enters move/collision logic when geometry differs | `node_modules/gridstack/dist/gridstack.js:1416-1433,1463-1477`; `gridstack-engine.js:936-999` | Verified |
+| Collision resolution sorts and scans nodes recursively | `gridstack-engine.js:70-114,964-998` | Verified |
+| Gridstack 12.6.0 detects transform scale | `node_modules/gridstack/package.json`; `utils.js:713-738` | Verified installed version/source |
+| Drag and resize use transform compensation | `gridstack.js:2667-2685`; `dd-draggable.js:195-218`; `dd-resizable.js:199-208` | Verified |
+| Visible tile set controls RAF streaming flushes | `chat-state/src/lib/tab-manager.service.ts:159-165,2353-2372`; `chat-streaming/src/lib/batched-update.service.ts:74-123` | Verified |
+| On destroy all partitioned tab IDs are force-closed | `canvas.store.ts:362-374`; `orchestra-canvas.component.ts:430-444` | Verified |
+
+## 1. Performance
+
+### Mounted chat surfaces and DOM retention
+
+The canvas does not virtualize or detach tiles. Each retained workspace has a `GridstackComponent`; each tile has a `CanvasTileComponent`, child `EnvironmentInjector`, dynamic `ChatViewComponent`, and one `ChatTranscriptComponent`. Inactive workspaces use `display:none`, preserving all component instances and DOM (`canvas-workspace-grid.component.ts:47-75`; `canvas-tile.component.ts:106-114,235-252`).
+
+**Measured ceiling:** `RETAINED_WORKSPACE_CAP (4) × MAX_TILES (9) = 36` mounted tile chat surfaces. The app shell also permanently mounts the single-panel chat beside the CSS-hidden grid view (`app-shell.component.html:681-712`), giving 37 `ChatViewComponent` instances. The main chat's component-scoped LRU retains at most eight transcripts while every tile chat renders one, hence `36 + 8 = 44` transcript trees. The exact DOM element count cannot be derived reliably because a message bubble expands into markdown, tools, execution nodes, agent controls.
+
+There is now message-level windowing. Every message keeps a persistent slot, but only intersecting messages, the last six, and current streaming messages keep the expensive bubble subtree; unmounted bubbles become measured-height placeholders (`transcript-render-window.ts:4-24,113-176`; `chat-transcript.component.html:7-30`). CSS `content-visibility:auto` adds another browser-native layout/paint skip (`chat-transcript.component.css:35-61`). This is meaningful, but it is not tile virtualization: injectors, chat headers/input/panels, transcript component, observers, signals, and one slot per message remain.
+
+### Workspace switching retention
+
+`switchWorkspaceTiles()` changes the active key and seeds only unseen paths; it does not delete old partition entries (`canvas.store.ts:280-330`). `setActivePath()` mounts/re-touches a grid, then LRU-evicts only from `workspacePaths`; eviction deliberately leaves `_workspaceTiles` and `_workspaceFocusedTabId` intact (`canvas.store.ts:441-474`). Therefore:
+
+- Up to four workspace grid DOM trees stay alive.
+- Workspaces beyond four lose their grid/chat DOM, but their small intent arrays and focus values remain for restoration.
+- `_tilesForCache` also retains a computed per visited path until explicit workspace removal (`canvas.store.ts:84-88,116-123,381-399`). This is bounded by visited workspaces, not by four; its memory is likely small, but that is an inference.
+
+The current branch preserves the previously documented four-grid mounted cap while intentionally retaining intent for all known workspaces; the critical anchors remain unchanged.
+
+### ResizeObserver and RAF driver
+
+One `CanvasLayoutService` observes the top-level canvas. Each observer delivery cancels the prior pending RAF and schedules a new one; the callback floors and writes width and height (`canvas-layout.service.ts:57-86`). This is latest-frame coalescing, not an unbounded RAF loop. Continuous resizing still produces approximately one layout opportunity per painted frame. It does not avoid identical signal writes explicitly; Angular signals' equality prevents notification when the same floored number is written.
+
+Each retained workspace owns a `layout` computed subscribed to the same two dimensions and its tile signal (`canvas-workspace-grid.component.ts:104-127`). `computeLayout()` sorts `n` tiles then walks rows: O(n log n) time and O(n) allocation (`canvas-layout.service.ts:105-142`). At today's caps this arithmetic is trivial. **Inference:** a resize can invalidate up to four layout computeds; actual recomputation depends on which effects/templates Angular evaluates in that zoneless render turn.
+
+### Duplicate Gridstack projection and collision work
+
+The intended imperative path is batched but still per tile: active, unlocked grids call `cellHeight()`, loop every engine node, and call `grid.update()` N times between `batchUpdate(true/false)` (`canvas-workspace-grid.component.ts:162-197`). Batching postpones final packing/change notification; it does not turn N API calls into one `load()`.
+
+There is a second projection path. `items()` creates fresh per-item options objects whenever derived layout changes (`canvas-workspace-grid.component.ts:130-145`). Angular binds each to `<gridstack-item [options]>`; Gridstack's Angular wrapper setter immediately invokes `grid.update(this.el, val)` after initialization (`gridstack-item.component.ts:89-97`). This path is outside `_applyingLayout`, `visible`, and `locked` guards. Consequently a dimension/intent invalidation can produce up to N wrapper updates for a retained grid and another N explicit updates for the active grid. At current caps the static upper bound is 36 wrapper setter calls plus nine explicit calls for one invalidation; whether every hidden OnPush view is checked in that turn is an **inference requiring instrumentation**.
+
+It also means the documentation claim that hidden/locked grids skip all layout projection is too strong. The explicit effect skips it, but the Angular input setter can still project changed item options. The stable `[options]="gsOptions"` object normally avoids repeated grid-level `updateOptions()` because the binding identity does not change; the duplicate issue is the per-item binding, not the grid options binding.
+
+When geometry differs, `grid.update()` calls engine movement; `moveNode()` scans collisions, can recursively fix collisions, and may pack (`gridstack.js:1416-1477`; `gridstack-engine.js:70-114,936-999`). Within explicit batch mode, automatic pack is suppressed until batch end, but collision detection is not eliminated. Worst-case collision cascades can approach quadratic behavior; that is an algorithmic inference, not a measured frame time. With `float:false`, batch close restores gravity/packing.
+
+### Signal/effect fan-out and writes
+
+Per workspace grid: three effects (layout projection, remeasure-on-show, static lock) plus three computeds (`tiles`, `layout`, `items`) (`canvas-workspace-grid.component.ts:104-220`). Per tile: at least three effects (freeze effort, freeze model, visibility registration), multiple computeds, a child injector, and the much larger `ChatViewComponent` graph (`canvas-tile.component.ts:157-200,225-246`). At 36 retained tiles, the canvas shell alone creates at least 108 tile effects before chat internals.
+
+Several effects write signals/services:
+
+- Tile visibility effect mutates `TabManagerService.visibleTabIds` (`canvas-tile.component.ts:193-200`). This is an external registration bridge and appropriate, but workspace switches can fan out to every tile in outgoing and incoming grids.
+- Orchestra request effects consume a signal and clear that request signal (`orchestra-canvas.component.ts:289-340`). They are command bridges, but effect ordering must remain guarded.
+- Tile effort/model effects call tab mutations, though `untracked()` and “undefined only” guards prevent loops (`canvas-tile.component.ts:157-183`).
+- The active-tab prune effect loops active tiles and can update the canvas map (`orchestra-canvas.component.ts:341-355`).
+
+### Per-tile streaming and RPC cost
+
+Hidden workspace tiles deregister from the visible set, so `BatchedUpdateService` keeps only the latest deferred `StreamingState` per tab and does not flush it into `TabManager`/downstream render computeds until visibility returns (`batched-update.service.ts:30-38,74-123`). Hidden transcript `mainPanelShowing()` is false and its view-model freezes (`chat-view.component.ts:527-543`). This avoids per-token DOM work for background workspaces.
+
+It does **not** stop backend sessions, incoming RPC/event routing, accumulation of the latest streaming state, or finalization. The service explicitly fully drains deferred entries at turn-end to avoid resurrecting stale state (`batched-update.service.ts:145-190`). Active workspace tiles are all registered visible, so up to nine concurrent streams can flush together on each shared RAF, each causing tab-state propagation and transcript/execution-tree work. At 25/50 visible tiles, per-frame cost scales with the number of concurrently changing tabs, not merely total tile count. Exact RPC, token-rate, and memory costs require profiling with representative concurrent sessions.
+
+## 2. Zoom
+
+### Option A — CSS transform on a grid world (recommended)
+
+Add an overflow viewport and a transformed “world” around the active grid: `transform: scale(var(--canvas-zoom)); transform-origin: 0 0`, as visual magnification, not reflow. Do not feed zoom into `CanvasLayoutService`, divide viewport dimensions by zoom, or change wrapping/columns. Explicitly compensate scroll/world bounds; zoom-out may show blank area unless product separately defines a larger logical world.
+
+What breaks or needs proof:
+
+- The generic warning “pointer coordinates are not scaled” is **not accurate for installed Gridstack 12.6.0**. It inserts a 1×1 transform reference, derives inverse X/Y scale, and uses that during drag start and resize (`utils.js:713-738`; `gridstack.js:2667-2685`; `dd-draggable.js:195-218`; `dd-resizable.js:199-208`). This makes the option viable, but nested scroll + inverse-sized world + transform-origin must be tested in the Electron and VS Code webviews.
+- A transform without inverse world sizing only shrinks visuals and produces unused space. A transformed element's layout box is not resized by CSS transform, so scroll extents need an explicit wrapper/spacer.
+- `CanvasLayoutService` currently observes the unscaled outer canvas and derives columns directly from width (`canvas-layout.service.ts:72-97`). If left unchanged, zoom-out would not increase logical width or columns. Leave this unchanged: zoom does not reflow.
+- Current tiles do not contain Monaco or xterm. If embedded later, those renderers may be bitmap/compositor-scaled. Browser pointer dispatch generally targets transformed descendants, but text/caret/canvas sharpness and device-pixel-ratio assumptions may degrade at fractional zoom. Treat that as a visual/input test requirement, not a proven failure. Prefer discrete scale steps such as 0.75/0.85/1/1.15 and offer “reset to 100%”.
+
+Exact product files: `orchestra-canvas.component.ts` (zoom state/controls and viewport), `canvas-workspace-grid.component.ts` (world wrapper/style/input and the only Gridstack coordination), plus their specs. `CanvasStore`, `CanvasTile`, and `TileLayout` need no shape changes.
+
+### Option B — cellHeight and column recomputation as zoom
+
+This is not real zoom. Reducing `cellHeight` only compresses vertical Gridstack tracks; tile text, toolbars, Monaco/xterm, and minimum usable widths remain unchanged. Increasing the engine column count conflicts with the current invariant that each row apportions exactly 12 units, while `MAX_COLUMNS` means tiles per row, not Gridstack engine columns (`canvas-layout.service.ts:3-24,113-142,177-220`). Calling Gridstack `column()` can transform cached positions and invoke engine work, then the derived projection overwrites it. It also couples `CanvasLayoutService` to renderer semantics unless carefully isolated. Reject for a scale-factor requirement.
+
+### Option C — replace positioning with a real pan/zoom viewport
+
+A semantic pan/zoom scene can cull aggressively, keep overlays at 1×, and eventually support a minimap. But replacing Gridstack positioning means rebuilding drag, horizontal resize, gravity/collision behavior, keyboard/accessibility semantics, persistence-to-intent write-back, scroll, and tests. If it still uses CSS/canvas scaling, embedded editor quality remains; if it renders semantic LOD, every tile needs multiple renderers. This is justified only as the many-tile stage-2 architecture, not as the first zoom feature.
+
+**Recommendation:** Option A behind a small scale signal and browser proof. Keep 100% as the editing-quality default; zoomed modes are overview modes. Do not assume compensation works merely because source contains it—exercise drag, east/west resize, nested vertical scroll, popovers, and both hosts.
+
+## 3. Beyond the nine-tile cap
+
+### What actually breaks at 25 or 50
+
+- **Row arithmetic:** the engine has 12 units and every row member has a two-unit floor. Therefore `12 / 2 = 6` is the absolute representable maximum per row. `apportionRow()`'s own boundedness comment assumes `row.length × MIN_TILE_UNITS <= 12` (`canvas-layout.service.ts:177-220`). Above six entries in one row, floors already sum beyond 12 and the correction loop cannot reduce any item below two; the row cannot be represented. Today `MAX_COLUMNS=3`, so this does not occur. A future zoom implementation must never derive more than six tiles per row without changing the unit model/floor.
+- **Current column clamp:** `MIN_TILE_WIDTH=480` and `MAX_COLUMNS=3` mean the layout remains 1–3 tiles wide regardless of tile count (`canvas-layout.service.ts:14-24,94-98`). Thus 25 tiles produce nine rows (last row one); 50 produce 17 rows (last row two) at three columns.
+- **Scroll height:** each tile is six cells tall; `cellHeightFor()` enforces a tile height of roughly 90% of viewport height (`canvas-layout.service.ts:155-169`). So three-column 25/50 layouts are approximately 8.1/15.3 viewport heights plus margins. This is intentional scrolling, but it makes most expensive tile surfaces off-screen while still mounted.
+- **DOM/renderers:** 25 or 50 full chat inputs, transcripts, agent panels, child injectors, observers, and per-message slots in one workspace scale memory approximately linearly. Windowed message bubbles reduce inner content cost, not the per-tile shell or slot count.
+- **Gridstack:** each projection still makes N wrapper updates and N explicit updates for the active grid, and each changed update may scan N nodes/collisions. Raising the cap magnifies the duplicate path and collision cascades before pure layout math becomes material.
+- **Session/RPC:** tabs and backend sessions exist independently of DOM. More tiles permit more simultaneous sessions/streams. Visibility gating currently treats every tile in the active workspace as visible even when vertically off-screen, so 50 active-workspace tiles can all flush streaming work, including the 47 that may be below the viewport.
+
+### Architecture for many tiles
+
+Keep one canonical intent list and derived layout, but split “tile exists” from “full chat surface is mounted”:
+
+1. A viewport-aware tile host observes tile intersection with a generous overscan. Focused, streaming-visible-nearby, dragging, and permission-request tiles mount the full `CanvasTileComponent`; far tiles render a lightweight placeholder containing title/status/last activity/static transcript preview.
+2. Visibility registration must follow actual viewport/LOD status, not only workspace visibility. Streaming state continues accumulating in the root store; a culled tile catches up once when promoted.
+3. Preserve stable Gridstack item shells and geometry for all tiles so the engine retains collision/layout identity; cull only the expensive content. This avoids trying to virtualize Gridstack nodes out from under drag/collision calculations.
+4. Add pages or named clusters. Only the active page mounts a Gridstack; other pages retain intent and summary metadata. A cluster of roughly 6–12 sessions provides a tractable working set while search/status surfaces span all sessions.
+5. Build the minimap from derived `TileLayout` plus statuses. A DOM/SVG or regular canvas static preview is sufficient. `OffscreenCanvas` is useful only if profiling shows main-thread minimap drawing is material; it cannot host Angular chat DOM, Monaco, or xterm and is not a tile virtualization solution.
+
+### Staged plan
+
+**Stage 1 — cheap, measurable wins**
+
+1. Instrument counts and timings: mounted full tiles, transcript slots/bubbles, Gridstack update calls, `computeLayout` calls, collision/pack duration, RAF flush tabs, heap after workspace switches.
+2. Remove the duplicate Gridstack projection contract: choose one owner. Prefer a single batched `grid.load(derivedWidgets)`/equivalent inside `CanvasWorkspaceGridComponent`, or make bound item options initial-only and update imperatively. Verify gesture write-back and Angular child stability.
+3. Make active-workspace streaming visibility viewport-aware so below-fold tiles defer flushes. Keep focused/permission tiles live.
+4. Add lightweight content mode for off-screen/unfocused tiles while retaining Gridstack item shells. Reuse existing transcript windowing and hidden transcript freeze.
+5. Add Option-A zoom with discrete steps and host-specific interaction/visual tests.
+
+**Stage 2 — structural scale**
+
+1. Introduce pages/clusters in canvas intent without storing geometry. Retain only a small LRU of page/workspace grids.
+2. Define tile LOD states: placeholder, static preview, live chat. Promotion/demotion owns injector creation/destruction and visible-tab registration.
+3. Add a derived SVG/canvas minimap and search/jump navigation; evaluate `OffscreenCanvas` only after profiling.
+4. If requirements demand hundreds of freely pannable nodes, prototype Option C behind the same intent/layout contracts. Do not replace Gridstack until the prototype matches drag/resize/accessibility and embedded-editor behavior.
+
+## Documentation drift and contradictions
+
+- `libs/frontend/canvas/CLAUDE.md` cites `canvas.store.ts:21` for the store; the class now starts at line 59 and `MAX_TILES` is line 69. `orchestra-canvas.component.ts:50` still points near the decorator (current line 50), not the class (239).
+- The guide says hidden layout math is skipped and locked mode freezes layout. The explicit projection effect does this (`canvas-workspace-grid.component.ts:163-171`), but `[options]="item.options"` reaches Gridstack's setter independently (`gridstack-item.component.ts:89-97`). The guarantee is therefore not complete.
+- “Geometry flows one way … to `grid.update()`” omits the fact that two code paths invoke update: the explicit engine-node loop and the Angular item input setter.
+- The current branch preserves the prior report's four-workspace retention cap; critical anchors are unchanged.
+- Tile-level non-virtualization coexists with the previously documented transcript windowing: Transcript bubbles have explicit intersection-based windowing and CSS `content-visibility`; persistent message slots and full tile/chat shells remain.
+- The common CSS-transform warning that Gridstack pointer coordinates are unscaled is contradicted by installed 12.6.0 source, which measures transform scale for drag and resize. End-to-end host behavior remains unmeasured.
+
+## Recommended sequence
+
+1. Profile the current 1/9/36-surface cases and record heap, long tasks, Gridstack calls, and concurrent-stream RAF cost.
+2. Eliminate the duplicate per-item/manual Gridstack projection path; confirm visibility and lock truly gate all programmatic layout.
+3. Make “visible tab” mean in-viewport full tile, with focused/permission exceptions.
+4. Add placeholder LOD for off-screen/unfocused tiles while retaining stable Gridstack shells.
+5. Implement viewport/world CSS zoom with visual-only scaling, unchanged layout math, explicit transformed bounds, and discrete steps; test drag/resize, scroll, popovers, VS Code, and Electron.
+6. Only then raise the per-page cap experimentally. Keep at most six tiles per row under the present 12-unit/two-unit contract.
+7. Add pages/clusters and a derived minimap before targeting 25–50 sessions as one navigable orchestra.

--- a/.ptah/specs/TASK_2026_404_6fcd/agent-output-root.md
+++ b/.ptah/specs/TASK_2026_404_6fcd/agent-output-root.md
@@ -1,0 +1,3 @@
+# Main deliverable
+
+The full adversarial plan review is [codex-plan-review.md](./codex-plan-review.md). This pointer exists to satisfy the task's `agent-output-{agentId}.md` harvesting convention; the canonical requested deliverable remains the full review at that linked path.

--- a/.ptah/specs/TASK_2026_404_6fcd/codex-canvas-investigation.md
+++ b/.ptah/specs/TASK_2026_404_6fcd/codex-canvas-investigation.md
@@ -1,0 +1,181 @@
+# Orchestra Canvas Technical Investigation
+
+Branch verified: `fix/task-401-agent-status-durability` on 2026-09-09. This is a static code investigation, not a runtime profile. Counts labeled **measured** follow directly from constants/templates; costs labeled **inference** need browser profiling. No product code was changed.
+
+## Decision summary
+
+- The current nine-tile experience is defensible, but the principal retained-memory cost is larger than nine tiles: the app shell always mounts the canvas and single-chat surfaces, while the canvas retains up to four workspace grids. At the configured caps that is up to **36 full tile `ChatViewComponent` trees**, plus the main `ChatViewComponent`, whose own LRU can retain up to eight transcript trees. The resulting static ceiling is **37 chat surfaces and 44 transcript component trees** before considering tribunal/pop-out surfaces.
+- The current branch preserves the previously documented mitigations: retained canvas workspaces are capped at four; hidden tiles deregister from visible streaming flushes and freeze their transcript view-model; transcript messages are windowed with persistent lightweight slots, a 2,000 px observer margin, and a six-message always-mounted tail. These reduce update/layout work, but do not detach full hidden tile subtrees.
+- Add zoom with a small **viewport/world CSS transform layer**, not by redefining Gridstack cells and not by replacing Gridstack. Gridstack 12.6.0 explicitly measures ancestor transforms and compensates drag and resize coordinates. The implementation still needs a browser proof for nested scrolling and embedded editors, scroll/world-bound compensation and transformed hit testing.
+- Do not raise `MAX_TILES` directly to 25 or 50. Geometry computation itself is cheap; full chat surfaces, session state, observers, effects, streaming/RPC work, and Gridstack's per-node collision path dominate. Add lightweight/off-screen tile modes and pages or clusters first.
+
+## Constraints that any design must preserve
+
+- Angular 21, standalone components, `ChangeDetectionStrategy.OnPush`, signals, `inject()`, and zoneless-safe behavior are mandatory.
+- Geometry is derived, never stored. `CanvasTile` remains intent only: `{ tabId, order, weight }`. Do not reintroduce `x/y/w/h` into it (`canvas.store.ts:6-13`; `canvas-layout.service.ts:29-38`).
+- Only `CanvasWorkspaceGridComponent` may call Gridstack APIs. `CanvasLayoutService` must remain independent of Gridstack.
+- Public `TileLayout` remains exactly `{ x, y, w, h }` (`canvas-layout.service.ts:40-45`). `libs/frontend/tribunal-panel/src/lib/types/tribunal-ui.types.ts:2,87` and `services/tribunal-state.service.ts:19,273,490` consume it; changing the shape is a cross-library break.
+- Frontend libraries must not import backend libraries.
+
+## Evidence table
+
+| Finding | Current file:line evidence | Status |
+|---|---|---|
+| Store intent contains only tab/order/weight | `canvas-layout.service.ts:29-38`; `canvas.store.ts:6-13` | Verified |
+| Nine tiles per workspace | `canvas.store.ts:62-69,131,155,172,319` | Verified |
+| Four workspace grids retained | `canvas.store.ts:25-32,79-88,441-474` | Verified |
+| Tile intent survives workspace-grid eviction | `canvas.store.ts:276-330,465-470` | Verified |
+| Parent mounts every retained grid and CSS-hides inactive ones | `orchestra-canvas.component.ts:67-79`; `canvas-workspace-grid.component.ts:47-55` | Verified |
+| Every mounted tile creates a child injector and full dynamic chat view | `canvas-tile.component.ts:106-114,203-215,235-246` | Verified |
+| Hidden tile chat views are not destroyed | `canvas-workspace-grid.component.ts:64-75`; `canvas-tile.component.ts:249-252` | Verified by template/lifecycle |
+| App shell keeps grid and single layouts mounted | `chat/src/lib/components/templates/app-shell.component.html:681-712` | Verified |
+| Main chat retains up to eight transcript trees | `chat/src/lib/services/transcript-retention.service.ts:14-18,102-130`; `chat-view.component.ts:497-525` | Verified |
+| Tile chat renders exactly one transcript | `chat-view.component.ts:503-525` | Verified |
+| Hidden tile transcript freezes | `canvas-tile.component.ts:128-134,185-200`; `chat-view.component.ts:527-543` | Verified |
+| Transcript bubbles are windowed, wrappers remain | `chat-transcript.component.html:7-30`; `transcript-render-window.ts:4-24,113-139`; `chat-transcript.component.css:35-61` | Verified |
+| ResizeObserver coalesces to the latest RAF | `canvas-layout.service.ts:72-86` | Verified |
+| Layout sorts and walks all tiles | `canvas-layout.service.ts:105-142` | Verified; O(n log n) due to sort |
+| Active projection calls `grid.update()` once per engine node inside a batch | `canvas-workspace-grid.component.ts:162-197` | Verified |
+| Angular item options setter independently calls `grid.update()` | `canvas-workspace-grid.component.ts:64-65,130-145`; `node_modules/gridstack/dist/angular/src/gridstack-item.component.ts:89-97` | Verified |
+| Grid options setter calls `updateOptions()` after init | `canvas-workspace-grid.component.ts:58-60`; `node_modules/gridstack/dist/angular/src/gridstack.component.ts:112-118` | Verified; current `gsOptions` identity is stable |
+| Gridstack update enters move/collision logic when geometry differs | `node_modules/gridstack/dist/gridstack.js:1416-1433,1463-1477`; `gridstack-engine.js:936-999` | Verified |
+| Collision resolution sorts and scans nodes recursively | `gridstack-engine.js:70-114,964-998` | Verified |
+| Gridstack 12.6.0 detects transform scale | `node_modules/gridstack/package.json`; `utils.js:713-738` | Verified installed version/source |
+| Drag and resize use transform compensation | `gridstack.js:2667-2685`; `dd-draggable.js:195-218`; `dd-resizable.js:199-208` | Verified |
+| Visible tile set controls RAF streaming flushes | `chat-state/src/lib/tab-manager.service.ts:159-165,2353-2372`; `chat-streaming/src/lib/batched-update.service.ts:74-123` | Verified |
+| On destroy all partitioned tab IDs are force-closed | `canvas.store.ts:362-374`; `orchestra-canvas.component.ts:430-444` | Verified |
+
+## 1. Performance
+
+### Mounted chat surfaces and DOM retention
+
+The canvas does not virtualize or detach tiles. Each retained workspace has a `GridstackComponent`; each tile has a `CanvasTileComponent`, child `EnvironmentInjector`, dynamic `ChatViewComponent`, and one `ChatTranscriptComponent`. Inactive workspaces use `display:none`, preserving all component instances and DOM (`canvas-workspace-grid.component.ts:47-75`; `canvas-tile.component.ts:106-114,235-252`).
+
+**Measured ceiling:** `RETAINED_WORKSPACE_CAP (4) × MAX_TILES (9) = 36` mounted tile chat surfaces. The app shell also permanently mounts the single-panel chat beside the CSS-hidden grid view (`app-shell.component.html:681-712`), giving 37 `ChatViewComponent` instances. The main chat's component-scoped LRU retains at most eight transcripts while every tile chat renders one, hence `36 + 8 = 44` transcript trees. The exact DOM element count cannot be derived reliably because a message bubble expands into markdown, tools, execution nodes, agent controls.
+
+There is now message-level windowing. Every message keeps a persistent slot, but only intersecting messages, the last six, and current streaming messages keep the expensive bubble subtree; unmounted bubbles become measured-height placeholders (`transcript-render-window.ts:4-24,113-176`; `chat-transcript.component.html:7-30`). CSS `content-visibility:auto` adds another browser-native layout/paint skip (`chat-transcript.component.css:35-61`). This is meaningful, but it is not tile virtualization: injectors, chat headers/input/panels, transcript component, observers, signals, and one slot per message remain.
+
+### Workspace switching retention
+
+`switchWorkspaceTiles()` changes the active key and seeds only unseen paths; it does not delete old partition entries (`canvas.store.ts:280-330`). `setActivePath()` mounts/re-touches a grid, then LRU-evicts only from `workspacePaths`; eviction deliberately leaves `_workspaceTiles` and `_workspaceFocusedTabId` intact (`canvas.store.ts:441-474`). Therefore:
+
+- Up to four workspace grid DOM trees stay alive.
+- Workspaces beyond four lose their grid/chat DOM, but their small intent arrays and focus values remain for restoration.
+- `_tilesForCache` also retains a computed per visited path until explicit workspace removal (`canvas.store.ts:84-88,116-123,381-399`). This is bounded by visited workspaces, not by four; its memory is likely small, but that is an inference.
+
+The current branch preserves the previously documented four-grid mounted cap while intentionally retaining intent for all known workspaces; the critical anchors remain unchanged.
+
+### ResizeObserver and RAF driver
+
+One `CanvasLayoutService` observes the top-level canvas. Each observer delivery cancels the prior pending RAF and schedules a new one; the callback floors and writes width and height (`canvas-layout.service.ts:57-86`). This is latest-frame coalescing, not an unbounded RAF loop. Continuous resizing still produces approximately one layout opportunity per painted frame. It does not avoid identical signal writes explicitly; Angular signals' equality prevents notification when the same floored number is written.
+
+Each retained workspace owns a `layout` computed subscribed to the same two dimensions and its tile signal (`canvas-workspace-grid.component.ts:104-127`). `computeLayout()` sorts `n` tiles then walks rows: O(n log n) time and O(n) allocation (`canvas-layout.service.ts:105-142`). At today's caps this arithmetic is trivial. **Inference:** a resize can invalidate up to four layout computeds; actual recomputation depends on which effects/templates Angular evaluates in that zoneless render turn.
+
+### Duplicate Gridstack projection and collision work
+
+The intended imperative path is batched but still per tile: active, unlocked grids call `cellHeight()`, loop every engine node, and call `grid.update()` N times between `batchUpdate(true/false)` (`canvas-workspace-grid.component.ts:162-197`). Batching postpones final packing/change notification; it does not turn N API calls into one `load()`.
+
+There is a second projection path. `items()` creates fresh per-item options objects whenever derived layout changes (`canvas-workspace-grid.component.ts:130-145`). Angular binds each to `<gridstack-item [options]>`; Gridstack's Angular wrapper setter immediately invokes `grid.update(this.el, val)` after initialization (`gridstack-item.component.ts:89-97`). This path is outside `_applyingLayout`, `visible`, and `locked` guards. Consequently a dimension/intent invalidation can produce up to N wrapper updates for a retained grid and another N explicit updates for the active grid. At current caps the static upper bound is 36 wrapper setter calls plus nine explicit calls for one invalidation; whether every hidden OnPush view is checked in that turn is an **inference requiring instrumentation**.
+
+It also means the documentation claim that hidden/locked grids skip all layout projection is too strong. The explicit effect skips it, but the Angular input setter can still project changed item options. The stable `[options]="gsOptions"` object normally avoids repeated grid-level `updateOptions()` because the binding identity does not change; the duplicate issue is the per-item binding, not the grid options binding.
+
+When geometry differs, `grid.update()` calls engine movement; `moveNode()` scans collisions, can recursively fix collisions, and may pack (`gridstack.js:1416-1477`; `gridstack-engine.js:70-114,936-999`). Within explicit batch mode, automatic pack is suppressed until batch end, but collision detection is not eliminated. Worst-case collision cascades can approach quadratic behavior; that is an algorithmic inference, not a measured frame time. With `float:false`, batch close restores gravity/packing.
+
+### Signal/effect fan-out and writes
+
+Per workspace grid: three effects (layout projection, remeasure-on-show, static lock) plus three computeds (`tiles`, `layout`, `items`) (`canvas-workspace-grid.component.ts:104-220`). Per tile: at least three effects (freeze effort, freeze model, visibility registration), multiple computeds, a child injector, and the much larger `ChatViewComponent` graph (`canvas-tile.component.ts:157-200,225-246`). At 36 retained tiles, the canvas shell alone creates at least 108 tile effects before chat internals.
+
+Several effects write signals/services:
+
+- Tile visibility effect mutates `TabManagerService.visibleTabIds` (`canvas-tile.component.ts:193-200`). This is an external registration bridge and appropriate, but workspace switches can fan out to every tile in outgoing and incoming grids.
+- Orchestra request effects consume a signal and clear that request signal (`orchestra-canvas.component.ts:289-340`). They are command bridges, but effect ordering must remain guarded.
+- Tile effort/model effects call tab mutations, though `untracked()` and “undefined only” guards prevent loops (`canvas-tile.component.ts:157-183`).
+- The active-tab prune effect loops active tiles and can update the canvas map (`orchestra-canvas.component.ts:341-355`).
+
+### Per-tile streaming and RPC cost
+
+Hidden workspace tiles deregister from the visible set, so `BatchedUpdateService` keeps only the latest deferred `StreamingState` per tab and does not flush it into `TabManager`/downstream render computeds until visibility returns (`batched-update.service.ts:30-38,74-123`). Hidden transcript `mainPanelShowing()` is false and its view-model freezes (`chat-view.component.ts:527-543`). This avoids per-token DOM work for background workspaces.
+
+It does **not** stop backend sessions, incoming RPC/event routing, accumulation of the latest streaming state, or finalization. The service explicitly fully drains deferred entries at turn-end to avoid resurrecting stale state (`batched-update.service.ts:145-190`). Active workspace tiles are all registered visible, so up to nine concurrent streams can flush together on each shared RAF, each causing tab-state propagation and transcript/execution-tree work. At 25/50 visible tiles, per-frame cost scales with the number of concurrently changing tabs, not merely total tile count. Exact RPC, token-rate, and memory costs require profiling with representative concurrent sessions.
+
+## 2. Zoom
+
+### Option A — CSS transform on a grid world (recommended)
+
+Add an overflow viewport and a transformed “world” around the active grid: `transform: scale(var(--canvas-zoom)); transform-origin: 0 0`, as visual magnification, not reflow. Do not feed zoom into `CanvasLayoutService`, divide viewport dimensions by zoom, or change wrapping/columns. Explicitly compensate scroll/world bounds; zoom-out may show blank area unless product separately defines a larger logical world.
+
+What breaks or needs proof:
+
+- The generic warning “pointer coordinates are not scaled” is **not accurate for installed Gridstack 12.6.0**. It inserts a 1×1 transform reference, derives inverse X/Y scale, and uses that during drag start and resize (`utils.js:713-738`; `gridstack.js:2667-2685`; `dd-draggable.js:195-218`; `dd-resizable.js:199-208`). This makes the option viable, but nested scroll + inverse-sized world + transform-origin must be tested in the Electron and VS Code webviews.
+- A transform without inverse world sizing only shrinks visuals and produces unused space. A transformed element's layout box is not resized by CSS transform, so scroll extents need an explicit wrapper/spacer.
+- `CanvasLayoutService` currently observes the unscaled outer canvas and derives columns directly from width (`canvas-layout.service.ts:72-97`). If left unchanged, zoom-out would not increase logical width or columns. Leave this unchanged: zoom does not reflow.
+- Current tiles do not contain Monaco or xterm. If embedded later, those renderers may be bitmap/compositor-scaled. Browser pointer dispatch generally targets transformed descendants, but text/caret/canvas sharpness and device-pixel-ratio assumptions may degrade at fractional zoom. Treat that as a visual/input test requirement, not a proven failure. Prefer discrete scale steps such as 0.75/0.85/1/1.15 and offer “reset to 100%”.
+
+Exact product files: `orchestra-canvas.component.ts` (zoom state/controls and viewport), `canvas-workspace-grid.component.ts` (world wrapper/style/input and the only Gridstack coordination), plus their specs. `CanvasStore`, `CanvasTile`, and `TileLayout` need no shape changes.
+
+### Option B — cellHeight and column recomputation as zoom
+
+This is not real zoom. Reducing `cellHeight` only compresses vertical Gridstack tracks; tile text, toolbars, Monaco/xterm, and minimum usable widths remain unchanged. Increasing the engine column count conflicts with the current invariant that each row apportions exactly 12 units, while `MAX_COLUMNS` means tiles per row, not Gridstack engine columns (`canvas-layout.service.ts:3-24,113-142,177-220`). Calling Gridstack `column()` can transform cached positions and invoke engine work, then the derived projection overwrites it. It also couples `CanvasLayoutService` to renderer semantics unless carefully isolated. Reject for a scale-factor requirement.
+
+### Option C — replace positioning with a real pan/zoom viewport
+
+A semantic pan/zoom scene can cull aggressively, keep overlays at 1×, and eventually support a minimap. But replacing Gridstack positioning means rebuilding drag, horizontal resize, gravity/collision behavior, keyboard/accessibility semantics, persistence-to-intent write-back, scroll, and tests. If it still uses CSS/canvas scaling, embedded editor quality remains; if it renders semantic LOD, every tile needs multiple renderers. This is justified only as the many-tile stage-2 architecture, not as the first zoom feature.
+
+**Recommendation:** Option A behind a small scale signal and browser proof. Keep 100% as the editing-quality default; zoomed modes are overview modes. Do not assume compensation works merely because source contains it—exercise drag, east/west resize, nested vertical scroll, popovers, and both hosts.
+
+## 3. Beyond the nine-tile cap
+
+### What actually breaks at 25 or 50
+
+- **Row arithmetic:** the engine has 12 units and every row member has a two-unit floor. Therefore `12 / 2 = 6` is the absolute representable maximum per row. `apportionRow()`'s own boundedness comment assumes `row.length × MIN_TILE_UNITS <= 12` (`canvas-layout.service.ts:177-220`). Above six entries in one row, floors already sum beyond 12 and the correction loop cannot reduce any item below two; the row cannot be represented. Today `MAX_COLUMNS=3`, so this does not occur. A future zoom implementation must never derive more than six tiles per row without changing the unit model/floor.
+- **Current column clamp:** `MIN_TILE_WIDTH=480` and `MAX_COLUMNS=3` mean the layout remains 1–3 tiles wide regardless of tile count (`canvas-layout.service.ts:14-24,94-98`). Thus 25 tiles produce nine rows (last row one); 50 produce 17 rows (last row two) at three columns.
+- **Scroll height:** each tile is six cells tall; `cellHeightFor()` enforces a tile height of roughly 90% of viewport height (`canvas-layout.service.ts:155-169`). So three-column 25/50 layouts are approximately 8.1/15.3 viewport heights plus margins. This is intentional scrolling, but it makes most expensive tile surfaces off-screen while still mounted.
+- **DOM/renderers:** 25 or 50 full chat inputs, transcripts, agent panels, child injectors, observers, and per-message slots in one workspace scale memory approximately linearly. Windowed message bubbles reduce inner content cost, not the per-tile shell or slot count.
+- **Gridstack:** each projection still makes N wrapper updates and N explicit updates for the active grid, and each changed update may scan N nodes/collisions. Raising the cap magnifies the duplicate path and collision cascades before pure layout math becomes material.
+- **Session/RPC:** tabs and backend sessions exist independently of DOM. More tiles permit more simultaneous sessions/streams. Visibility gating currently treats every tile in the active workspace as visible even when vertically off-screen, so 50 active-workspace tiles can all flush streaming work, including the 47 that may be below the viewport.
+
+### Architecture for many tiles
+
+Keep one canonical intent list and derived layout, but split “tile exists” from “full chat surface is mounted”:
+
+1. A viewport-aware tile host observes tile intersection with a generous overscan. Focused, streaming-visible-nearby, dragging, and permission-request tiles mount the full `CanvasTileComponent`; far tiles render a lightweight placeholder containing title/status/last activity/static transcript preview.
+2. Visibility registration must follow actual viewport/LOD status, not only workspace visibility. Streaming state continues accumulating in the root store; a culled tile catches up once when promoted.
+3. Preserve stable Gridstack item shells and geometry for all tiles so the engine retains collision/layout identity; cull only the expensive content. This avoids trying to virtualize Gridstack nodes out from under drag/collision calculations.
+4. Add pages or named clusters. Only the active page mounts a Gridstack; other pages retain intent and summary metadata. A cluster of roughly 6–12 sessions provides a tractable working set while search/status surfaces span all sessions.
+5. Build the minimap from derived `TileLayout` plus statuses. A DOM/SVG or regular canvas static preview is sufficient. `OffscreenCanvas` is useful only if profiling shows main-thread minimap drawing is material; it cannot host Angular chat DOM, Monaco, or xterm and is not a tile virtualization solution.
+
+### Staged plan
+
+**Stage 1 — cheap, measurable wins**
+
+1. Instrument counts and timings: mounted full tiles, transcript slots/bubbles, Gridstack update calls, `computeLayout` calls, collision/pack duration, RAF flush tabs, heap after workspace switches.
+2. Remove the duplicate Gridstack projection contract: choose one owner. Prefer a single batched `grid.load(derivedWidgets)`/equivalent inside `CanvasWorkspaceGridComponent`, or make bound item options initial-only and update imperatively. Verify gesture write-back and Angular child stability.
+3. Make active-workspace streaming visibility viewport-aware so below-fold tiles defer flushes. Keep focused/permission tiles live.
+4. Add lightweight content mode for off-screen/unfocused tiles while retaining Gridstack item shells. Reuse existing transcript windowing and hidden transcript freeze.
+5. Add Option-A zoom with discrete steps and host-specific interaction/visual tests.
+
+**Stage 2 — structural scale**
+
+1. Introduce pages/clusters in canvas intent without storing geometry. Retain only a small LRU of page/workspace grids.
+2. Define tile LOD states: placeholder, static preview, live chat. Promotion/demotion owns injector creation/destruction and visible-tab registration.
+3. Add a derived SVG/canvas minimap and search/jump navigation; evaluate `OffscreenCanvas` only after profiling.
+4. If requirements demand hundreds of freely pannable nodes, prototype Option C behind the same intent/layout contracts. Do not replace Gridstack until the prototype matches drag/resize/accessibility and embedded-editor behavior.
+
+## Documentation drift and contradictions
+
+- `libs/frontend/canvas/CLAUDE.md` cites `canvas.store.ts:21` for the store; the class now starts at line 59 and `MAX_TILES` is line 69. `orchestra-canvas.component.ts:50` still points near the decorator (current line 50), not the class (239).
+- The guide says hidden layout math is skipped and locked mode freezes layout. The explicit projection effect does this (`canvas-workspace-grid.component.ts:163-171`), but `[options]="item.options"` reaches Gridstack's setter independently (`gridstack-item.component.ts:89-97`). The guarantee is therefore not complete.
+- “Geometry flows one way … to `grid.update()`” omits the fact that two code paths invoke update: the explicit engine-node loop and the Angular item input setter.
+- The current branch preserves the prior report's four-workspace retention cap; critical anchors are unchanged.
+- Tile-level non-virtualization coexists with the previously documented transcript windowing: Transcript bubbles have explicit intersection-based windowing and CSS `content-visibility`; persistent message slots and full tile/chat shells remain.
+- The common CSS-transform warning that Gridstack pointer coordinates are unscaled is contradicted by installed 12.6.0 source, which measures transform scale for drag and resize. End-to-end host behavior remains unmeasured.
+
+## Recommended sequence
+
+1. Profile the current 1/9/36-surface cases and record heap, long tasks, Gridstack calls, and concurrent-stream RAF cost.
+2. Eliminate the duplicate per-item/manual Gridstack projection path; confirm visibility and lock truly gate all programmatic layout.
+3. Make “visible tab” mean in-viewport full tile, with focused/permission exceptions.
+4. Add placeholder LOD for off-screen/unfocused tiles while retaining stable Gridstack shells.
+5. Implement viewport/world CSS zoom with visual-only scaling, unchanged layout math, explicit transformed bounds, and discrete steps; test drag/resize, scroll, popovers, VS Code, and Electron.
+6. Only then raise the per-page cap experimentally. Keep at most six tiles per row under the present 12-unit/two-unit contract.
+7. Add pages/clusters and a derived minimap before targeting 25–50 sessions as one navigable orchestra.

--- a/.ptah/specs/TASK_2026_404_6fcd/codex-plan-review.md
+++ b/.ptah/specs/TASK_2026_404_6fcd/codex-plan-review.md
@@ -1,0 +1,400 @@
+# Adversarial review: Ptah Orchestra Canvas plan
+
+Reviewed against branch `fix/task-401-agent-status-durability` on 2026-09-09. This is a design review only; no production code was changed.
+
+## Executive verdict
+
+| Area | Verdict | Short reason |
+| --- | --- | --- |
+| A. Compact tile redesign | **Right, but underspecified** | Replacing the miniature transcript with a glanceable summary is the correct product move. The asserted finalized-tree prose duplication is false, the proposed prompt priority is not yet correctly routed per tile, and the border-animation claim confuses a CSS variable with compositor-only animation. |
+| B. Intent persistence | **Right direction, materially misstated** | Canvas intent is currently retained only in the component-scoped `CanvasStore`; tabs and session-list metadata are separate stores. Lowering the mounted-grid cap rebuilds component/DOM state from retained `TabState.messages`; it normally does not reload the transcript from the backend. Persistence needs its own versioned, validated envelope. |
+| C. LOD ladder | **Right, but missing the allocation policy** | `pin` is legitimate intent. Angular `@defer (on viewport)` is useful for first creation, but installed Angular proves the block is monotonic and does not evict. A central allocator—not each tile—must enforce budgets and drive explicit destruction. |
+| D. Zoom | **Right, but coupled to C and layout math** | Separate continuous visual scale from the named semantic stop. Keep GridStack geometry in unscaled world units, make scroll bounds explicit, and derive the effective lock. Do not feed transformed measurements back into cell-height calculations. |
+| E. Notification center | **Product intent right; proposed event architecture wrong** | Pending prompts are current state and should be computed from existing signals. Completion and unread are history and require a small event ledger. Completion must be recorded at the accepted `turn_state` transition, not pushed independently by `StreamRouter`. Focus is a cross-workspace transaction that does not exist today. |
+
+There is also a newly confirmed, release-critical requirement outside A–E: **25–50 sessions must be generating simultaneously**. That is not solved by LOD or DOM eviction. It requires a backend/transport/resource-budget track and a 50-run soak gate before the UI tile limit is raised.
+
+## Branch drift in citations
+
+Most canvas and compact-session citations are unchanged from the earlier investigation. The material shifts on this branch are in `SessionLoaderService`: the workspace-list cache is now documented at `session-loader.service.ts:113-141`, workspace switching at `:433-460`, LRU eviction at `:477-501`, the live-session fast path at `:570-579`, and the actual `session:load` call at `:590-599`. The status path is now especially explicit because `TabManagerService.applyTurnState` at `tab-manager.service.ts:1120-1210` is documented as the single accepted writer.
+
+## A. Compact tile redesign
+
+### Verdict
+
+Proceed with the information-hierarchy redesign, but do not justify it with the duplication claim. The existing component is too transcript-like: it has an internal scrolling feed (`compact-session-activity.component.ts:197`), auto-scroll work (`:494-505`), and up to 50 entries supplied by the card (`compact-session-card.component.ts:83-89`). The card also composes a header (`:65-71`), stats (`:74-79`), activity (`:83-91`), input (`:96-101`), and footer controls (`:104` onward) inside a canvas tile that already supplies its own header and mode control (`canvas-tile.component.ts:65-97`). The critique of density and duplicated chrome is sound.
+
+### The prose-duplication claim is false on the claimed code path
+
+The exact finalized-message path is:
+
+1. `feedEntries` chooses `buildFeedFromMessages()` only when there is no non-empty live event map (`compact-session-activity.component.ts:508-515`).
+2. `buildFeedFromMessages()` visits each finalized assistant message's execution root and calls `walkExecutionTree()` once (`:531-542`).
+3. When that walker reaches an `agent` node, it gathers **direct** text children into `textParts` (`:545-556`), chooses `node.summaryContent` first or joined child text as fallback (`:558-559`), pushes exactly one `agent` feed entry (`:561-581`), and then **returns immediately** at `:582`.
+4. The standalone `text` entry branch is below that return (`:585-590`). The generic recursive descent is lower still (`:600-635`, with the recursive call at `:630`). Neither is reached for an agent node.
+
+The builder can put the same semantic summary in two places: it reads `agentSummaryAccumulators` (`agent-node.fn.ts:83-85`) and, when there are no content blocks, also creates a summary text child (`:97-107`) before returning the agent with those children (`:116-121`). That is not rendered twice by this walker because of the agent-branch return. If the return were removed during refactoring, duplication would immediately become real; pin this behavior with a regression test.
+
+The live-event path also contains an explicit seen-text guard (`compact-session-activity.component.ts:681-698`), so there is no evidence for the broader claim that the current UI blindly emits every prose block twice. The redesign remains worthwhile without that claim.
+
+### Seven required corrections
+
+1. **Replace the feed; do not mutate it into four zones.** Introduce a small summary view-model/reducer that derives `statusLine`, recent semantic marks, `primaryContent`, and aggregate footer metrics. Remove the scrolling template and its `afterRenderEffect`; do not keep a hidden 50-entry transcript computation behind the new UI.
+
+2. **Define “newest” over semantic events, not raw deltas.** Text deltas, partial JSON, and repeated progress updates must coalesce. A pulse mark should represent a completed/meaningfully changed tool, agent start/end, prose block, prompt, or terminal state. Bound it (for example, 16–24 marks) and key it by stable event identity. Otherwise 50 simultaneous streams make the strip a repaint and allocation hot spot.
+
+3. **Make the live verb a total, tested mapping.** Prefer a pending prompt (“Needs permission”), then terminal/error, then the newest active tool/agent, then streaming prose, then idle. Tool-specific verbs such as “Editing `foo.ts`” must be derived from already-validated tool input and degrade to “Running Edit” when a path is absent. Display only a basename or workspace-relative path; do not leak an absolute home path into a tiny cross-session overview.
+
+4. **Route the “one thing” to this tile.** `ChatStore` exposes global arrays at `chat.store.ts:94-96`. `PermissionHandlerService` stores target maps (`permission-handler.service.ts:61` and `:125`), but its current visibility fallback deliberately returns true globally (`:169-178`). The compact card must use the router-attached target ids (`targetTabsFor` at `:343-345`; `questionTargetTabsFor` at `:552-554`) and an explicit, tested unresolved-target fallback. Simply taking the newest global request would show one session's permission in every tile.
+
+5. **Make priority deterministic.** Recommended slot order: targeted question, targeted permission, latest non-empty assistant prose, latest meaningful tool/agent result, empty/starting state. If several prompts target the same session, show the oldest actionable item plus “+N more”; FIFO is the only ordering that helps unblock work.
+
+6. **Do not equate a custom property with compositor execution.** Animating border color, box-shadow, or an unregistered color custom property still paints. Use a pseudo-element whose `opacity` and/or `transform` is animated; set one non-animated custom property for its state color if desired. Disable motion under `prefers-reduced-motion`, retain a non-motion border/icon, and do not encode status by color alone. Amber should mean actionable blockage only, not every question-like state.
+
+7. **Remove chrome contextually, not by deleting shared atoms prematurely.** `CompactSessionCardComponent` is also used by `ChatViewComponent` (`chat-view.component.ts:39,117` and `chat-view.component.html:9`). Add a canvas presentation contract or make the redesigned card intrinsically headerless, then verify the non-canvas compact mode. Remove public exports for `CompactSessionHeaderComponent` and `CompactSessionInputComponent` only after repository-wide callers are gone (`chat-ui/src/index.ts:47-48`; chat re-exports at `chat/src/lib/components/index.ts:139-140`). The tile's existing mode button at `canvas-tile.component.ts:79` makes the inner “Full View” control redundant in canvas, but not automatically elsewhere.
+
+Acceptance must include finalized and live paths, nested agents, a summary-child fixture proving one prose rendering, multiple targeted prompts, reduced motion, long/Unicode paths, and 50 concurrent high-rate view-model inputs.
+
+## B. Intent persistence instead of retained DOM
+
+### Verdict
+
+Persisting arrangement is correct. The claim that the current cap exists purely because tabs do not persist is incorrect, and “restoreCanvasTilesFromTabs already covers this” is only true for membership, not user intent.
+
+### Three stores were conflated
+
+1. **Canvas intent/keep-alive store.** The component-scoped `CanvasStore` owns `_workspaceTiles`, focused tile ids, mounted workspace paths, and recency (`canvas.store.ts:45-88`). A `CanvasTile` is presently only `TileIntent` (`:6-13`). LRU eviction removes a path only from `_workspacePaths`; it deliberately leaves the map entry intact (`:472-491`). This preserves order/weight only for the lifetime of that mounted `OrchestraCanvasComponent`, not across a reload or layout-mode destruction.
+
+2. **Tab/transcript store.** `TabWorkspacePartitionService` holds all workspace tab sets in memory (`tab-workspace-partition.service.ts:69-76`) and loads/saves a per-workspace, optionally per-panel localStorage key (`:481-512`). The envelope is version 2. `tab-persistence.ts:24-31` explicitly confirms finalized execution trees remain in `TabState.messages` and that restored transcripts are not re-fetched. This store preserves sessions and cached transcript data, not canvas order/weight.
+
+3. **Session-list cache.** `SessionLoaderService.sessionCache` is a separate, ten-workspace LRU for session-list metadata (`session-loader.service.ts:113-141,477-501`). On a hit, workspace switching restores its signals without RPC (`:433-449`); on a miss it calls `loadSessionsForWorkspace` (`:451-460`). It is not the tile store and not the per-tab transcript cache.
+
+`restoreCanvasTilesFromTabs()` recreates one tile for every active tab (`orchestra-canvas.component.ts:372-395`) using default append order and weight (`canvas.store.ts:405-409`). It therefore restores membership and active focus only. It cannot restore rearrangement, resizing, pins, or the distinction “tab exists but user removed it from canvas.” It also stops at the current nine-tile cap through `addTileFromSession`/`adoptTab` (`canvas.store.ts:130-176`).
+
+### What lowering `RETAINED_WORKSPACE_CAP` to 1 actually costs
+
+The cap is currently four (`canvas.store.ts:25-32`). At one, every workspace switch unmounts the previous `CanvasWorkspaceGridComponent`, its GridStack instance, every `CanvasTileComponent`, and every child injector/chat or compact component. Returning remounts and reconstructs execution-tree presentation from the `TabState.messages` already held by the tab partition. It also re-registers visible tiles (`canvas-tile.component.ts:195-198`), recreates child injectors (`:207-238`), runs Angular templates/computeds, rebuilds markdown/tool/agent DOM, and asks GridStack to measure/layout again.
+
+That is potentially expensive—especially for long transcripts—but it is **not normally a backend transcript load**. `SessionLoaderService.switchSession()` returns early for an active-workspace tab with `hasLiveSession` (`session-loader.service.ts:570-579`). The actual `session:load` is at `:590-599` and is reached when the fast-path preconditions do not hold. A process reload is different: persisted messages rebuild the transcript, while status is reconciled separately; `tab-persistence.ts:24-31` says resume results are intentionally discarded because messages are already cached.
+
+Therefore “Folded everywhere, focused Live” is cheaper than retained full DOM only if Folded does not instantiate transcript-heavy children. If a Folded tile still computes `feedEntries`, parses markdown, or creates `ChatViewComponent` behind CSS, the session data cost remains. Conversely, focused Live can still incur a large synchronous reconstruction from in-memory messages. Measure remount scripting, node count, heap, long tasks, and first-interaction latency on worst-case transcripts before setting the cap to one.
+
+The statement “removes the workspace-count limit entirely” is too strong. It removes the **mounted-grid** count limit. In-memory tab sets, cached messages, canvas intent, notification history, and session-list cache remain bounded or need bounds. At 25–50 running sessions, stream state and transcript retention—not hidden grid count alone—can dominate memory.
+
+### Correct persistence contract
+
+Use a dedicated canvas envelope, not fields smuggled into the tab-v2 blob:
+
+```ts
+type PersistedCanvasWorkspaceV1 = {
+  version: 1;
+  workspaceKey: string;
+  tiles: Array<{ tabId: string; order: number; weight: number; pin?: boolean }>;
+  focusedTabId: string | null;
+};
+```
+
+- Key it by the same canonical encoded workspace path and panel id rules as tabs, but under a distinct namespace such as `ptah.canvas.ws.{encodedPath}[.{panelId}]`.
+- Parse the localStorage boundary with Zod. Reject unknown version/envelope corruption safely; sanitize each tile: known tab id only, finite positive weight clamped to supported limits, unique tab ids, dense deterministic order, boolean pin.
+- Reconcile against restored tabs. Missing tabs are dropped; newly restored tabs are **not automatically added** if a persisted canvas envelope exists, because absence is user intent. Auto-seed all tabs only when no canvas record exists (migration/default case).
+- Debounce drag/resize writes and flush on workspace switch/destruction. Do not persist derived GridStack `x/y/w/h`.
+- Version canvas independently of tab persistence. Bumping tab version 2 would currently make existing readers reject all restored tabs (`tab-persistence.ts:53-60`; partition reader at `tab-workspace-partition.service.ts:504-506`).
+- Keep focused id as navigation intent, but sanitize it to a surviving tile. LOD itself remains derived; only `pin` is persisted.
+
+## C. Level-of-detail ladder
+
+### Verdict
+
+The ladder is necessary for 25–50 live streams, but “use `@defer` and cap Live at 6–9” is not an allocation design. It needs explicit creation, eviction, prioritization, hysteresis, and per-level work contracts.
+
+### `pin` is acceptable intent
+
+`pin` records a user preference, not derived geometry, so `{tabId, order, weight, pin?}` respects the intent-only rule. Its semantics must be precise: **pin raises allocation priority/minimum detail; it does not override hard safety budgets**. If nine slots are available and ten tiles are pinned, the UI must remain bounded and explain which pins are waiting. Naming it “keep detailed” may be clearer than implying permanent Live residency.
+
+### Installed Angular proves `@defer` is creation-only here
+
+The installed Angular runtime defines defer states in increasing order—Placeholder 0, Loading 1, Complete 2, Error 3 (`node_modules/@angular/core/fesm2022/_debug_node-chunk.mjs:10274-10280`)—and accepts only `currentState < newState` (`:10858-10859`). There is no Complete-to-Placeholder transition. The viewport trigger is an `IntersectionObserver` that fires only when `isIntersecting` (`:2116-2124`). Angular wraps observer construction outside and callback execution inside `NgZone` (`:10421-10423`), so the trigger works with Angular's zoneless-compatible `NgZone` implementation; it does not rely on a patched scroll event.
+
+But a retained workspace host is literally `display:none` (`canvas-workspace-grid.component.ts:47-55`). Its descendants have no rendered box and cannot become intersecting until the workspace is shown. That behavior is desirable for initial creation, but it means `@defer (on viewport)` is not a background prefetch mechanism. Once a defer block reaches Complete, leaving the viewport or hiding the ancestor does not tear it down.
+
+Use this contract:
+
+- `@defer (on viewport)` may gate the **first import/creation** of a heavy surface.
+- An explicit `@if (effectiveLod() === 'live')` owns **residency and destruction**. Put defer inside that branch if bundle deferral is still valuable.
+- The allocator's `effectiveLod` is the eviction trigger. Do not use scroll effects that directly mutate per-tile signals independently.
+- Determine viewport membership from the transformed tile bounds relative to the canvas viewport, preferably in one observer/coordinator. Add entry/exit margins and time hysteresis to prevent thrash during pan/zoom.
+
+### Missing allocation policy
+
+One central `CanvasLodAllocator` should take `zoomStop`, focused tab, viewport membership, pins, prompt-blocked state, running state, recency, and budgets. It returns a read-only map. A deterministic priority order is: focused; actionable prompt; pinned; visible and running; visible and recently active; everything else. Tie-break by last meaningful activity then tile order. Reserve headroom for a newly focused tile so focusing never temporarily creates Live N+1.
+
+A reasonable starting policy—not a performance fact until profiled—is:
+
+| Stop | Live budget | Compact budget | Default remainder | Notes |
+| --- | ---: | ---: | --- | --- |
+| Focus | 1–3, hard max 6 | up to 8 visible | Folded | Focused is always Live; adjacent/pinned candidates use spare Live slots. |
+| Grid | hard max 6 | up to 12 visible | Folded | Prompts and pins outrank merely recent running sessions. |
+| Deck | hard max 1 | up to 8 visible | Folded/Chip | Focus may be Live; pinned means Compact minimum, not Live. |
+| Overview | 0 | at most focused/actionable summaries | Chip | No `ChatViewComponent`; overview is navigation/triage. |
+
+For 25–50 simultaneous runs, start with six rather than nine Live surfaces and validate. “Running” does not imply “Live”: background streams must continue through state services while their view is Folded/Chip. Each level needs a negative contract:
+
+- **Live:** full chat surface, composer, markdown, terminals/tool details.
+- **Compact:** four-zone summary only; no full transcript DOM, no Monaco/xterm, no mini input.
+- **Folded:** header/status/actionable count; no execution-tree walk or markdown parsing.
+- **Chip:** name, status icon, unread/actionable badge only.
+
+Test that eviction destroys component instances and releases tile visibility/stream subscriptions. `CanvasTileComponent` currently registers/unregisters visibility at `canvas-tile.component.ts:195-198` and creates/destroys child injector state at `:207-251`; these lifecycle effects are part of the residency contract, not implementation trivia.
+
+## D. Zoom
+
+### Verdict
+
+Keep the viewport/world design, but split visual interpolation from semantic policy and define who owns measurements. Otherwise continuous scaling, LOD, GridStack drag math, and the existing “row is 90% of viewport” rule form a feedback loop.
+
+### `zoomScale` and `zoomStop` are different state
+
+- `zoomScale: number` is transient presentation state used only by the world transform and scroll-bound compensation. It may interpolate continuously during wheel/pinch/animation.
+- `zoomStop: 'focus' | 'grid' | 'deck' | 'overview'` is discrete semantic state. It drives the LOD budget, labels, snap behavior, and overview lock.
+
+Do not derive LOD continuously from every scale tick. Change `zoomStop` only at defined thresholds with hysteresis or after snapping, then let the allocator in C recompute once. During an animated transition, keep the source stop's allocations until the destination is committed, or use a separate `isZoomTransitioning` flag that temporarily prevents costly promotions.
+
+### World-bounds contract
+
+GridStack and `CanvasLayoutService` operate in **unscaled world coordinates**. The world element has intrinsic width/height from GridStack. A surrounding bounds/spacer element exposes scroll extents equal to `worldWidth * zoomScale` and `worldHeight * zoomScale`; the transformed world uses `transform-origin: 0 0`. Clamp/recenter scroll offsets when scale changes so the pointer or viewport center remains anchored.
+
+Never feed `getBoundingClientRect()` from the scaled world back into layout as its unscaled container size. GridStack itself has transform compensation—installed `Utils.getValuesFromTransformedElement()` measures a one-pixel child and returns inverse X/Y scale (`node_modules/gridstack/dist/utils.js:713-735`)—but that is evidence to test dragging under a transform, not permission to mix coordinate systems.
+
+The current layout makes each tile at least 90% of the measured viewport height (`canvas-layout.service.ts:8-12,155-169`). Keep that cell height in world units based on the unscaled Focus/Grid viewport. At scale 0.5, a row should visually become roughly 45% of the viewport—that is the point of zooming out. Dividing cell height by scale to keep every row visually at 90% would defeat Deck/Overview and make continuous zoom trigger GridStack relayout. ResizeObserver should react to the outer viewport's actual resize, not the transformed world's compensated bounds.
+
+### Derived effective lock
+
+Do not overwrite the user's lock when entering Overview. Preserve `userLocked` and derive:
+
+```text
+effectiveLocked = userLocked || zoomStop === 'overview' || isZoomTransitioning
+```
+
+Pass only `effectiveLocked` to GridStack's `setStatic`; the current call is at `canvas-workspace-grid.component.ts:216-220`. Exiting Overview then restores the user's prior choice. Keyboard reordering and tile mode controls must follow the same effective lock, not just pointer gestures.
+
+The zoom implementation must be tested with drag/resize at every scale, pointer-anchored zoom, nested scroll containers, a hidden-then-restored workspace, focus preservation, reduced motion, and LOD threshold hysteresis. The existing hidden-grid remeasure path (`canvas-workspace-grid.component.ts:199-213`) must run after the world is visible and its scale/bounds are committed.
+
+## E. Notification center
+
+### Verdict
+
+Build it, but do not create a second source of truth by having `StreamRouter` “push notifications.” Use a state projection for pending work, a small accepted-transition ledger for historical completion/unread, and one shell-owned navigation transaction.
+
+### 1. Computed state versus events: the exact line
+
+No general event bus is needed.
+
+- **Pending permission and question entries are state.** `PermissionHandlerService` already owns readonly signal arrays (`permission-handler.service.ts:43,103,110,115`), adds/removes requests in its handlers (`:288-300`, `:310-318`, `:389-419`, `:487-525`), and receives routing targets from `StreamRouter` (`stream-router.service.ts:416-471,493-520`). The bell's actionable list should be a `computed` projection of those signals plus target/workspace metadata. Removing/responding to a request automatically removes it. Do not copy a “prompt arrived” record into a notification queue.
+- **Finished and read/unread are history.** “Finished” is an accepted transition and disappears from current status; “read” is user-owned state. These require a bounded notification ledger with stable ids, timestamps, workspace/tab/session identity, kind, terminal reason, and `readAt`/dismissal state.
+- **Sound and ARIA announcement are side effects.** They react to a newly appended ledger sequence, but do not write business state. This is an appropriate narrowly scoped effect/subscription; the ledger append itself happens in the imperative turn-state application path.
+
+That boundary follows the repository's signal architecture: `computed` for synchronous derivation; an event record only where time/history matters; effects only for external side effects. It avoids a StreamRouter notification bus that can race the actual prompt queue or retain a prompt after it was auto-resolved.
+
+There is one required reactivity repair before that computed is correct. Both target indexes are currently plain `Map`s (`permission-handler.service.ts:61,125`). The router attaches targets **after** enqueueing. `attachQuestionTargets()` forces a new request-array identity at `:543-544`, but `attachPromptTargets()` only mutates the map at `:332-335`; no signal invalidates. A computed can therefore run when the permission is appended, see no targets, and never rerun when routing metadata arrives. Make target attachment atomic with enqueueing, or expose an immutable signal-backed target map/version for both prompt kinds. Do not paper over this by copying the prompt into a notification event.
+
+### 2. Completion edge without an effect that writes signals
+
+The backend's source is `SessionTurnState` (`stream-background.ts:255-273`). `TurnStateApplier.apply()` first performs session/revision acceptance (`turn-state-applier.service.ts:87-113`), finalizes terminal phases (`:115-135`), and then calls `TabManagerService.applyTurnState()` for every accepted target (`:137-139`). `TabManagerService.applyTurnState()` reads the old tab before writing and is documented as the single status writer (`tab-manager.service.ts:1120-1155`); it maps `generating` to `streaming`, background/sleeping to themselves, and `idle`/`failed` to `loaded` (`:1157-1195`) before one update (`:1209`).
+
+Record completion **inside this accepted imperative transition**, not in a signal effect watching `tabs()`:
+
+```text
+previous phase-class = tab.status in {streaming, awaiting-background, sleeping}
+accepted terminal event = state.phase in {idle, failed}
+dedupe identity = sessionId + revision (+ tabId only for fan-out presentation)
+success completion = state.phase === idle && state.terminalReason === completed
+failure completion = state.phase === failed or non-completed terminalReason
+```
+
+If the product means “the foreground answer finished even though background work remains,” that is a different edge (`generating -> awaiting-background`) and must be named separately. The bell wording “session finished” should mean all tracked turn work is terminal, so use `busy-class -> idle/failed`. A sleeping cron is not “finished” merely because its spinner is absent. Preserve the accepted `revision` as dedupe protection; reload reconciliation or fan-out can replay terminal state.
+
+Implementation-wise, add a bounded append-only terminal pulse/ledger writer at the same accepted command boundary (or have `TurnStateApplier` call a narrow data-access port after acceptance). Do not add an `effect(() => { if status changed) notifications.update(...) })`; it loses the previous accepted event semantics, can duplicate during workspace projection swaps, and violates the no-signal-writes-from-effect rule.
+
+### 3. Ownership and Nx tags
+
+Create `libs/frontend/notification-center` with `scope:webview` and `type:feature`. Those are the tags used by the shared Angular feature surface (`chat-streaming`, `chat-routing`, `chat-ui`, `canvas`, and `chat` are all `scope:webview`; their project files show `type:feature`, while `chat-state` is `type:data-access`). `type:feature` may depend on feature/data-access/util under the current boundary rules (`eslint.config.mjs:226-239`). Both the VS Code webview and Electron renderer already consume these frontend libraries, so `scope:webview` is the repo's actual shared-renderer scope despite the label.
+
+The new library should own:
+
+- notification projection/store: pending computeds, bounded completion ledger/read state, grouping;
+- a smart `NotificationCenterComponent`/popover using `inject()` and OnPush;
+- a dumb bell/list-row presentation split if the template grows;
+- sound/announcement side-effect adapters;
+- the focus request issued through a core/chat orchestration contract.
+
+Do not put notification domain behavior in `chat-ui`; it is not a presentational atom. Do not put the bell/popover in `chat-state`; that library is data access. The lower-level accepted terminal pulse may live in `chat-state` because `TabManagerService` owns the transition, exposed readonly to the feature. Avoid making `chat` import a feature that imports `chat` back: the new feature should consume `chat-state`/`chat-streaming` and a core navigation token, not `ChatStore`. The shell merely places the component beside the theme control.
+
+### 4. Focus routing is a transaction, not a click handler
+
+The working route today is only active-workspace-centric:
+
+```text
+AppStateManager.requestCanvasSession(sessionId)
+  -> canvasSessionRequest signal (`app-state.service.ts:657-674`)
+  -> mounted OrchestraCanvas effect (`orchestra-canvas.component.ts:289-304`)
+  -> CanvasStore.addTileFromSession
+  -> ChatStore.switchSession
+```
+
+Workspace switching is a separate orchestration: `WorkspaceCoordinatorService.switchWorkspace()` changes workspace scope, tabs, session-list cache, pickers, and app state synchronously (`workspace-coordinator.service.ts:130-182`); the canvas then reacts to the new active path and calls `switchWorkspaceTiles()` (`orchestra-canvas.component.ts:329-334`). `CanvasStore.focusTile()` only writes focus for its current path and calls `TabManagerService.switchTab()` (`canvas.store.ts:264-273`). No method composes these into an awaited cross-workspace focus.
+
+Six cases have no complete path today:
+
+1. **Resolve identity:** an entry can carry a rotated session id, a tab id, or fan out to several bound tabs; current `CanvasSessionRequest` carries only `sessionId`/name (`app-state.service.ts:108-120`). Resolve to a canonical `{workspacePath, tabId, sessionId}` using the tab partition/router indexes, with deterministic handling of multiple tabs.
+2. **Non-active workspace:** the current request is consumed by whichever canvas is active. It does not switch workspace. The transaction must `await workspaceCoordinator.switchWorkspace(targetPath)` before issuing tile focus.
+3. **LRU-evicted grid:** after the switch, the target `CanvasWorkspaceGridComponent` may be newly mounted. Wait for a canvas/grid-ready acknowledgement; a signal write followed immediately by `focusTile` is a race with component creation and GridStack registration.
+4. **Existing tab and existing tile:** focus it without calling `session:load`; switch the tab and then focus the tile after restoration.
+5. **Existing tab but no canvas tile:** call `adoptTab(tabId)`, not `addTileFromSession`, then focus. This covers user-removed tiles and tabs restored beyond prior canvas membership.
+6. **No usable tab/tile:** decide explicitly whether to create/load a tab and adopt it, or show a stale/deleted notification. Handle the nine-tile cap (`canvas.store.ts:130-176`), layout not in grid mode, canvas unmounted (the current request merely times out false after five seconds at `app-state.service.ts:653-674`), removed workspace, and missing session without silently doing nothing.
+
+Define a core request/response contract such as `requestCanvasFocus(target): Promise<FocusResult>` with structured outcomes (`focused`, `stale`, `workspace-missing`, `tile-cap`, `canvas-unavailable`, `load-failed`). The chat shell/orchestrator owns the transaction because it can coordinate workspace and view state; the component-scoped CanvasStore remains behind the existing signal bridge. Set the app view/layout to the canvas before waiting for readiness, restore focus to the tile or first actionable control, and mark read only after successful navigation—not on pointer-down.
+
+### 5. Sound and CSP
+
+The VS Code webview CSP is `default-src 'none'` and includes img/script/style/font/connect/frame/object/base directives but **no `media-src`** (`apps/ptah-extension-vscode/src/services/webview-html-generator.ts:269-278`). Therefore a bundled `<audio>` file is not currently allowed merely because its URI came through `asWebviewUri`; `default-src 'none'` is the fallback. A data URI also needs an explicit `media-src data:`. Electron's renderer path does not remove the VS Code constraint from the shared component.
+
+The simplest cross-host choice is a short WebAudio oscillator/envelope generated in code: no fetched asset, no second host URL adapter, and no CSP media change. It must lazily create/resume `AudioContext` after user activation; autoplay policy means the first background completion before any interaction may be silent, and that is an acceptable documented fallback. If product insists on a designed audio asset, bundle it and add the narrow `media-src ${webview.cspSource}` (and `data:` only if actually used), then test the production webview CSP.
+
+Provide a real mute preference. `prefers-reduced-motion` must disable pulse/transition motion; it is not semantically an audio preference, though it may be used as a conservative default for surprise effects. Persist `notifications.soundEnabled` through the existing host-backed `settings:get`/`settings:set` RPC rather than ad-hoc localStorage so VS Code and Electron agree; those methods are the shared settings boundary (`rpc.types.ts:1347-1355`, handlers in `libs/backend/rpc-handlers/src/lib/handlers/settings-rpc.handlers.ts:104-163`). Validate the boundary and make sound opt-in or clearly controllable. Never play a sound for restored/replayed history, self-acknowledged prompts, or while the relevant session is already focused.
+
+### 6. Accessibility
+
+- Bell is a real button with an accessible name containing the unread count, `aria-expanded`, `aria-controls`, and visible focus.
+- Popover supports Enter/Space to open, Escape to close, Arrow keys or normal tab order, Home/End if using listbox semantics, and returns focus to the bell on close. Do not use menu semantics unless every child really is a menu item.
+- On open, focus the heading or first unread entry; after successful activation, move focus to the target tile/header or its pending prompt control.
+- Keep one visually hidden `aria-live="polite"`/`role="status"` announcer outside the popover. Announce a coalesced summary (“12 sessions finished; 3 need attention”), not every streaming event. Permission requests needing immediate action may be announced assertively only if testing shows it is not disruptive.
+- Icons/colors require text labels (“Needs permission”, “Failed”, “Finished”). Respect reduced motion and high-contrast/forced-colors modes.
+- Theme placement is host-specific: VS Code's theme toggle is only inside `@if (!isElectron)` at `app-shell.component.html:660-677`; Electron places its global theme toggle at `electron-shell.component.ts:211-222`. The bell must be added to both locations, not only `AppShell`.
+
+### 7. Bursts: 30 open, 12 complete together
+
+Keep individual records for navigation, but present and announce groups. Group by workspace and kind in the popover; default sort is actionable prompts first, then failures, then completions, newest group first. Collapse a burst window (for example 750–1500 ms) into one sound and one live-region announcement. Never debounce ledger insertion—the identities and navigation targets must survive—but debounce/coalesce only the external sound/announcement side effects.
+
+Bound history by both count and age (for example 200 records/7 days), while unresolved prompt entries remain source-derived and therefore cannot be evicted from the actionable view. Deduplicate terminal records by `{sessionId, revision, kind}`; fan-out tabs should be one completion with multiple possible surfaces unless product explicitly wants one record per tab. Badge count should mean unread groups or unread sessions, not raw events. A “mark all read” action must not resolve prompts.
+
+At 25–50 simultaneous sessions, add a notification storm test: 12 terminal states in one batch, prompt arrivals during the burst, replayed terminal revisions, workspace switching during click, and two clicks racing to different workspaces.
+
+## Confirmed concurrency track: 25–50 generating sessions
+
+This requirement is now in scope, not a hypothetical risk. The UI plan can reduce renderer cost, but it does not establish that the product can sustain 50 SDK queries, tool processes, permission waits, event streams, persistence writes, and session-state records concurrently.
+
+Before raising `CanvasStore.MAX_TILES` above nine, establish:
+
+- a documented per-session and host-wide resource budget (processes, file descriptors/handles, memory, stdout/event throughput, PTYs/tool children, pending prompts, transcript/event caps);
+- admission and overload behavior that still permits the target 50 genuine generators on supported hardware, with cancellation/fairness and no session starving another;
+- isolation: one blocked tool/prompt, slow consumer, malformed event, or failed SDK process cannot stall other sessions;
+- transport backpressure and batching. The existing `ChatStreamBroadcaster` and `stream-batch-buffer.ts` are the correct surfaces to profile; do not create one UI subscription per rendered level or drop events merely because a tile is not Live;
+- durable, bounded turn-state and prompt routing across workspace switches and renderer reloads;
+- load tests at 25 and 50 simultaneous root sessions, including subagents/tools, plus a soak long enough to expose heap growth, synchronous localStorage pressure, event-loop lag, and sound/notification storms.
+
+Relevant implementation surfaces to audit are `libs/backend/agent-sdk/src/lib/sdk-agent-adapter.ts`, `helpers/session-turn-state.registry.ts`, permission/question registries, `libs/backend/rpc-handlers/src/lib/chat/streaming/chat-stream-broadcaster.service.ts`, `stream-batch-buffer.ts`, the host webview managers, frontend `StreamingHandlerService`/accumulators, and tab persistence. The internal-query gate described in `agent-sdk/CLAUDE.md` governs a different background-query facility; do not mistake its configurable concurrency for user-session capacity.
+
+The UI allocator must also be load-tested with all 50 continuing to update while only 0–6 are Live. If Folded/Chip still causes full execution-tree reconstruction or every delta triggers global computed invalidation, the LOD design has failed even if DOM node count looks small.
+
+## Corrected ordered sequence
+
+The confirmation of 25–50 simultaneous runs changes the sequence. Compact redesign remains the first **UI** change, but concurrency discovery and a baseline load harness become step zero and a release gate; no tile-cap increase waits until the backend/transport track passes.
+
+1. **Concurrency baseline and contracts.** Build a repeatable 25/50-session load/soak harness; measure host/SDK process count, heap, event-loop lag, batch throughput, persistence, renderer signal invalidations, and failure isolation. Decide supported hardware/resource budgets and overload behavior.
+2. **Compact summary reducer and card.** Replace the mini transcript with the four-zone, non-scrolling presentation; correct prompt routing and state animation; retain current max tile count.
+3. **Versioned canvas-intent persistence.** Add the independent V1 envelope, reconciliation, debounced writes, and migration behavior. Measure remount from worst-case persisted messages before changing keep-alive.
+4. **LOD allocator and lifecycle.** Implement the central budget policy, four negative work contracts, viewport/hysteresis calculation, initial `@defer`, and explicit `@if` eviction. Prove background sessions keep routing while heavy views are destroyed.
+5. **Lower retained-grid cap experimentally.** Profile cap 4 versus 1 with long transcripts and 50 active streams. Ship 1 only if remount latency is acceptable; otherwise retain 2 or add a short warm cache. This is a measured value, not an architectural axiom.
+6. **Backend/transport hardening to the confirmed concurrency target.** Address bottlenecks exposed by step 1, then pass 25/50 soak and failure-injection gates. Only now raise canvas/session membership caps and remove the 3x3 assumptions.
+7. **Notification data model and terminal edge.** Add the accepted-transition completion ledger, computed prompt projection, dedupe/read/group policies, and replay tests before building the popover.
+8. **Cross-workspace focus transaction.** Add the awaited core bridge and all structured failure cases; test active, inactive, evicted, absent-tile, cap, missing-workspace/session, and rapid-race paths.
+9. **Notification UI, sound, and accessibility.** Place the bell in both shells, add keyboard/live-region behavior, mute setting, WebAudio side effect, and burst coalescing.
+10. **Zoom after LOD semantics are stable.** Add world/viewport scaling, bounds compensation, stop hysteresis, and derived locking. Zoom consumes the allocator; implementing it first would force the LOD policy to be rewritten.
+11. **Integrated performance/accessibility gate.** Run 50 simultaneous sessions across several workspaces with zooming, eviction, prompts, burst completions, reduced motion, keyboard-only navigation, and host-specific VS Code/Electron builds.
+
+## File-level change list by step
+
+This is a planning inventory, not permission to implement.
+
+### 1 and 6: concurrency baseline/hardening
+
+- `libs/backend/agent-sdk/src/lib/sdk-agent-adapter.ts` and its specs — lifecycle, cancellation, per-query resource accounting.
+- `libs/backend/agent-sdk/src/lib/helpers/session-turn-state.registry.ts` and specs — bounded 50-session state/revision behavior.
+- `libs/backend/agent-sdk/src/lib/permission/*` — pending prompt capacity, cleanup, and isolation.
+- `libs/backend/rpc-handlers/src/lib/chat/streaming/chat-stream-broadcaster.service.ts`, `stream-batch-buffer.ts`, and specs — batching/backpressure/fairness.
+- Host webview/message managers in `apps/ptah-extension-vscode` and `apps/ptah-electron` — delivery throughput and closed-renderer behavior.
+- `libs/frontend/chat-streaming/src/lib/*accumulator*`, `streaming-handler.service.ts`, and specs — bounded event retention and cross-session invalidation.
+- `libs/frontend/chat-state/src/lib/tab-persistence.ts` and partition specs — persistence cost under 50 active sessions.
+- A dedicated performance/load harness project or existing e2e/perf project, with both VS Code and Electron scenarios; do not hide it in a unit spec.
+
+### 2: compact tile
+
+- `libs/frontend/chat-ui/src/lib/molecules/compact-session/compact-session-activity.component.ts` and spec — replace feed UI with presentational four-zone component or split atoms.
+- New compact summary types/pure reducer under `libs/frontend/chat-ui/src/lib/molecules/compact-session/` only if inputs remain presentation-ready; otherwise place orchestration in chat.
+- `libs/frontend/chat/src/lib/components/molecules/compact-session/compact-session-card.component.ts` and spec — derive per-tab inputs, targeted prompts, remove canvas-redundant chrome/input/footer.
+- `libs/frontend/canvas/src/lib/canvas-tile.component.ts` and spec — pass canvas context/status style, retain sole title/mode controls.
+- `libs/frontend/chat-ui/src/index.ts` and `libs/frontend/chat/src/lib/components/index.ts` — remove obsolete exports only after usage is gone.
+- `apps/ptah-extension-webview/src/styles.css` or component styles — compositor-safe pseudo-element and reduced-motion fallback.
+
+### 3 and 5: persistence/retention
+
+- New focused persistence adapter/schema files in `libs/frontend/canvas/src/lib/` (for example `canvas-persistence.ts` and `.spec.ts`) — V1 Zod envelope, sanitize/reconcile.
+- `libs/frontend/canvas/src/lib/canvas.store.ts` and spec — hydrate/write intent, pin field, focused id, membership semantics, configurable/measured retained cap.
+- `libs/frontend/canvas/src/lib/orchestra-canvas.component.ts` and spec — initialization ordering and flush/restore; replace membership-only restoration when a canvas record exists.
+- `libs/frontend/chat-state/src/lib/tab-workspace-partition.service.ts` only if a public canonical workspace storage-key helper is extracted; do not couple canvas to its private map.
+- Keep `tab-persistence.ts` version 2 unchanged unless tab schema itself changes.
+
+### 4: LOD
+
+- New `libs/frontend/canvas/src/lib/canvas-lod-allocator.service.ts` and spec — central budgets, priority, hysteresis, hard cap.
+- `canvas-workspace-grid.component.ts` and spec — viewport reporting and LOD input per tile.
+- `canvas-tile.component.ts` and spec — explicit Live/Compact/Folded/Chip branches, defer-for-create and if-for-evict, lifecycle cleanup.
+- `canvas.store.ts` — user pin intent only; no persisted effective LOD.
+- `orchestra-canvas.component.ts` — allocator composition and global budgets across the active/retained surfaces.
+
+### 7–9: notification center and navigation
+
+- New `libs/frontend/notification-center/project.json` with `scope:webview`, `type:feature`; `src/index.ts` as the only public API.
+- New notification projection/store, component/popover, sound service, and focused specs in that lib.
+- `libs/frontend/chat-state/src/lib/tab-manager.service.ts` and specs — emit/append a dedupable terminal transition record at accepted `applyTurnState`; expose cross-workspace lookup metadata without UI dependencies.
+- `libs/frontend/chat-streaming/src/lib/permission-handler.service.ts` and specs — expose target-aware readonly projections/helpers without duplicating request state.
+- `libs/frontend/chat-routing/src/lib/stream-router.service.ts` tests — prove routing metadata, not notification duplication.
+- `libs/frontend/core/src/lib/services/app-state.service.ts` plus a core token/type — structured, awaited canvas-focus request/result.
+- `libs/frontend/chat/src/lib/services/workspace-coordinator.service.ts` and a new/focused navigation orchestrator — own the cross-workspace transaction.
+- `libs/frontend/canvas/src/lib/orchestra-canvas.component.ts`, `canvas.store.ts`, and specs — consume focus requests, await readiness/adoption/focus, return structured result.
+- `libs/frontend/chat/src/lib/components/templates/app-shell.component.html/.ts` — VS Code placement.
+- `libs/frontend/chat/src/lib/components/templates/electron-shell.component.ts` — Electron placement.
+- Shared settings RPC contracts/registry and frontend settings UI for `notifications.soundEnabled`; `apps/ptah-extension-vscode/src/services/webview-html-generator.ts` only if an audio asset is chosen and `media-src` is required.
+- Webview/electron e2e tests — keyboard, focus restoration, live announcements, CSP/audio, burst grouping, cross-workspace navigation.
+
+### 10: zoom
+
+- `libs/frontend/canvas/src/lib/orchestra-canvas.component.ts` and styles — controls, outer viewport/world/bounds wrapper.
+- `canvas-workspace-grid.component.ts` and specs — scale/stop/effective-lock inputs and hidden-grid remeasure ordering.
+- `canvas-layout.service.ts` and specs — explicit unscaled measurement contract; no scale feedback into `cellHeightFor`.
+- New small zoom state/controller under canvas if needed — `zoomScale`, `zoomStop`, threshold hysteresis, pointer anchor math.
+- `canvas.store.ts` only for persisted user zoom preference if product explicitly wants one; do not mix zoom with tile geometry intent by default.
+
+## What to drop or change
+
+- **Drop the prose-duplication rationale.** It is refuted by the immediate return at `compact-session-activity.component.ts:582`.
+- **Drop a general notification event bus and StreamRouter “notification pushes.”** They duplicate prompt truth and reintroduce ordering races.
+- **Drop “custom property means compositor.”** Animate transform/opacity on a pseudo-element.
+- **Drop `@defer` as eviction.** It is a monotonic creation state machine in the installed Angular runtime.
+- **Drop “cap 1” as a foregone conclusion.** Make it a profiled result; cap 2 may be a better remount/heap tradeoff.
+- **Drop “workspace limit removed entirely.”** Only mounted grids become unbounded in count; retained state still needs bounds.
+- **Drop a permanent 6–9 Live target without stop-specific budgets.** Overview should have zero Live surfaces, and the confirmed 50-run target argues for starting at six or fewer.
+- **Defer deletion of compact header/input classes until non-canvas use is resolved.** Remove redundant composition first.
+- **Do not make `prefers-reduced-motion` the only sound control.** Add an explicit mute setting.
+
+## Riskiest assumption—now confirmed as a required track
+
+The earlier riskiest assumption was that “many tiles” meant many open sessions with only a few generating. The user has now confirmed the opposite: **25–50 sessions must be running simultaneously**. The risk is no longer uncertainty about scope; it is that this plan is predominantly a renderer design while the hardest capacity constraint may be backend process creation, tool/PTY fan-out, provider limits, stream multiplexing, memory retention, or synchronous persistence.
+
+That confirmation changes the recommendation in three ways:
+
+1. A concurrency load harness and resource contract move to step zero, before UI cap changes.
+2. LOD is still mandatory, but its proof is “44–50 background streams continue correctly while at most six heavy views exist,” not merely “the DOM is smaller.”
+3. Zoom and notification polish move behind a 25/50-session soak gate; otherwise the team can ship an elegant overview of a workload the core cannot sustain.
+
+The single highest-risk implementation assumption is now: **that the existing backend and host transport can run and fairly multiplex 50 independent SDK turns without an explicit, measured capacity architecture.** Nothing inspected establishes that. Treat 50-way generation as a cross-host performance and fault-isolation feature with its own acceptance criteria, not as a larger `MAX_TILES` constant.

--- a/.ptah/specs/TASK_2026_404_6fcd/context.md
+++ b/.ptah/specs/TASK_2026_404_6fcd/context.md
@@ -1,0 +1,73 @@
+# Context — Scale the Orchestra Canvas beyond nine tiles
+
+## What the user asked for
+
+The user opened this work with a question about the current Gridstack and canvas
+implementation. They wanted three things:
+
+1. Better performance.
+2. Zoom in and out.
+3. A way to go beyond the `MAX_TILES = 9` cap.
+
+Across the conversation the intent sharpened:
+
+- The user wants a **clear sweet spot between UI and UX**, not only a raw tile
+  count. Many tiles are useless if each one costs a screen of scrolling.
+- The user wants **collapsed, compacted and folded states** so a tile can cost
+  very little when it is not the one being read.
+- The user stated plainly that the **current compact view looks and feels bad**,
+  and supplied a screenshot. This is the highest-priority item to them.
+- The user wants **persistence to survive workspace switches** while many
+  sessions are open.
+- The user wants a **notification center**: a bell near the theme toggle that
+  surfaces finished sessions, pending permission requests and pending
+  `AskUserQuestion` prompts, with a short sound, and a click that focuses the
+  session.
+
+## Decisions the user made
+
+| Decision | Value | Consequence |
+|---|---|---|
+| Host priority | **Electron first.** VS Code may hide a capability if it is a blocker. | The webview CSP stops being a hard constraint on the sound. Per-host gating follows the existing `@if (!isElectron)` convention. |
+| Session target | **Many running at once**, not merely many open. | The renderer plan alone is insufficient. A concurrency track is required. |
+| This task | **Write the specification only.** No production code yet. | This folder is the deliverable. Implementation is a follow-up. |
+
+## How the analysis was produced
+
+Two passes, both by a Codex CLI agent working in parallel with the assistant,
+then reconciled against the code.
+
+1. `codex-canvas-investigation.md` — a read-only investigation of performance,
+   zoom options and the tile cap, with a file-and-line evidence table.
+2. `codex-plan-review.md` — an adversarial review of the resulting plan,
+   including the notification center design.
+
+The review corrected four assistant claims. Those corrections are recorded in
+`task-description.md` under "Claims that were wrong", because each one had
+already influenced the plan and must not be reintroduced by a later reader.
+
+## Task-id history
+
+This task was first written to `.ptah/specs/TASK_2026_392/`. That was an id
+collision: `origin/main` already carried a different `TASK_2026_392` (a CI and
+outage task). A branch checkout on 2026-09-09 at 03:02 replaced this task's
+`task.md` and `context.md` with main's, and the remaining files were lost.
+
+Re-minted here as `TASK_2026_404_6fcd` under the interim collision protocol:
+`404` is above the highest id known across `origin/main` (400), the current
+branch (401) and the `agent-messaging` worktree (402, 403), and the `6fcd`
+suffix makes the folder distinct even if another branch also mints 404.
+
+Do not renumber this folder. Do not "fix" the `id` field.
+
+## The one thing a reader should carry away
+
+Bound the **Live** population, not the tile count.
+
+Six to nine full chat surfaces is the readable maximum on any real monitor.
+Above that number, more tiles help navigation and awareness, not reading. So the
+product should let a user open fifty sessions, keep a handful alive, and make
+the rest cost a header strip each.
+
+The same idea already governs geometry in this library: geometry is derived and
+never stored. This work extends that idea to fidelity.

--- a/.ptah/specs/TASK_2026_404_6fcd/task-description.md
+++ b/.ptah/specs/TASK_2026_404_6fcd/task-description.md
@@ -1,0 +1,419 @@
+# Task description — Scale the Orchestra Canvas beyond nine tiles
+
+Status: specification. No production code has been written for this task.
+
+## Problem
+
+`CanvasStore.MAX_TILES = 9` and `RETAINED_WORKSPACE_CAP = 4` are memory brakes,
+not product choices. They exist because the canvas retains the wrong thing.
+
+Two facts drive everything below.
+
+1. **Every tile builds a full chat surface.** `CanvasTileComponent` creates a
+   child `EnvironmentInjector` in `ngOnInit` and instantiates `ChatViewComponent`
+   (`libs/frontend/canvas/src/lib/canvas-tile.component.ts:235-247`, `:107-114`).
+   The `@if (childInjector())` guard reads like a choice but is only a readiness
+   check, so it is always true. There is no tile-level virtualization.
+2. **A hidden workspace stays mounted.** The grid host only sets `display: none`
+   (`canvas-workspace-grid.component.ts:55`). Four retained workspaces times nine
+   tiles is up to 36 chat surfaces, plus the always-mounted main panel, which
+   retains up to eight transcript trees.
+
+The `visible` input does not stop rendering. It only defers streaming flushes and
+freezes the transcript view model. A hidden tile is still built and still in the
+DOM.
+
+The user's own summary of the symptom is that the compact tile "looks and feels
+very bad". That is the same problem seen from the front: the compact view is a
+smaller transcript, so it saves neither pixels nor work.
+
+## Two tracks
+
+The user confirmed the target is **25 to 50 sessions running at the same time**,
+not merely open. That splits the work.
+
+| Track | Owns | Bounds |
+|---|---|---|
+| **R — Renderer** | Tile fidelity, compact redesign, zoom, intent persistence, notifications | How much the UI costs per open session |
+| **C — Concurrency** | Running-session budget, streaming flush cost, transcript retention, provider rate limits | How much the system costs per running session |
+
+Track R does not bound Track C. A chip costs the same backend session as a full
+tile. Do not raise `MAX_TILES` until Track C has a measured answer.
+
+## In scope
+
+### Track R
+
+**Step 0 — Session identity.** A prerequisite found after the review. A
+notification and a compact status line both need to say *which* session they
+refer to, and today nothing can. See "Session identity" under Design decisions.
+
+1. **Instrumentation and contracts.** Counters for mounted Live surfaces, layout
+   passes, Gridstack `update()` calls, and streaming flushes per frame. The
+   level-of-detail admission table, the notification identity and read
+   semantics, and the canvas persistence schema, all written before any UI work.
+2. **Compact tile redesign.** Replace the scrolling activity feed with a bounded
+   summary view model that has two adapters, one for live `StreamingState` events
+   and one for finalized `ExecutionNode` messages.
+3. **Tile shell split and level-of-detail allocation.** Separate the tile shell
+   from the heavy chat surface. Add a central allocator with a Live budget.
+4. **Versioned canvas intent persistence.** Per workspace and panel, validated at
+   the storage boundary.
+5. **Zoom.** A continuous `zoomScale` for the transform and a stable `zoomStop`
+   for fidelity.
+6. **Notification center.** A new `libs/frontend/notification-center` library.
+7. **Cross-workspace focus routing.** One acknowledged activation transaction.
+8. **Host integration.** The bell beside the theme toggle in both shells.
+
+### Track C
+
+Track C begins with an investigation, because nothing here has been measured.
+
+1. Measure one running session end to end: renderer memory, backend memory,
+   event rate, and CPU.
+2. Determine whether any concurrency limit exists today in `agent-sdk` or
+   `cli-agent-runtime`, and where a budget would belong.
+3. Measure `BatchedUpdateService` flush cost as the count of streaming visible
+   tabs rises. It flushes per RAF for every registered visible tab
+   (`libs/frontend/chat-streaming/src/lib/batched-update.service.ts:85-124`).
+4. Measure localStorage pressure. `TabState.messages` retains full finalized
+   execution trees and persists them (`tab-persistence.ts:24-31`). Fifty long
+   transcripts may exceed the quota. Define the eviction policy if so.
+5. Define provider rate-limit and cost guardrails, and the queue behavior when
+   the budget is full.
+
+## Out of scope
+
+- A freeform pan-and-zoom viewport that replaces Gridstack positioning. Revisit
+  only if infinite space and cross-cluster drag become real requirements.
+- Any change to the `TileLayout` shape. `libs/frontend/tribunal-panel` imports it
+  and mutates positions through `updateTilePosition`.
+- Re-adding `x`, `y`, `w` or `h` to `CanvasTile`.
+- Making `CanvasStore` root-scoped. It must stay per panel.
+- Raising `MAX_TILES` in this task. That is gated on Track C.
+
+## Constraints
+
+- Angular 21 signals, standalone components, `OnPush`, zoneless-safe.
+- Geometry stays derived. A durable user preference such as a fidelity pin is
+  acceptable intent. Derived geometry is not.
+- Only `CanvasWorkspaceGridComponent` may call a Gridstack API.
+  `CanvasLayoutService` must never import Gridstack.
+- Frontend libraries must not import backend libraries.
+- `MAX_COLUMNS` must stay at 6 or below. Above 6, `apportionRow` returns a row
+  wider than `GRID_COLUMNS = 12` and the layout corrupts
+  (`canvas-layout.service.ts:177-220`). This dependency is not documented in
+  `libs/frontend/canvas/CLAUDE.md:26` and must be added.
+
+## Claims that were wrong
+
+These four claims shaped an earlier version of the plan. They are false. Do not
+reintroduce them.
+
+1. **Finalized prose is not duplicated.** `walkExecutionTree` returns
+   immediately after the agent branch (`compact-session-activity.component.ts:582`)
+   and never recurses into the agent's direct text children. The compact redesign
+   is justified by low information density, not by duplication.
+2. **Workspace eviction does not reload the session.** Tab state is returned from
+   the in-memory partition map, and `TabState.messages` retains finalized trees.
+   The real cost is DOM and injector reconstruction.
+3. **Canvas intent is not persisted today.** `restoreCanvasTilesFromTabs()` only
+   seeds default order and weight through `appendTile()`. It restores no prior
+   arrangement.
+4. **Animating a border color is paint work, not compositor work.** Use a
+   positioned pseudo-element and animate `opacity` or `transform`.
+
+## Design decisions
+
+### Session identity (step 0)
+
+A notification that reads "session-09-09-03-14 finished" is useless at 30
+sessions. Today a tab title comes from one of five places, and none of them
+describes the work:
+
+| Path | Title | Evidence |
+|---|---|---|
+| User types a name | The name | `tab-manager.service.ts:778` |
+| User does not | `defaultSessionName()` → `session-09-09-03-14` | `default-session-name.util.ts:25` |
+| New tab | `'New Chat'` | `tab-manager.service.ts:953` |
+| Loaded session, no title | `claudeSessionId.substring(0, 50)` — a raw ID | `:740` |
+| Rename | Manual only; the UI must collect the input | `:2082` |
+
+There is no auto-titling from message content. Verified.
+
+Identity has three parts, and all three are needed:
+
+1. **Name.** Precedence: an explicit user name, then a title auto-derived from
+   the first user message, then the timestamp default. The middle layer is the
+   missing one. Derive on the first user message of a session: strip markdown,
+   collapse whitespace, truncate to about 40 characters, write once. Never
+   overwrite a user-given name, and never re-derive on later messages.
+2. **Place.** The workspace folder basename. The user runs nine workspaces, so a
+   title alone is ambiguous. A notification row reads
+   `ptah-extension · fix the compaction reload bug · finished`.
+3. **Color.** A stable color derived from the session ID, shown as a dot in the
+   tile header and in the notification row. `generateAgentColor` already exists
+   (`libs/frontend/chat-ui/src/lib/utils/agent-color.utils.ts`) and returns
+   OKLCH. Matching a notification to a tile becomes a color match rather than a
+   text read, which is what makes it work at 30 tiles.
+
+Constraints for this step: the derive must not fire for a session restored from
+history, must be idempotent under a replayed message, and must respect the
+existing `renameTab` result as user-owned. Title writes go through the existing
+`updateTabInternal` path, and the persistence mirror rules in
+`tab-persistence.ts` still apply.
+
+### Compact tile
+
+Four fixed zones and no inner scroll: a status line, a pulse strip of about 24
+marks, one content slot, and a metrics footer.
+
+Delete `CompactSessionHeaderComponent` and `CompactSessionInputComponent` from
+the card, and delete the card's own collapse and full-view footer. The canvas
+tile header already carries the title and the mode toggle
+(`canvas-tile.component.ts:65-97`). Remove the exports at
+`libs/frontend/chat-ui/src/index.ts:47-48` if the files are deleted.
+
+Content slot precedence: targeted pending question, then targeted pending
+permission, then newest error, then newest prose, then idle.
+
+Two rules that a naive implementation will get wrong:
+
+- **Resolve the prompt by router target metadata first, then by session ID.**
+  Filtering by `request.sessionId` alone (`compact-session-card.component.ts:161`)
+  can miss the exact prompt the tile is meant to surface, because
+  `PermissionHandlerService` documents ID mismatches and router-attached target
+  tabs.
+- **Do not put a full prompt form in a fixed no-scroll slot.** A question card
+  can hold several questions. Render a blocking summary plus one action that
+  opens the full tile.
+
+State and focus must not share a style channel. Focus already owns
+`border-primary` and `ring-primary`. Give state the border and glow, and give
+focus the outline.
+
+`SessionStatus` has no `error` member. Derive error meaning from
+`lastTerminalReason`, not from `status`.
+
+### Level of detail
+
+`level = f(zoomStop, focus, intersection, pin, budget)`.
+
+Levels are Live, Compact, Folded and Chip. Only the pin is stored, and it must be
+named for what it promises, for example `detailPin?: 'live' | 'compact'`. A bare
+boolean called `pin` invites the reading "never evict", which cannot coexist with
+a hard budget.
+
+Admission order when several tiles want Live: the focused tile, then a blocking
+targeted prompt, then explicit pins by recency, then intersecting tiles by
+distance to the viewport center, then overscan. Take the first N. Start N at 6.
+
+`@defer (on viewport)` is a creation trigger only. Its state machine is
+monotonic, so it never evicts. The outer `@if (lod() === 'live')` owns eviction.
+A `display: none` ancestor delays the trigger, which is correct behavior for a
+retained workspace and not a defect.
+
+Tie `registerVisibleTab()` to an admitted Live surface, not to a mounted grid
+tile. Otherwise a folded tile keeps receiving per-frame streaming flushes and the
+level-of-detail work buys nothing.
+
+**Two traps in the shell split.** First, destroying the child injector must not
+destroy the session. The injector only provides `SESSION_CONTEXT`; the session
+lives in `TabManagerService` and `ChatStore`. A demotion keeps the tab open, the
+session running and `TabState.messages` intact. Assert this with a test, because
+it is the failure that would be worst and quietest. Second, promotion back to
+Live must re-read `TabState.messages` and must not call `switchSession()` — the
+current path at `orchestra-canvas.component.ts:290-301` does, which can trigger a
+needless `session:load` on every promotion.
+
+A demoted tile loses its transcript scroll position and promotion lands at the
+bottom. That is probably acceptable, but it should be chosen rather than
+discovered.
+
+### Zoom
+
+Four stops: Focus, Grid, Deck, Overview. A continuous `zoomScale` drives the CSS
+transform. A stable `zoomStop` with hysteresis drives fidelity. Fidelity must
+never follow a raw scale tick, or a small wheel movement near a threshold will
+repeatedly destroy and recreate a chat view.
+
+Wrapper contract:
+
+- The outer scroll viewport is the element `CanvasLayoutService` measures.
+- An untransformed spacer exposes the scaled scroll extents.
+- The inner world uses `transform: scale()` with `transform-origin: 0 0`.
+- The transformed world must never be the `ResizeObserver` target. Dividing the
+  measured width by the scale creates a feedback loop and cancels the zoom.
+- The spacer must follow Gridstack's real rendered height, not a height guessed
+  from the row rule in another service.
+
+Gridstack 12.6.0 does compensate for CSS transforms. It measures transformed
+elements (`node_modules/gridstack/dist/utils.js:714-736`) and stores a
+`dragTransform` at drag start (`gridstack.js:2678-2688`). This supports the
+approach but is third-party behavior, so it still needs integration coverage.
+
+Overview must derive `effectiveStatic = userLocked || zoomStop === 'overview'`.
+Calling `locked.set(true)` destroys the user's manual choice.
+
+Preserve a scroll anchor around the focused tile across stop changes.
+
+### Notification center
+
+Pending prompts are state. Completion is history. Do not push a duplicate event
+for a prompt from `StreamRouter`; a pushed queue can disagree with the source
+after an auto-resolution, a response, a timeout or a cancellation.
+
+The completion edge is detected inside `TabManagerService.applyTurnState()`
+(`tab-manager.service.ts:1157-1209`), which already searches across workspaces and
+is replay-protected by a monotonic revision. Detect it there, imperatively, in
+the reducer that already owns the transition. Do not watch `tabs()` in an effect:
+`tabs()` exposes only the active workspace and would miss the background
+completions this feature promises. Do not treat `status: loaded` as the signal —
+finalization and history loading also write it.
+
+Classify `phase === 'failed'` as an error. For idle, read `terminalReason`; an
+abort or a limit is not a pleasant success.
+
+Ownership: a new `libs/frontend/notification-center` tagged `scope:webview` and
+`type:feature`. The store cannot live in `chat-state`, which is tagged
+`type:data-access` and may depend only on data-access and util
+(`eslint.config.mjs:235-241`). `chat-state` contributes only the typed terminal
+pulse and the cross-workspace lookup. The shells own activation, because they
+already own navigation.
+
+Focus routing is one acknowledged transaction:
+
+```
+resolve {workspacePath, tabId?, sessionId}
+  -> appState.setCurrentView('chat')
+  -> appState.setLayoutMode('grid')
+  -> workspaceCoordinator.switchWorkspace(workspacePath)
+  -> acknowledged canvas focus request carrying workspacePath + tabId/sessionId
+  -> focus existing intent, else adopt existing tab, else open session
+  -> focus the tile after its shell exists
+  -> mark read only on success
+```
+
+It returns `{ success, outcome }` where outcome is one of `focused`, `adopted`,
+`opened`, `cap-reached` or `missing`. On `cap-reached`, fall back to the normal
+full session view rather than leaving a dead entry.
+
+`CanvasStore` is component-scoped, so the shell cannot inject it. Keep the
+`AppStateManager` bridge or add a narrow canvas-focus port.
+
+Sound: start with a short Web Audio envelope. It needs no asset and no CSP
+change, and it behaves the same in both hosts. Create or resume the
+`AudioContext` only after a user gesture, and skip the sound if it stays
+suspended. One sound per coalesced burst with a cooldown of about two seconds. A
+mute toggle in the panel. Suppress in automated tests.
+
+Bursts: bound the store to 50 to 100 entries. Coalesce completions inside a 250
+to 500 ms window and group by workspace. Never coalesce pending prompts so
+tightly that a request becomes unreachable.
+
+Accessibility: a real `<button>` with `aria-label`, `aria-haspopup`,
+`aria-expanded` and `aria-controls`; an exact count in the accessible name with
+`9+` capping only the visual badge; focus moved into the panel on open and
+restored on Escape; and one visually hidden `role="status"` announcer that
+speaks a coalesced phrase rather than twelve insertions.
+
+## Acceptance criteria
+
+### Track R
+
+0. A session whose user never typed a name shows a title derived from its first
+   user message. The derive runs once, does not fire on a history restore, does
+   not overwrite a user-given name, and survives a reload. Each session exposes
+   a stable color and a workspace label.
+1. A canvas holding 30 tiles mounts no more than the configured Live budget of
+   full `ChatViewComponent` instances. A test asserts the count.
+2. A compact tile renders in a fixed height with no internal scrollbar, and it
+   shows a blocking prompt summary within one frame of the prompt arriving.
+3. A layout pass issues at most one Gridstack `update()` call per changed node.
+   The current duplicate path through the Angular `[options]` setter is gone.
+4. Switching to single-chat layout mode deregisters the canvas tiles. The main
+   transcript and the canvas transcripts are never both live.
+5. Canvas order, weight and pin survive an application restart, restore against
+   valid tabs only, and reject a corrupt or older stored payload without
+   throwing.
+6. Drag and east-or-west resize behave correctly at every zoom stop, at non-unit
+   browser zoom, and at a non-unit Electron device pixel ratio.
+7. Entering Overview does not change the user's manual lock state. Leaving it
+   restores the prior interaction state.
+8. Demoting a tile below Live keeps its tab open, its session running and its
+   messages intact. Promoting it back issues no `session:load`.
+9. A completion in a background workspace produces exactly one notification
+   entry, and a replayed revision produces none.
+10. Clicking a notification for another workspace switches the workspace, focuses
+    the tile, and marks the entry read only on success.
+11. The bell is reachable and operable by keyboard, and a burst of twelve
+    completions produces one announcement and one sound.
+
+### Track C
+
+1. The per-session cost of one running session is measured and recorded.
+2. A concurrency budget exists, with defined queue behavior when it is full.
+3. Streaming flush cost is measured against the count of streaming visible tabs,
+   and the scaling is documented.
+4. A transcript retention or eviction policy exists that keeps persisted state
+   inside the storage quota at the target session count.
+5. `MAX_TILES` is raised only after criteria 1 to 4 hold.
+
+## Sequence
+
+Track R runs in this order. Zoom follows the level-of-detail work, because a zoom
+stop otherwise has nothing deterministic to control.
+
+0. Session identity — a prerequisite for steps 2 and 6
+1. Instrumentation and contracts
+2. Compact redesign
+3. Tile shell split and level-of-detail allocation
+4. Intent persistence
+5. Zoom
+6. Terminal pulse and notification store
+7. Cross-workspace focus routing
+8. Host integration
+
+Track C step 1, the measurement, should start in parallel with Track R step 1.
+Everything else in Track C depends on what that measurement finds.
+
+Step 3 is load-bearing. Until the child injector and the chat outlet in
+`CanvasTileComponent` are conditional, a folded tile still pays most of today's
+cost, and steps 4 through 8 deliver much less than they appear to. Step 4's
+"restore folded, hydrate focused" has no cheap rendering to restore into, and
+step 5's Overview would scale full chat views down to chips rather than
+replacing them.
+
+## Risks
+
+| Risk | Why it matters | Mitigation |
+|---|---|---|
+| Renderer work is mistaken for concurrency work | A chip costs the same backend session as a full tile | Track C is separate and gates `MAX_TILES` |
+| Level-of-detail thrash at viewport edges | Mount and unmount churn is worse than always-live | Hysteresis, root margin, and a demotion delay |
+| Zoom and fidelity coupled to one value | A wheel tick destroys a chat view | Split `zoomScale` from `zoomStop` |
+| Notification queue drifts from the prompt source | A badge outlives the request | Pending prompts stay computed and are never pushed |
+| localStorage quota at 50 long transcripts | Silent persistence failure | Track C criterion 4 |
+| Gridstack behavior under transform | Third-party behavior, not a guarantee | Integration tests at several scales and device pixel ratios |
+
+## Open questions
+
+1. What is the per-session backend cost of a running session? Unmeasured.
+2. Does any concurrency limit exist today in `agent-sdk` or `cli-agent-runtime`?
+3. What is the correct Live budget? Six is a starting value, not a measurement.
+4. Should the notification mute preference live in localStorage as a UI-only
+   setting, or in the host-agnostic `~/.ptah/settings.json` path? Choose one.
+   Do not create two stores.
+5. Does the product want a Live focused tile in Overview? If yes, Overview is not
+   a cheap overview and the stop table must change.
+
+## Evidence
+
+- `codex-canvas-investigation.md` — performance, zoom options and the tile cap,
+  with a file-and-line evidence table.
+- `codex-plan-review.md` — adversarial review of this plan, including the
+  notification architecture and the corrections listed above.
+
+Both reports were lost to the `TASK_2026_392` id collision and were regenerated
+by resuming the original Codex sessions. If either is missing, resume Codex
+session `01a08296-7c0b-7391-90a6-e9296450e463` (investigation) or
+`01a082c3-5e70-7581-ae98-dc71403bf65f` (review).

--- a/.ptah/specs/TASK_2026_404_6fcd/task.md
+++ b/.ptah/specs/TASK_2026_404_6fcd/task.md
@@ -1,0 +1,19 @@
+---
+id: TASK_2026_404_6fcd
+status: backlog
+type: feature
+title: Scale the Orchestra Canvas beyond nine tiles
+description: >-
+  Replace DOM-based retention with derived tile fidelity, redesign the compact
+  tile as a glanceable summary, add semantic zoom, persist canvas intent, and
+  add a notification center. Includes a separate concurrency track for many
+  simultaneously running sessions.
+---
+
+Two tracks. Track R makes the renderer bounded so tile count stops being the
+limit. Track C bounds simultaneously running agent sessions, which the renderer
+work does not address.
+
+Investigation and adversarial review are complete. See `context.md` for intent,
+`task-description.md` for scope and acceptance criteria,
+`codex-canvas-investigation.md` and `codex-plan-review.md` for the evidence.

--- a/apps/ptah-docs/src/content/docs/git/worktrees.md
+++ b/apps/ptah-docs/src/content/docs/git/worktrees.md
@@ -15,13 +15,13 @@ Worktrees sidestep this entirely. Each agent can be pinned to its own worktree, 
 
 | Scenario                               | Without worktrees         | With worktrees                       |
 | -------------------------------------- | ------------------------- | ------------------------------------ |
-| Review a PR while an agent refactors   | Stash, checkout, un-stash | `git worktree add ../review pr-123`  |
+| Review a PR while an agent refactors   | Stash, checkout, un-stash | One branch per worktree              |
 | Run agents on two features in parallel | Serial execution only     | Two worktrees, two concurrent agents |
-| Hotfix on `main` during feature work   | Stash or commit WIP first | Add a worktree on `main`, fix, push  |
+| Hotfix on `main` during feature work   | Stash or commit WIP first | Separate hotfix worktree             |
 
 ## Creating a worktree
 
-From the UI: **View → Git Worktrees → Add worktree**. Pick a target folder and either an existing branch or a new branch name.
+From the UI: open the **Git** dock, expand **Worktrees**, then choose **Add worktree**. Enter an existing branch and optional target path, or select **Create new branch**. Creation refreshes the list but does not switch your current workspace; click the new row when you want to open it.
 
 From an agent, using the MCP tool:
 
@@ -29,22 +29,23 @@ From an agent, using the MCP tool:
 {
   "tool": "ptah_git_worktree_add",
   "arguments": {
-    "path": "../my-project-feature-x",
     "branch": "feature/x",
     "createBranch": true
   }
 }
 ```
 
+Omit `path` to use Ptah's default: `<workspace>/.claude-worktrees/<safe-branch-name>`. For example, `feature/x` becomes `.claude-worktrees/feature-x`. Relative custom paths must remain inside the workspace; use an absolute path when another location or volume is required.
+
 Equivalent shell:
 
 ```bash
-git worktree add -b feature/x ../my-project-feature-x
+git worktree add -b feature/x .claude-worktrees/feature-x
 ```
 
 ## Listing worktrees
 
-The **Git Worktrees** panel shows every worktree linked to the current repo, with its path, branch, and HEAD commit. Clicking a worktree opens it as a workspace in a new Ptah window.
+The **Git Worktrees** panel shows every worktree linked to the current repo, with its path, branch, and HEAD commit. Creation events only refresh this list. Clicking a worktree row explicitly registers it in the current Ptah window and switches to it. Background agent worktree creation never changes the current workspace or session.
 
 Via MCP tool:
 
@@ -56,7 +57,7 @@ Via MCP tool:
 
 ## Removing a worktree
 
-From the UI: right-click a worktree in the panel → **Remove**. Ptah prompts before removing and refuses to remove a worktree with uncommitted changes unless you explicitly override.
+From the UI: choose **Remove** on a non-main worktree. Ptah prompts before removing and refuses to remove a worktree with uncommitted changes unless you explicitly override. If you had explicitly opened that worktree in the current window, successful removal unregisters it; unopened worktrees do not affect the workspace list.
 
 Via MCP tool:
 
@@ -64,7 +65,7 @@ Via MCP tool:
 {
   "tool": "ptah_git_worktree_remove",
   "arguments": {
-    "path": "../my-project-feature-x",
+    "path": "/absolute/path/to/my-project-feature-x",
     "force": false
   }
 }
@@ -76,14 +77,18 @@ Via MCP tool:
 
 ## Layout convention
 
-A worktree-friendly folder layout that plays nicely with Ptah:
+The MCP default keeps worktrees inside the repository:
 
 ```
-~/code/
-├── my-project/              # Main worktree (clone root)
-├── my-project-feature-x/    # Worktree: feature/x
-├── my-project-review-123/   # Worktree: pr-123
-└── my-project-hotfix/       # Worktree: hotfix/urgent
+~/code/my-project/
+├── .claude-worktrees/
+│   ├── feature-x/       # Worktree: feature/x
+│   └── hotfix-urgent/   # Worktree: hotfix/urgent
+└── ...                  # Main worktree
 ```
 
-Ptah detects that all four folders share the same git repo and groups them in the worktree panel, regardless of which one you opened first.
+Run agents and development commands with `cwd` set to the selected worktree path. In this nested layout, Node resolves dependencies through ancestor directories, so a worktree normally reuses the main checkout's `node_modules`; Ptah does not create a dependency symlink. Install dependencies inside the worktree only when it has a different dependency graph or no usable ancestor install.
+
+Ptah never auto-links `.env` files, secrets, caches, or build output into a worktree. Copy or configure only the inputs that task needs.
+
+Explicit absolute paths remain supported. Ptah detects linked worktrees and groups them in the panel regardless of which one you opened first.

--- a/apps/ptah-docs/src/content/docs/git/worktrees.md
+++ b/apps/ptah-docs/src/content/docs/git/worktrees.md
@@ -35,7 +35,7 @@ From an agent, using the MCP tool:
 }
 ```
 
-Omit `path` to use Ptah's default: `<workspace>/.claude-worktrees/<safe-branch-name>`. For example, `feature/x` becomes `.claude-worktrees/feature-x`. Relative custom paths must remain inside the workspace; use an absolute path when another location or volume is required.
+Omit `path` to use Ptah's default: `<workspace>/.claude-worktrees/<safe-branch-name>`. For example, `feature/x` becomes a bounded name such as `.claude-worktrees/feature-x-<hash>`; the hash keeps similar and long branch names distinct. Relative custom paths must remain inside the workspace; use an absolute path when another location or volume is required.
 
 Equivalent shell:
 

--- a/apps/ptah-electron-e2e/src/specs/git/git-dock.spec.ts
+++ b/apps/ptah-electron-e2e/src/specs/git/git-dock.spec.ts
@@ -191,9 +191,9 @@ test.describe('Git dock', () => {
     ).toBeVisible();
     expect(await ui.getObservedCalls('git:diffFile')).toEqual([]);
     await expect(page.locator('ptah-diff-view')).toHaveCount(0);
-    await expect(page.locator('[data-testid="diff-error-overlay"]')).toHaveCount(
-      0,
-    );
+    await expect(
+      page.locator('[data-testid="diff-error-overlay"]'),
+    ).toHaveCount(0);
 
     await changedSrc.click();
     await expect(changedSrc).toHaveAttribute('aria-expanded', 'false');
@@ -253,9 +253,9 @@ test.describe('Git dock', () => {
       exact: true,
     });
     await expect(alphaTab).toBeVisible();
-    await expect(page.locator('ptah-diff-view .view-lines').last()).toContainText(
-      'alpha modified',
-    );
+    await expect(
+      page.locator('ptah-diff-view .view-lines').last(),
+    ).toContainText('alpha modified');
 
     await ui.mockRpc({
       'git:diffFile': gitDiffFileMock({
@@ -278,15 +278,15 @@ test.describe('Git dock', () => {
     await expect(diffTablist).toBeVisible();
     await expect(diffTablist.getByRole('tab')).toHaveCount(2);
     await expect(betaTab).toHaveAttribute('aria-selected', 'true');
-    await expect(page.locator('ptah-diff-view .view-lines').last()).toContainText(
-      'beta modified',
-    );
+    await expect(
+      page.locator('ptah-diff-view .view-lines').last(),
+    ).toContainText('beta modified');
 
     await alphaTab.click();
     await expect(alphaTab).toHaveAttribute('aria-selected', 'true');
-    await expect(page.locator('ptah-diff-view .view-lines').last()).toContainText(
-      'alpha modified',
-    );
+    await expect(
+      page.locator('ptah-diff-view .view-lines').last(),
+    ).toContainText('alpha modified');
 
     await page
       .getByRole('button', {
@@ -297,8 +297,8 @@ test.describe('Git dock', () => {
     await expect(alphaTab).toHaveCount(0);
     await expect(diffTablist.getByRole('tab')).toHaveCount(1);
     await expect(betaTab).toHaveAttribute('aria-selected', 'true');
-    await expect(page.locator('ptah-diff-view .view-lines').last()).toContainText(
-      'beta modified',
-    );
+    await expect(
+      page.locator('ptah-diff-view .view-lines').last(),
+    ).toContainText('beta modified');
   });
 });

--- a/apps/ptah-electron-e2e/src/specs/git/git-dock.spec.ts
+++ b/apps/ptah-electron-e2e/src/specs/git/git-dock.spec.ts
@@ -16,6 +16,61 @@ import { gitDiffFileMock } from '../../support/git-diff-mock';
  * (see `git-dock.component.ts`'s constructor doc).
  */
 test.describe('Git dock', () => {
+  test('background worktree creation refreshes the list without switching workspace', async ({
+    ui,
+  }) => {
+    const workspacePath = 'C:\\ptah-e2e-ws';
+    const worktreePath = `${workspacePath}\\.claude-worktrees\\agent-task`;
+    await ui.mockRpc({
+      'git:worktrees': {
+        worktrees: [
+          {
+            path: workspacePath,
+            branch: 'main',
+            head: 'abc1234',
+            isMain: true,
+            isBare: false,
+          },
+          {
+            path: worktreePath,
+            branch: 'agent/task',
+            head: 'def5678',
+            isMain: false,
+            isBare: false,
+          },
+        ],
+      },
+    });
+    await ui.goto('git');
+    await ui.page
+      .getByRole('button', { name: 'Toggle worktrees section' })
+      .click();
+
+    const switchCallsBefore = (await ui.getObservedCalls('workspace:switch'))
+      .length;
+    const registerCallsBefore = (
+      await ui.getObservedCalls('workspace:registerFolder')
+    ).length;
+
+    await ui.pushEvent({
+      type: 'git:worktreeChanged',
+      payload: {
+        action: 'created',
+        name: 'agent-task',
+        path: worktreePath,
+      },
+    });
+
+    await expect(
+      ui.page.getByRole('button', { name: `Switch to ${worktreePath}` }),
+    ).toBeVisible();
+    expect(await ui.getObservedCalls('workspace:switch')).toHaveLength(
+      switchCallsBefore,
+    );
+    expect(await ui.getObservedCalls('workspace:registerFolder')).toHaveLength(
+      registerCallsBefore,
+    );
+  });
   test('git dock header hides the push button when there is nothing to push', async ({
     ui,
   }) => {

--- a/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.service.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.service.spec.ts
@@ -71,12 +71,18 @@ jest.mock('@ptah-extension/vscode-core', () => ({
 }));
 
 // Mock platform-core for the PLATFORM_TOKENS.WORKSPACE_PROVIDER injection.
-jest.mock('@ptah-extension/platform-core', () => ({
-  PLATFORM_TOKENS: {
-    WORKSPACE_PROVIDER: Symbol('WORKSPACE_PROVIDER'),
-    MCP_SERVER_STATUS: Symbol('MCP_SERVER_STATUS'),
-  },
-}));
+jest.mock('@ptah-extension/platform-core', () => {
+  const actual = jest.requireActual<
+    typeof import('@ptah-extension/platform-core')
+  >('@ptah-extension/platform-core');
+  return {
+    PLATFORM_TOKENS: {
+      WORKSPACE_PROVIDER: Symbol('WORKSPACE_PROVIDER'),
+      MCP_SERVER_STATUS: Symbol('MCP_SERVER_STATUS'),
+    },
+    isPathWithinRoots: actual.isPathWithinRoots,
+  };
+});
 
 // We need uuid to generate valid AgentIds, but shared uses it internally.
 // Produce unique-but-valid v4-shaped ids so multiple agents can coexist in

--- a/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.service.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.service.ts
@@ -14,7 +14,6 @@ import {
   type IHarnessPreflight,
 } from '@ptah-extension/agent-sdk';
 import { ChildProcess } from 'child_process';
-import { promises as fsPromises } from 'fs';
 import { EventEmitter } from 'eventemitter3';
 import {
   TOKENS,
@@ -22,7 +21,10 @@ import {
   SubagentRegistryService,
 } from '@ptah-extension/vscode-core';
 import type { SentryService } from '@ptah-extension/vscode-core';
-import { PLATFORM_TOKENS } from '@ptah-extension/platform-core';
+import {
+  PLATFORM_TOKENS,
+  isPathWithinRoots,
+} from '@ptah-extension/platform-core';
 import type {
   ICallerWorkspaceResolver,
   IMcpServerStatus,
@@ -2099,25 +2101,7 @@ export class AgentProcessManager {
     if (!dir || dir.trim() === '') {
       throw new Error('Working directory is required but was empty.');
     }
-    let normalizedDir: string;
-    let normalizedRoot: string;
-    if (process.platform === 'win32') {
-      const asciiLower = (s: string): string =>
-        s.replace(/[A-Z]/g, (c) => String.fromCharCode(c.charCodeAt(0) + 32));
-      normalizedDir = asciiLower(dir.replace(/\\/g, '/'));
-      normalizedRoot = asciiLower(workspaceRoot.replace(/\\/g, '/'));
-    } else {
-      let realDir = dir;
-      let realRoot = workspaceRoot;
-
-      realDir = await fsPromises.realpath(dir);
-
-      realRoot = await fsPromises.realpath(workspaceRoot);
-      normalizedDir = realDir;
-      normalizedRoot = realRoot;
-    }
-
-    if (!normalizedDir.startsWith(normalizedRoot)) {
+    if (!isPathWithinRoots(dir, [workspaceRoot])) {
       throw new Error(
         `Working directory must be within workspace root. ` +
           `Got: ${dir}, Expected prefix: ${workspaceRoot}`,

--- a/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.service.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.service.ts
@@ -14,6 +14,7 @@ import {
   type IHarnessPreflight,
 } from '@ptah-extension/agent-sdk';
 import { ChildProcess } from 'child_process';
+import { promises as fsPromises } from 'fs';
 import { EventEmitter } from 'eventemitter3';
 import {
   TOKENS,
@@ -2101,10 +2102,22 @@ export class AgentProcessManager {
     if (!dir || dir.trim() === '') {
       throw new Error('Working directory is required but was empty.');
     }
-    if (!isPathWithinRoots(dir, [workspaceRoot])) {
+    let realDirectory: string;
+    let realWorkspaceRoot: string;
+    try {
+      [realDirectory, realWorkspaceRoot] = await Promise.all([
+        fsPromises.realpath(dir),
+        fsPromises.realpath(workspaceRoot),
+      ]);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Cannot resolve working directory scope: ${message}`);
+    }
+
+    if (!isPathWithinRoots(realDirectory, [realWorkspaceRoot])) {
       throw new Error(
         `Working directory must be within workspace root. ` +
-          `Got: ${dir}, Expected prefix: ${workspaceRoot}`,
+          `Got: ${dir}, Expected root: ${workspaceRoot}`,
       );
     }
   }

--- a/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.workspace-scope.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.workspace-scope.spec.ts
@@ -17,15 +17,12 @@ import type {
   ICallerWorkspaceResolver,
   IWorkspaceProvider,
 } from '@ptah-extension/platform-core';
+import { promises as fsPromises } from 'fs';
 import type { AgentId, AgentProcessInfo } from '@ptah-extension/shared';
 import { AgentProcessManager } from './agent-process-manager.service';
 
-// The roots below are synthetic Windows paths that exist on no machine.
-// `validateWorkingDirectory` skips `realpath` on win32 but calls it everywhere
-// else, so without this mock the whole file passes on a developer's Windows box
-// and fails on the ubuntu CI runner with ENOENT. Identity-resolve, so the
-// `startsWith` prefix check downstream still measures what it is here to
-// measure. Same mock, same reason, as `agent-process-manager.service.spec.ts`.
+// Synthetic roots exist on no machine. Identity-resolve by default; focused
+// tests override this to model symlink/junction escapes and resolution errors.
 jest.mock('fs', () => {
   const actual = jest.requireActual('fs');
   return {
@@ -39,6 +36,9 @@ jest.mock('fs', () => {
 
 const ROOT_A = 'D:\\projects\\workspace-a';
 const ROOT_B = 'D:\\projects\\workspace-b';
+const mockedRealpath = fsPromises.realpath as jest.MockedFunction<
+  typeof fsPromises.realpath
+>;
 
 function makeManager(options: {
   providerRoot: string | undefined;
@@ -112,6 +112,9 @@ function validateWorkingDirectory(
 }
 
 describe('AgentProcessManager workspace scoping (TASK_2026_364)', () => {
+  beforeEach(() => {
+    mockedRealpath.mockImplementation(async (p) => String(p));
+  });
   describe('no resolver registered — the CLI host, and every pre-port caller', () => {
     it('validates the working directory against the platform provider root, as before', async () => {
       const manager = makeManager({ providerRoot: ROOT_A });
@@ -123,6 +126,27 @@ describe('AgentProcessManager workspace scoping (TASK_2026_364)', () => {
       );
     });
 
+    it('rejects a symlink or junction whose physical target escapes the workspace', async () => {
+      const manager = makeManager({ providerRoot: ROOT_A });
+      mockedRealpath.mockImplementation(async (input) => {
+        const value = String(input);
+        if (value === `${ROOT_A}\\linked-out`) return 'D:\\outside\\payload';
+        return value;
+      });
+
+      await expect(
+        validateWorkingDirectory(manager, `${ROOT_A}\\linked-out`),
+      ).rejects.toThrow(/within workspace root/);
+    });
+
+    it('fails closed when physical path resolution fails', async () => {
+      const manager = makeManager({ providerRoot: ROOT_A });
+      mockedRealpath.mockRejectedValueOnce(new Error('ENOENT'));
+
+      await expect(
+        validateWorkingDirectory(manager, `${ROOT_A}\\missing`),
+      ).rejects.toThrow(/Cannot resolve working directory scope: ENOENT/);
+    });
     it('rejects a Windows sibling whose path only shares the workspace prefix', async () => {
       const manager = makeManager({ providerRoot: ROOT_A });
       await expect(

--- a/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.workspace-scope.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.workspace-scope.spec.ts
@@ -123,6 +123,12 @@ describe('AgentProcessManager workspace scoping (TASK_2026_364)', () => {
       );
     });
 
+    it('rejects a Windows sibling whose path only shares the workspace prefix', async () => {
+      const manager = makeManager({ providerRoot: ROOT_A });
+      await expect(
+        validateWorkingDirectory(manager, `${ROOT_A}-evil\\sub`),
+      ).rejects.toThrow(/within workspace root/);
+    });
     it('getStatus() scoped by the provider root hides nothing the provider owns', () => {
       const manager = makeManager({ providerRoot: ROOT_A });
       seedAgent(manager, 'agent-1', `${ROOT_A}\\sub`);

--- a/libs/backend/vscode-core/src/index.ts
+++ b/libs/backend/vscode-core/src/index.ts
@@ -103,6 +103,10 @@ export {
   WORKTREE_GIT_TIMEOUT_MS,
 } from './utils/exec-git';
 export type { ExecGitOptions, ExecGitResult } from './utils/exec-git';
+export {
+  resolveWorktreePath,
+  worktreeDirectoryName,
+} from './utils/worktree-path';
 export { WorkspaceContextManager } from './services/workspace-context-manager';
 export { WorkspaceAwareStateStorage } from './services/workspace-aware-state-storage';
 export type { StateStorageFactory } from './services/workspace-aware-state-storage';

--- a/libs/backend/vscode-core/src/services/git-info.service.spec.ts
+++ b/libs/backend/vscode-core/src/services/git-info.service.spec.ts
@@ -36,6 +36,7 @@
  */
 
 import 'reflect-metadata';
+import * as path from 'path';
 
 // ---------------------------------------------------------------------------
 // Mock cross-spawn so we control stdout/stderr/exitCode per test.
@@ -116,6 +117,53 @@ describe('GitInfoService — new git methods (TASK_2026_111)', () => {
   // getBranches
   // ==========================================================================
 
+  describe('worktree paths', () => {
+    it('uses the shared nested default for UI/backend creation', async () => {
+      mockSpawn.mockImplementation(() =>
+        makeSpawnResult({ stdout: '', exitCode: 0 }),
+      );
+      const branch = 'feature/ui-default';
+
+      const result = await service.addWorktree(WS, { branch });
+
+      expect(result.success).toBe(true);
+      expect(result.worktreePath).toContain(
+        `${path.sep}.claude-worktrees${path.sep}`,
+      );
+      expect((mockSpawn.mock.calls[0][1] as string[]).at(-1)).toBe(branch);
+    });
+
+    it('rejects an escaping relative custom path before spawning git', async () => {
+      const result = await service.addWorktree(WS, {
+        branch: 'feature/x',
+        path: '../workspace-evil',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Relative worktree path must stay/);
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it('retains an explicit absolute custom path', async () => {
+      mockSpawn.mockImplementation(() =>
+        makeSpawnResult({ stdout: '', exitCode: 0 }),
+      );
+      const explicit = path.resolve('/worktrees/ui-explicit');
+
+      const result = await service.addWorktree(WS, {
+        branch: 'feature/x',
+        path: explicit,
+      });
+
+      expect(result).toEqual({ success: true, worktreePath: explicit });
+      expect(mockSpawn.mock.calls[0][1]).toEqual([
+        'worktree',
+        'add',
+        explicit,
+        'feature/x',
+      ]);
+    });
+  });
   describe('getBranches()', () => {
     /**
      * One `for-each-ref` line, in the field order of

--- a/libs/backend/vscode-core/src/services/git-info.service.ts
+++ b/libs/backend/vscode-core/src/services/git-info.service.ts
@@ -6,6 +6,7 @@
  */
 
 import * as path from 'path';
+import { resolveWorktreePath } from '../utils/worktree-path';
 import { createHash } from 'crypto';
 import type { IProcessSpawner } from '@ptah-extension/platform-core';
 import type { Logger } from '../logging';
@@ -431,8 +432,11 @@ export class GitInfoService {
     params: { branch: string; path?: string; createBranch?: boolean },
   ): Promise<{ success: boolean; worktreePath?: string; error?: string }> {
     try {
-      const worktreePath =
-        params.path || path.join(path.dirname(workspacePath), params.branch);
+      const worktreePath = resolveWorktreePath(
+        workspacePath,
+        params.branch,
+        params.path,
+      );
 
       const args = ['worktree', 'add'];
       if (params.createBranch) {

--- a/libs/backend/vscode-core/src/utils/worktree-path.spec.ts
+++ b/libs/backend/vscode-core/src/utils/worktree-path.spec.ts
@@ -1,0 +1,56 @@
+import { createHash } from 'crypto';
+import * as path from 'path';
+import { resolveWorktreePath, worktreeDirectoryName } from './worktree-path';
+
+function shortHash(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex').slice(0, 12);
+}
+
+describe('worktree path resolution', () => {
+  it('uses a nested, bounded, deterministic default path', () => {
+    const root = path.resolve('/repo');
+    const branch = 'feature/deep-change';
+
+    expect(resolveWorktreePath(root, branch)).toBe(
+      path.join(
+        root,
+        '.claude-worktrees',
+        `feature-deep-change-${shortHash(branch)}`,
+      ),
+    );
+  });
+
+  it('does not collapse distinct branch refs onto one directory', () => {
+    expect(worktreeDirectoryName('feature/a-b')).not.toBe(
+      worktreeDirectoryName('feature/a/b'),
+    );
+  });
+
+  it.each([`feature/${'a'.repeat(180)}`, 'feature/修复-ёж', '../escape'])(
+    'maps %p to one bounded filesystem-safe segment',
+    (branch) => {
+      const name = worktreeDirectoryName(branch);
+      expect(name.length).toBeLessThanOrEqual(64);
+      expect(name).not.toMatch(/[\\/]/);
+      expect(name).not.toBe('.');
+      expect(name).not.toBe('..');
+      expect(name.endsWith(shortHash(branch))).toBe(true);
+    },
+  );
+
+  it('rejects a relative custom path escaping the workspace', () => {
+    const root = path.resolve('/repo');
+    expect(() =>
+      resolveWorktreePath(root, 'feature/x', '../repo-evil'),
+    ).toThrow(/Relative worktree path must stay/);
+  });
+
+  it('retains explicit absolute paths', () => {
+    const root = path.resolve('/repo');
+    const explicit = path.resolve('/worktrees/feature-x');
+    expect(resolveWorktreePath(root, 'feature/x', explicit)).toBe(explicit);
+    expect(resolveWorktreePath(root, 'feature/x', 'D:/worktrees/x')).toBe(
+      'D:/worktrees/x',
+    );
+  });
+});

--- a/libs/backend/vscode-core/src/utils/worktree-path.ts
+++ b/libs/backend/vscode-core/src/utils/worktree-path.ts
@@ -1,0 +1,74 @@
+import { createHash } from 'crypto';
+import * as path from 'path';
+
+const WORKTREE_DIRECTORY = '.claude-worktrees';
+const MAX_WORKTREE_NAME_LENGTH = 64;
+const HASH_LENGTH = 12;
+const MAX_STEM_LENGTH = MAX_WORKTREE_NAME_LENGTH - HASH_LENGTH - 1;
+
+/**
+ * Derive a bounded directory name from a full branch ref.
+ *
+ * Git remains the authority on whether the ref itself is valid. The directory
+ * name cannot contain path separators or traversal segments, while a hash of
+ * the unmodified ref prevents distinct refs with similar readable stems from
+ * selecting the same directory.
+ */
+export function worktreeDirectoryName(branch: string): string {
+  const hash = createHash('sha256')
+    .update(branch, 'utf8')
+    .digest('hex')
+    .slice(0, HASH_LENGTH);
+  const stem = branch
+    .normalize('NFKC')
+    .replace(/[\\/]+/g, '-')
+    .replace(/[^\p{L}\p{N}._-]+/gu, '-')
+    .replace(/[-_.]{2,}/g, '-')
+    .replace(/^[-_.]+|[-_.]+$/g, '')
+    .slice(0, MAX_STEM_LENGTH)
+    .replace(/[-_.]+$/g, '');
+
+  return `${stem || 'worktree'}-${hash}`;
+}
+
+/**
+ * Resolve a worktree target consistently for UI RPC and MCP callers.
+ *
+ * Omitted paths use the nested SDK convention. Absolute paths remain an
+ * explicit escape hatch. Relative paths must remain lexically contained by the
+ * workspace root; physical containment is not applicable because the target
+ * normally does not exist yet.
+ */
+export function resolveWorktreePath(
+  workspaceRoot: string,
+  branch: string,
+  requestedPath?: string,
+): string {
+  if (!requestedPath) {
+    return path.join(
+      workspaceRoot,
+      WORKTREE_DIRECTORY,
+      worktreeDirectoryName(branch),
+    );
+  }
+
+  if (path.win32.isAbsolute(requestedPath)) {
+    return requestedPath;
+  }
+  if (path.isAbsolute(requestedPath)) {
+    return path.normalize(requestedPath);
+  }
+
+  const resolved = path.resolve(workspaceRoot, requestedPath);
+  const relative = path.relative(workspaceRoot, resolved);
+  if (
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(
+      'Relative worktree path must stay within the workspace root. Use an absolute path for another location.',
+    );
+  }
+  return resolved;
+}

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-core/tool-description.builder.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-core/tool-description.builder.ts
@@ -799,7 +799,7 @@ export function buildWorktreeAddTool(): MCPToolDefinition {
         path: {
           type: 'string',
           description:
-            'Custom path for the worktree directory (defaults to ../<branch>)',
+            'Custom path. Omit to use <workspace>/.claude-worktrees/<safe-branch-name>. Relative paths must stay inside the workspace; absolute paths may select another location.',
         },
         createBranch: {
           type: 'boolean',

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-core/tool-description.builder.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/mcp-core/tool-description.builder.ts
@@ -799,7 +799,7 @@ export function buildWorktreeAddTool(): MCPToolDefinition {
         path: {
           type: 'string',
           description:
-            'Custom path. Omit to use <workspace>/.claude-worktrees/<safe-branch-name>. Relative paths must stay inside the workspace; absolute paths may select another location.',
+            'Custom path. Omit to use <workspace>/.claude-worktrees/<safe-branch-name>-<hash>. Relative paths must stay inside the workspace; absolute paths may select another location.',
         },
         createBranch: {
           type: 'boolean',

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.spec.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import { EventEmitter } from 'events';
+import * as path from 'path';
 
 // Must mock before importing the SUT.
 jest.mock('cross-spawn', () => jest.fn());
@@ -171,6 +172,56 @@ describe('buildGitNamespace — worktreeList', () => {
 // ---------------------------------------------------------------------------
 
 describe('buildGitNamespace — worktreeAdd', () => {
+  it('defaults to a sanitized path nested under the workspace', async () => {
+    queueFakeChild({ exitCode: 0 });
+    const root = path.resolve('/repo');
+    const out = await buildGitNamespace(
+      makeDeps({ getWorkspaceRoot: () => root }),
+    ).worktreeAdd({ branch: 'feature/deep-change' });
+
+    const expected = path.join(
+      root,
+      '.claude-worktrees',
+      'feature-deep-change',
+    );
+    expect(out).toEqual({ success: true, worktreePath: expected });
+    const [, args] = crossSpawnMock.mock.calls[0];
+    expect(args).toEqual(['worktree', 'add', expected, 'feature/deep-change']);
+  });
+
+  it('rejects unsafe branch traversal before creating a default path', async () => {
+    const root = path.resolve('/repo');
+    const out = await buildGitNamespace(
+      makeDeps({ getWorkspaceRoot: () => root }),
+    ).worktreeAdd({ branch: '../escape' });
+
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/Branch name may contain only/);
+    expect(crossSpawnMock).not.toHaveBeenCalled();
+  });
+  it('rejects a relative custom path that traverses outside the workspace', async () => {
+    const root = path.resolve('/repo');
+    const out = await buildGitNamespace(
+      makeDeps({ getWorkspaceRoot: () => root }),
+    ).worktreeAdd({ branch: 'feature/x', path: '../repo-evil' });
+
+    expect(out.success).toBe(false);
+    expect(out.error).toMatch(/Relative worktree path must stay/);
+    expect(crossSpawnMock).not.toHaveBeenCalled();
+  });
+
+  it('retains an explicit absolute path outside the workspace', async () => {
+    queueFakeChild({ exitCode: 0 });
+    const root = path.resolve('/repo');
+    const explicit = path.resolve('/worktrees/feature-x');
+    const out = await buildGitNamespace(
+      makeDeps({ getWorkspaceRoot: () => root }),
+    ).worktreeAdd({ branch: 'feature/x', path: explicit });
+
+    expect(out).toEqual({ success: true, worktreePath: explicit });
+    const [, args] = crossSpawnMock.mock.calls[0];
+    expect(args).toEqual(['worktree', 'add', explicit, 'feature/x']);
+  });
   it('invokes `git worktree add <path> <branch>` by default', async () => {
     queueFakeChild({ exitCode: 0 });
     const out = await buildGitNamespace(makeDeps()).worktreeAdd({

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.spec.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import { EventEmitter } from 'events';
+import { createHash } from 'crypto';
 import * as path from 'path';
 
 // Must mock before importing the SUT.
@@ -29,6 +30,47 @@ jest.mock('@ptah-extension/vscode-core', () => {
   return {
     WORKTREE_GIT_TIMEOUT_MS: 300_000,
     DEFAULT_GIT_TIMEOUT_MS: 10_000,
+    resolveWorktreePath: (
+      workspaceRoot: string,
+      branch: string,
+      requestedPath?: string,
+    ) => {
+      const { createHash } = require('crypto');
+      const nodePath = require('path');
+      if (requestedPath) {
+        if (
+          nodePath.isAbsolute(requestedPath) ||
+          nodePath.win32.isAbsolute(requestedPath)
+        ) {
+          return requestedPath;
+        }
+        const resolved = nodePath.resolve(workspaceRoot, requestedPath);
+        const relative = nodePath.relative(workspaceRoot, resolved);
+        if (relative === '..' || relative.startsWith(`..${nodePath.sep}`)) {
+          throw new Error(
+            'Relative worktree path must stay within the workspace root.',
+          );
+        }
+        return resolved;
+      }
+      const hash = createHash('sha256')
+        .update(branch, 'utf8')
+        .digest('hex')
+        .slice(0, 12);
+      const stem = branch
+        .normalize('NFKC')
+        .replace(/[\\/]+/g, '-')
+        .replace(/[^\p{L}\p{N}._-]+/gu, '-')
+        .replace(/[-_.]{2,}/g, '-')
+        .replace(/^[-_.]+|[-_.]+$/g, '')
+        .slice(0, 51)
+        .replace(/[-_.]+$/g, '');
+      return nodePath.join(
+        workspaceRoot,
+        '.claude-worktrees',
+        `${stem || 'worktree'}-${hash}`,
+      );
+    },
     execGit: (args: string[], cwd: string) =>
       new Promise((resolve, reject) => {
         const child = crossSpawn('git', args, {
@@ -172,32 +214,76 @@ describe('buildGitNamespace — worktreeList', () => {
 // ---------------------------------------------------------------------------
 
 describe('buildGitNamespace — worktreeAdd', () => {
-  it('defaults to a sanitized path nested under the workspace', async () => {
+  it('defaults to a bounded hashed path nested under the workspace', async () => {
     queueFakeChild({ exitCode: 0 });
     const root = path.resolve('/repo');
+    const branch = 'feature/deep-change';
     const out = await buildGitNamespace(
       makeDeps({ getWorkspaceRoot: () => root }),
-    ).worktreeAdd({ branch: 'feature/deep-change' });
+    ).worktreeAdd({ branch });
 
+    const hash = createHash('sha256')
+      .update(branch, 'utf8')
+      .digest('hex')
+      .slice(0, 12);
     const expected = path.join(
       root,
       '.claude-worktrees',
-      'feature-deep-change',
+      `feature-deep-change-${hash}`,
     );
     expect(out).toEqual({ success: true, worktreePath: expected });
     const [, args] = crossSpawnMock.mock.calls[0];
-    expect(args).toEqual(['worktree', 'add', expected, 'feature/deep-change']);
+    expect(args).toEqual(['worktree', 'add', expected, branch]);
   });
 
-  it('rejects unsafe branch traversal before creating a default path', async () => {
+  it('keeps formerly-colliding branch refs on distinct default paths', async () => {
+    queueFakeChild({ exitCode: 0 });
+    queueFakeChild({ exitCode: 0 });
+    const root = path.resolve('/repo');
+    const namespace = buildGitNamespace(
+      makeDeps({ getWorkspaceRoot: () => root }),
+    );
+
+    const hyphenated = await namespace.worktreeAdd({ branch: 'feature/a-b' });
+    const nested = await namespace.worktreeAdd({ branch: 'feature/a/b' });
+
+    expect(hyphenated.success).toBe(true);
+    expect(nested.success).toBe(true);
+    expect(hyphenated.worktreePath).not.toBe(nested.worktreePath);
+  });
+
+  it.each([
+    ['long', `feature/${'a'.repeat(180)}`],
+    ['Unicode', 'feature/修复-ёж'],
+  ])(
+    'supports a legitimate %s branch with a bounded default path',
+    async (_name, branch) => {
+      queueFakeChild({ exitCode: 0 });
+      const root = path.resolve('/repo');
+      const out = await buildGitNamespace(
+        makeDeps({ getWorkspaceRoot: () => root }),
+      ).worktreeAdd({ branch });
+
+      expect(out.success).toBe(true);
+      expect(path.basename(out.worktreePath ?? '').length).toBeLessThanOrEqual(
+        64,
+      );
+      const [, args] = crossSpawnMock.mock.calls[0];
+      expect(args.at(-1)).toBe(branch);
+    },
+  );
+
+  it('turns traversal-looking refs into one safe hashed directory segment', async () => {
+    queueFakeChild({ exitCode: 0 });
     const root = path.resolve('/repo');
     const out = await buildGitNamespace(
       makeDeps({ getWorkspaceRoot: () => root }),
     ).worktreeAdd({ branch: '../escape' });
 
-    expect(out.success).toBe(false);
-    expect(out.error).toMatch(/Branch name may contain only/);
-    expect(crossSpawnMock).not.toHaveBeenCalled();
+    expect(out.success).toBe(true);
+    const target = out.worktreePath ?? '';
+    expect(path.dirname(target)).toBe(path.join(root, '.claude-worktrees'));
+    expect(path.basename(target)).not.toContain('..');
   });
   it('rejects a relative custom path that traverses outside the workspace', async () => {
     const root = path.resolve('/repo');

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.ts
@@ -9,9 +9,12 @@
  * Pattern: namespace-builders/agent-namespace.builder.ts
  */
 
-import * as path from 'path';
 import type { GitNamespace } from '../types';
-import { execGit, WORKTREE_GIT_TIMEOUT_MS } from '@ptah-extension/vscode-core';
+import {
+  execGit,
+  resolveWorktreePath,
+  WORKTREE_GIT_TIMEOUT_MS,
+} from '@ptah-extension/vscode-core';
 import {
   parseWorktreeList,
   type GitWorktreeInfo,
@@ -37,77 +40,6 @@ export interface GitNamespaceDependencies {
   getWorkspaceRoot: () => string;
   /** Optional callback fired after worktree add/remove to notify frontend */
   onWorktreeChanged?: WorktreeChangeCallback;
-}
-
-const WORKTREE_DIRECTORY = '.claude-worktrees';
-const MAX_WORKTREE_NAME_LENGTH = 64;
-
-/**
- * Convert a branch ref into one stable directory name without allowing path
- * traversal. Branch hierarchy remains readable while separators and unsafe
- * characters are rejected. Ref separators collapse to hyphens.
- */
-function safeWorktreeName(branch: string): string {
-  const segments = branch.trim().split(/[\\/]+/);
-  if (
-    segments.some(
-      (segment) =>
-        !segment ||
-        segment === '.' ||
-        segment === '..' ||
-        !/^[A-Za-z0-9._-]+$/.test(segment),
-    )
-  ) {
-    throw new Error(
-      'Branch name may contain only letters, digits, dots, underscores, hyphens, and ref separators.',
-    );
-  }
-
-  const normalized = segments.join('-');
-  if (normalized.length > MAX_WORKTREE_NAME_LENGTH) {
-    throw new Error(
-      `Safe worktree name must be at most ${MAX_WORKTREE_NAME_LENGTH} characters.`,
-    );
-  }
-  return normalized;
-}
-
-/**
- * Explicit worktree paths may be absolute or workspace-relative, but relative
- * traversal may not escape the workspace root. Absolute paths remain supported
- * because callers use them to keep worktrees on another volume.
- */
-function resolveWorktreePath(
-  workspaceRoot: string,
-  branch: string,
-  requestedPath?: string,
-): string {
-  if (!requestedPath) {
-    return path.join(
-      workspaceRoot,
-      WORKTREE_DIRECTORY,
-      safeWorktreeName(branch),
-    );
-  }
-
-  if (path.win32.isAbsolute(requestedPath)) {
-    return requestedPath;
-  }
-  if (path.isAbsolute(requestedPath)) {
-    return path.normalize(requestedPath);
-  }
-  const resolved = path.resolve(workspaceRoot, requestedPath);
-  const relative = path.relative(workspaceRoot, resolved);
-  if (
-    relative === '..' ||
-    relative.startsWith(`..${path.sep}`) ||
-    path.isAbsolute(relative)
-  ) {
-    throw new Error(
-      'Relative worktree path must stay within the workspace root. Use an absolute path for another location.',
-    );
-  }
-  return resolved;
 }
 
 /**

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.ts
@@ -39,6 +39,77 @@ export interface GitNamespaceDependencies {
   onWorktreeChanged?: WorktreeChangeCallback;
 }
 
+const WORKTREE_DIRECTORY = '.claude-worktrees';
+const MAX_WORKTREE_NAME_LENGTH = 64;
+
+/**
+ * Convert a branch ref into one stable directory name without allowing path
+ * traversal. Branch hierarchy remains readable while separators and unsafe
+ * characters are rejected. Ref separators collapse to hyphens.
+ */
+function safeWorktreeName(branch: string): string {
+  const segments = branch.trim().split(/[\\/]+/);
+  if (
+    segments.some(
+      (segment) =>
+        !segment ||
+        segment === '.' ||
+        segment === '..' ||
+        !/^[A-Za-z0-9._-]+$/.test(segment),
+    )
+  ) {
+    throw new Error(
+      'Branch name may contain only letters, digits, dots, underscores, hyphens, and ref separators.',
+    );
+  }
+
+  const normalized = segments.join('-');
+  if (normalized.length > MAX_WORKTREE_NAME_LENGTH) {
+    throw new Error(
+      `Safe worktree name must be at most ${MAX_WORKTREE_NAME_LENGTH} characters.`,
+    );
+  }
+  return normalized;
+}
+
+/**
+ * Explicit worktree paths may be absolute or workspace-relative, but relative
+ * traversal may not escape the workspace root. Absolute paths remain supported
+ * because callers use them to keep worktrees on another volume.
+ */
+function resolveWorktreePath(
+  workspaceRoot: string,
+  branch: string,
+  requestedPath?: string,
+): string {
+  if (!requestedPath) {
+    return path.join(
+      workspaceRoot,
+      WORKTREE_DIRECTORY,
+      safeWorktreeName(branch),
+    );
+  }
+
+  if (path.win32.isAbsolute(requestedPath)) {
+    return requestedPath;
+  }
+  if (path.isAbsolute(requestedPath)) {
+    return path.normalize(requestedPath);
+  }
+  const resolved = path.resolve(workspaceRoot, requestedPath);
+  const relative = path.relative(workspaceRoot, resolved);
+  if (
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(
+      'Relative worktree path must stay within the workspace root. Use an absolute path for another location.',
+    );
+  }
+  return resolved;
+}
+
 /**
  * Build the git namespace with worktree operations.
  *
@@ -96,9 +167,17 @@ export function buildGitNamespace(
       createBranch?: boolean;
     }): Promise<{ success: boolean; worktreePath?: string; error?: string }> {
       try {
-        const worktreePath =
-          params.path ||
-          path.join(path.dirname(getWorkspaceRoot()), params.branch);
+        const workspaceRoot = getWorkspaceRoot();
+        if (!workspaceRoot) {
+          throw new Error(
+            'Cannot add worktree: workspace root is not resolved. Open a workspace folder first.',
+          );
+        }
+        const worktreePath = resolveWorktreePath(
+          workspaceRoot,
+          params.branch,
+          params.path,
+        );
 
         const args = ['worktree', 'add'];
         if (params.createBranch) {

--- a/libs/frontend/chat/src/lib/components/organisms/workspace-sidebar.component.ts
+++ b/libs/frontend/chat/src/lib/components/organisms/workspace-sidebar.component.ts
@@ -128,6 +128,6 @@ export class WorkspaceSidebarComponent {
 
   onRemoveFolder(event: Event, index: number): void {
     event.stopPropagation();
-    this.layout.removeFolder(index);
+    void this.layout.removeFolder(index);
   }
 }

--- a/libs/frontend/core/src/lib/services/electron-layout.service.spec.ts
+++ b/libs/frontend/core/src/lib/services/electron-layout.service.spec.ts
@@ -1454,7 +1454,7 @@ describe('ElectronLayoutService — removeFolder()', () => {
 
     (service as never)['_workspaceFolders'].set([{ path: '/a', name: 'a' }]);
     rpc.call.mockClear();
-    await service.removeFolder(5);
+    await expect(service.removeFolder(5)).resolves.toBe(false);
     // No workspace:removeFolder call should occur for out-of-bounds
     const removeCalls = (rpc.call as jest.Mock).mock.calls.filter(
       (c: unknown[]) => c[0] === 'workspace:removeFolder',
@@ -1496,7 +1496,7 @@ describe('ElectronLayoutService — removeFolder()', () => {
     ]);
     (service as never)['_activeWorkspaceIndex'].set(0);
 
-    await service.removeFolder(1);
+    await expect(service.removeFolder(1)).resolves.toBe(true);
     jest.advanceTimersByTime(150);
     await Promise.resolve();
     jest.useRealTimers();
@@ -1536,7 +1536,7 @@ describe('ElectronLayoutService — removeFolder()', () => {
     ]);
     (service as never)['_activeWorkspaceIndex'].set(0);
 
-    await service.removeFolder(0);
+    await expect(service.removeFolder(0)).resolves.toBe(true);
 
     expect(service.workspaceFolders()).toHaveLength(0);
     expect(service.activeWorkspaceIndex()).toBe(0);
@@ -1578,7 +1578,7 @@ describe('ElectronLayoutService — removeFolder()', () => {
     ]);
     (service as never)['_activeWorkspaceIndex'].set(0);
 
-    await expect(service.removeFolder(0)).resolves.toBeUndefined();
+    await expect(service.removeFolder(0)).resolves.toBe(true);
 
     expect(vscodeService.updateWorkspaceRoot).toHaveBeenCalledWith('');
     expect(consoleError).toHaveBeenCalled();
@@ -1597,7 +1597,7 @@ describe('ElectronLayoutService — removeFolder()', () => {
     ]);
     (service as never)['_activeWorkspaceIndex'].set(0);
 
-    await service.removeFolder(0);
+    await expect(service.removeFolder(0)).resolves.toBe(true);
 
     expect(coordinator.clearWorkspace).not.toHaveBeenCalled();
     expect(coordinator.switchWorkspace).toHaveBeenCalledWith('/b');
@@ -1627,11 +1627,34 @@ describe('ElectronLayoutService — removeFolder()', () => {
 
     (service as never)['_workspaceFolders'].set([{ path: '/a', name: 'a' }]);
 
-    await service.removeFolder(0);
+    await expect(service.removeFolder(0)).resolves.toBe(false);
 
     expect(service.workspaceFolders()).toHaveLength(1);
   });
 
+  it('returns false when the user cancels closing a streaming workspace', async () => {
+    coordinator = buildCoordinator();
+    coordinator.getStreamingSessionIds = jest.fn().mockReturnValue(['sess-1']);
+    coordinator.confirm = jest.fn().mockResolvedValue(false);
+    vscodeService = buildVscodeService(null);
+    appState = buildAppState();
+    rpc = buildRpc();
+
+    TestBed.configureTestingModule({
+      providers: [
+        ElectronLayoutService,
+        { provide: VSCodeService, useValue: vscodeService },
+        { provide: AppStateManager, useValue: appState },
+        { provide: ClaudeRpcService, useValue: rpc },
+        { provide: WORKSPACE_COORDINATOR, useValue: coordinator },
+      ],
+    });
+    service = TestBed.inject(ElectronLayoutService);
+    (service as never)['_workspaceFolders'].set([{ path: '/a', name: 'a' }]);
+
+    await expect(service.removeFolder(0)).resolves.toBe(false);
+    expect(service.workspaceFolders()).toHaveLength(1);
+  });
   it('does not mutate state when backend removeFolder RPC fails', async () => {
     coordinator = buildCoordinator();
     coordinator.getStreamingSessionIds = jest.fn().mockReturnValue([]);
@@ -1660,7 +1683,7 @@ describe('ElectronLayoutService — removeFolder()', () => {
 
     (service as never)['_workspaceFolders'].set([{ path: '/a', name: 'a' }]);
 
-    await service.removeFolder(0);
+    await expect(service.removeFolder(0)).resolves.toBe(false);
 
     expect(service.workspaceFolders()).toHaveLength(1);
   });

--- a/libs/frontend/core/src/lib/services/electron-layout.service.ts
+++ b/libs/frontend/core/src/lib/services/electron-layout.service.ts
@@ -277,10 +277,11 @@ export class ElectronLayoutService implements MessageHandler {
    * WORKSPACE_COORDINATOR.
    *
    * Handles edge case: removing the only workspace resets to "no workspace" state.
+   * Returns false when index is invalid, user cancels, or backend rejects removal.
    */
-  async removeFolder(index: number): Promise<void> {
+  async removeFolder(index: number): Promise<boolean> {
     const folders = this._workspaceFolders();
-    if (index < 0 || index >= folders.length) return;
+    if (index < 0 || index >= folders.length) return false;
 
     const removedFolder = folders[index];
     if (this.coordinator) {
@@ -304,7 +305,7 @@ export class ElectronLayoutService implements MessageHandler {
         });
 
         if (!confirmed) {
-          return;
+          return false;
         }
         await Promise.allSettled(
           streamingSessionIds.map((sessionId) =>
@@ -327,14 +328,14 @@ export class ElectronLayoutService implements MessageHandler {
           '[ElectronLayout] Backend rejected folder removal:',
           result,
         );
-        return;
+        return false;
       }
     } catch (error) {
       console.error(
         '[ElectronLayout] Failed to remove folder from backend:',
         error,
       );
-      return;
+      return false;
     }
     this._workspaceFolders.update((f) => f.filter((_, i) => i !== index));
 
@@ -356,6 +357,7 @@ export class ElectronLayoutService implements MessageHandler {
     }
 
     this.persistLayout();
+    return true;
   }
 
   /**

--- a/libs/frontend/git-ui/src/lib/services/worktree.service.spec.ts
+++ b/libs/frontend/git-ui/src/lib/services/worktree.service.spec.ts
@@ -272,6 +272,9 @@ describe('WorktreeService as a MessageHandler', () => {
   });
 
   it('keeps an already-deleted open worktree registered when notification cleanup is cancelled', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
     layout.workspaceFolders.set([
       { path: '/repo/.claude-worktrees/open', name: 'open' },
     ]);
@@ -288,8 +291,7 @@ describe('WorktreeService as a MessageHandler', () => {
         path: '/repo/.claude-worktrees/open',
       },
     });
-    await Promise.resolve();
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(layout.removeFolder).toHaveBeenCalledWith(0);
     expect(layout.workspaceFolders()).toEqual([
@@ -300,6 +302,14 @@ describe('WorktreeService as a MessageHandler', () => {
       'git:worktrees',
       {},
     );
+    expect(consoleError).toHaveBeenCalledWith(
+      '[WorktreeService] Failed to close removed worktree workspace',
+      expect.objectContaining({
+        message:
+          'Open worktree workspace could not be closed; Git removal was cancelled.',
+      }),
+    );
+    consoleError.mockRestore();
   });
   it('ignores an unknown failed removal event without unregistering a valid folder', async () => {
     layout.workspaceFolders.set([

--- a/libs/frontend/git-ui/src/lib/services/worktree.service.spec.ts
+++ b/libs/frontend/git-ui/src/lib/services/worktree.service.spec.ts
@@ -55,7 +55,9 @@ function makeVscodeStub() {
 
 function makeLayoutStub() {
   return {
+    workspaceFolders: signal<{ path: string; name: string }[]>([]),
     addFolderByPath: jest.fn().mockResolvedValue(undefined),
+    removeFolder: jest.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -107,7 +109,32 @@ describe('WorktreeService as a MessageHandler', () => {
     addSpy.mockRestore();
   });
 
-  it('resolves the matching pending op from a correlated created push and registers the folder', async () => {
+  it('refreshes a synchronous UI creation without opening the folder', async () => {
+    mockRpcCall.mockImplementation((_vscode, method: string) => {
+      if (method === 'git:addWorktree') {
+        return Promise.resolve({
+          success: true,
+          data: {
+            success: true,
+            worktreePath: '/repo/.claude-worktrees/feature-x',
+          },
+        });
+      }
+      return Promise.resolve({ success: true, data: { worktrees: [] } });
+    });
+
+    await expect(service.addWorktree('feature/x')).resolves.toEqual({
+      success: true,
+    });
+
+    expect(layout.addFolderByPath).not.toHaveBeenCalled();
+    expect(mockRpcCall).toHaveBeenCalledWith(
+      expect.anything(),
+      'git:worktrees',
+      {},
+    );
+  });
+  it('resolves a correlated created push and refreshes without opening the folder', async () => {
     // The backend acks the RPC as pending, then completes it out of band.
     mockRpcCall.mockImplementation((_vscode, method: string) => {
       if (method === 'git:addWorktree') {
@@ -143,12 +170,108 @@ describe('WorktreeService as a MessageHandler', () => {
     });
 
     await expect(addPromise).resolves.toEqual({ success: true });
-    expect(layout.addFolderByPath).toHaveBeenCalledWith(
-      '/repo/.worktrees/feature-x',
+    expect(layout.addFolderByPath).not.toHaveBeenCalled();
+    expect(mockRpcCall).toHaveBeenCalledWith(
+      expect.anything(),
+      'git:worktrees',
+      {},
     );
     expect(service.isLoading()).toBe(false);
   });
 
+  it('refreshes an unknown correlated created push without opening the folder', async () => {
+    mockRpcCall.mockResolvedValue({
+      success: true,
+      data: { worktrees: [] },
+    });
+
+    service.handleMessage({
+      type: WORKTREE_CHANGED_MESSAGE_TYPE,
+      payload: {
+        action: 'created',
+        operationId: 'created-by-another-renderer',
+        path: '/repo/.claude-worktrees/background-agent',
+      },
+    });
+    await Promise.resolve();
+
+    expect(layout.addFolderByPath).not.toHaveBeenCalled();
+    expect(mockRpcCall).toHaveBeenCalledWith(
+      expect.anything(),
+      'git:worktrees',
+      {},
+    );
+  });
+  it('refreshes an uncorrelated created push without opening or switching workspaces', async () => {
+    mockRpcCall.mockResolvedValue({
+      success: true,
+      data: { worktrees: [] },
+    });
+
+    service.handleMessage({
+      type: WORKTREE_CHANGED_MESSAGE_TYPE,
+      payload: {
+        action: 'created',
+        path: '/repo/.claude-worktrees/background-agent',
+      },
+    });
+    await Promise.resolve();
+
+    expect(layout.addFolderByPath).not.toHaveBeenCalled();
+    expect(layout.removeFolder).not.toHaveBeenCalled();
+    expect(mockRpcCall).toHaveBeenCalledWith(
+      expect.anything(),
+      'git:worktrees',
+      {},
+    );
+  });
+
+  it('unregisters an uncorrelated removed worktree only when it is open', async () => {
+    layout.workspaceFolders.set([
+      { path: '/repo', name: 'repo' },
+      { path: '/repo/.claude-worktrees/open', name: 'open' },
+    ]);
+    mockRpcCall.mockResolvedValue({
+      success: true,
+      data: { worktrees: [] },
+    });
+
+    service.handleMessage({
+      type: WORKTREE_CHANGED_MESSAGE_TYPE,
+      payload: {
+        action: 'removed',
+        path: '/repo/.claude-worktrees/open/',
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(layout.removeFolder).toHaveBeenCalledWith(1);
+    expect(mockRpcCall).toHaveBeenCalledWith(
+      expect.anything(),
+      'git:worktrees',
+      {},
+    );
+  });
+
+  it('does not unregister an uncorrelated removed worktree that was never opened', async () => {
+    layout.workspaceFolders.set([{ path: '/repo', name: 'repo' }]);
+    mockRpcCall.mockResolvedValue({
+      success: true,
+      data: { worktrees: [] },
+    });
+
+    service.handleMessage({
+      type: WORKTREE_CHANGED_MESSAGE_TYPE,
+      payload: {
+        action: 'removed',
+        path: '/repo/.claude-worktrees/unopened',
+      },
+    });
+    await Promise.resolve();
+
+    expect(layout.removeFolder).not.toHaveBeenCalled();
+  });
   it('ignores an unrelated message type', () => {
     service.handleMessage({
       type: 'git:status-update',

--- a/libs/frontend/git-ui/src/lib/services/worktree.service.spec.ts
+++ b/libs/frontend/git-ui/src/lib/services/worktree.service.spec.ts
@@ -32,7 +32,7 @@ jest.mock('@ptah-extension/core', () => {
   };
 });
 
-function makeVscodeStub() {
+function makeVscodeStub(platform = 'linux') {
   return {
     config: signal({
       isVSCode: false,
@@ -45,6 +45,7 @@ function makeVscodeStub() {
       userIconUri: '',
       panelId: '',
       isElectron: true,
+      platform,
     }).asReadonly(),
     isConnected: signal(false).asReadonly(),
     getState: jest.fn().mockReturnValue(null),
@@ -57,7 +58,7 @@ function makeLayoutStub() {
   return {
     workspaceFolders: signal<{ path: string; name: string }[]>([]),
     addFolderByPath: jest.fn().mockResolvedValue(undefined),
-    removeFolder: jest.fn().mockResolvedValue(undefined),
+    removeFolder: jest.fn().mockResolvedValue(true),
   };
 }
 
@@ -226,6 +227,151 @@ describe('WorktreeService as a MessageHandler', () => {
     );
   });
 
+  it('reports partial failure when Git removes an open worktree but workspace close is cancelled', async () => {
+    layout.workspaceFolders.set([
+      { path: '/repo/.claude-worktrees/open', name: 'open' },
+    ]);
+    layout.removeFolder.mockResolvedValue(false);
+    mockRpcCall.mockImplementation((_vscode, method: string) => {
+      if (method === 'git:removeWorktree') {
+        return Promise.resolve({
+          success: true,
+          data: { success: true, pending: false },
+        });
+      }
+      return Promise.resolve({ success: true, data: { worktrees: [] } });
+    });
+
+    await expect(
+      service.removeWorktree('/repo/.claude-worktrees/open'),
+    ).resolves.toEqual({
+      success: false,
+      error:
+        'Open worktree workspace could not be closed; Git removal was cancelled.',
+    });
+  });
+
+  it('reports partial failure when workspace removal throws', async () => {
+    layout.workspaceFolders.set([
+      { path: '/repo/.claude-worktrees/open', name: 'open' },
+    ]);
+    layout.removeFolder.mockRejectedValue(new Error('workspace RPC failed'));
+    mockRpcCall.mockImplementation((_vscode, method: string) => {
+      if (method === 'git:removeWorktree') {
+        return Promise.resolve({
+          success: true,
+          data: { success: true, pending: false },
+        });
+      }
+      return Promise.resolve({ success: true, data: { worktrees: [] } });
+    });
+
+    await expect(
+      service.removeWorktree('/repo/.claude-worktrees/open'),
+    ).resolves.toEqual({ success: false, error: 'workspace RPC failed' });
+  });
+
+  it('keeps an already-deleted open worktree registered when notification cleanup is cancelled', async () => {
+    layout.workspaceFolders.set([
+      { path: '/repo/.claude-worktrees/open', name: 'open' },
+    ]);
+    layout.removeFolder.mockResolvedValue(false);
+    mockRpcCall.mockResolvedValue({
+      success: true,
+      data: { worktrees: [] },
+    });
+
+    service.handleMessage({
+      type: WORKTREE_CHANGED_MESSAGE_TYPE,
+      payload: {
+        action: 'removed',
+        path: '/repo/.claude-worktrees/open',
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(layout.removeFolder).toHaveBeenCalledWith(0);
+    expect(layout.workspaceFolders()).toEqual([
+      { path: '/repo/.claude-worktrees/open', name: 'open' },
+    ]);
+    expect(mockRpcCall).toHaveBeenCalledWith(
+      expect.anything(),
+      'git:worktrees',
+      {},
+    );
+  });
+  it('ignores an unknown failed removal event without unregistering a valid folder', async () => {
+    layout.workspaceFolders.set([
+      { path: '/repo/.claude-worktrees/valid', name: 'valid' },
+    ]);
+
+    service.handleMessage({
+      type: WORKTREE_CHANGED_MESSAGE_TYPE,
+      payload: {
+        action: 'removed',
+        operationId: 'unknown-operation',
+        success: false,
+        path: '/repo/.claude-worktrees/valid',
+      },
+    });
+    await Promise.resolve();
+
+    expect(layout.removeFolder).not.toHaveBeenCalled();
+    expect(mockRpcCall).not.toHaveBeenCalled();
+  });
+
+  it('keeps POSIX paths case-sensitive when reconciling removal', async () => {
+    TestBed.resetTestingModule();
+    layout = makeLayoutStub();
+    layout.workspaceFolders.set([{ path: '/repo/Open', name: 'Open' }]);
+    TestBed.configureTestingModule({
+      providers: [
+        WorktreeService,
+        { provide: VSCodeService, useValue: makeVscodeStub('linux') },
+        { provide: ElectronLayoutService, useValue: layout },
+      ],
+    });
+    service = TestBed.inject(WorktreeService);
+    mockRpcCall.mockResolvedValue({
+      success: true,
+      data: { worktrees: [] },
+    });
+
+    service.handleMessage({
+      type: WORKTREE_CHANGED_MESSAGE_TYPE,
+      payload: { action: 'removed', path: '/repo/open' },
+    });
+    await Promise.resolve();
+
+    expect(layout.removeFolder).not.toHaveBeenCalled();
+  });
+
+  it('matches Windows paths case- and separator-insensitively', async () => {
+    TestBed.resetTestingModule();
+    layout = makeLayoutStub();
+    layout.workspaceFolders.set([{ path: 'D:\\Repo\\Open', name: 'Open' }]);
+    TestBed.configureTestingModule({
+      providers: [
+        WorktreeService,
+        { provide: VSCodeService, useValue: makeVscodeStub('win32') },
+        { provide: ElectronLayoutService, useValue: layout },
+      ],
+    });
+    service = TestBed.inject(WorktreeService);
+    mockRpcCall.mockResolvedValue({
+      success: true,
+      data: { worktrees: [] },
+    });
+
+    service.handleMessage({
+      type: WORKTREE_CHANGED_MESSAGE_TYPE,
+      payload: { action: 'removed', path: 'd:/repo/open/' },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(layout.removeFolder).toHaveBeenCalledWith(0);
+  });
   it('unregisters an uncorrelated removed worktree only when it is open', async () => {
     layout.workspaceFolders.set([
       { path: '/repo', name: 'repo' },

--- a/libs/frontend/git-ui/src/lib/services/worktree.service.ts
+++ b/libs/frontend/git-ui/src/lib/services/worktree.service.ts
@@ -145,7 +145,9 @@ export class WorktreeService implements MessageHandler {
   }
 
   /**
-   * Remove a worktree. Async-pending semantics mirror addWorktree above.
+   * Remove a worktree. An explicitly opened workspace must close first; a
+   * cancelled or failed close prevents destructive Git removal. Async-pending
+   * semantics otherwise mirror addWorktree above.
    */
   async removeWorktree(
     path: string,
@@ -153,6 +155,15 @@ export class WorktreeService implements MessageHandler {
   ): Promise<{ success: boolean; error?: string }> {
     this._isLoading.set(true);
 
+    try {
+      await this.unregisterOpenWorktree(path);
+    } catch (error: unknown) {
+      this._isLoading.set(false);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
     const operationId = this.generateOperationId();
     const pendingPromise = this.registerPendingOperation(operationId);
 
@@ -175,7 +186,6 @@ export class WorktreeService implements MessageHandler {
       this.cancelPendingOperation(operationId);
       if (ack.data.success) {
         this.removeWorktreeLocally(path);
-        await this.unregisterOpenWorktree(path);
         this._isLoading.set(false);
         return { success: true };
       }
@@ -189,7 +199,6 @@ export class WorktreeService implements MessageHandler {
     const outcome = await pendingPromise;
     if (outcome.success) {
       this.removeWorktreeLocally(path);
-      await this.unregisterOpenWorktree(path);
       this._isLoading.set(false);
       return { success: true };
     }
@@ -207,7 +216,7 @@ export class WorktreeService implements MessageHandler {
   }
 
   /**
-   * Unregister a removed worktree only when the user had explicitly opened it.
+   * Close a worktree workspace only when the user had explicitly opened it.
    * Creation notifications never register folders; selecting a row is the sole
    * opt-in path into ElectronLayoutService.addFolderByPath().
    */
@@ -215,23 +224,37 @@ export class WorktreeService implements MessageHandler {
     const index = this.layoutService
       .workspaceFolders()
       .findIndex((folder) => this.pathsEqual(folder.path, path));
-    if (index >= 0) {
-      await this.layoutService.removeFolder(index);
+    if (index < 0) return;
+
+    const removed = await this.layoutService.removeFolder(index);
+    if (!removed) {
+      throw new Error(
+        'Open worktree workspace could not be closed; Git removal was cancelled.',
+      );
     }
   }
 
   private pathsEqual(left: string, right: string): boolean {
     const normalize = (value: string): string =>
-      value.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
-    return normalize(left) === normalize(right);
+      value.replace(/\\/g, '/').replace(/\/+$/, '');
+    const platform = this.vscodeService.config().platform;
+    return platform === 'win32'
+      ? normalize(left).toLowerCase() === normalize(right).toLowerCase()
+      : normalize(left) === normalize(right);
   }
-
   private async reconcileRemovedWorktree(path?: string): Promise<void> {
+    let closeError: unknown;
     if (path) {
-      await this.unregisterOpenWorktree(path);
+      try {
+        await this.unregisterOpenWorktree(path);
+      } catch (error: unknown) {
+        closeError = error;
+      }
     }
     await this.loadWorktrees();
+    if (closeError !== undefined) throw closeError;
   }
+
   private generateOperationId(): string {
     const cryptoRef = globalThis.crypto as Crypto | undefined;
     if (cryptoRef?.randomUUID) {
@@ -293,10 +316,15 @@ export class WorktreeService implements MessageHandler {
       }
     }
 
+    if (payload.success === false) return;
+
     if (payload.action === 'created') {
       void this.loadWorktrees();
     } else if (payload.action === 'removed') {
-      void this.reconcileRemovedWorktree(payload.path);
+      void this.reconcileRemovedWorktree(payload.path).catch(() => {
+        // Git already removed this worktree. Keep the still-open workspace and
+        // let the user close it after active sessions or transient RPC failure.
+      });
     }
   }
 }

--- a/libs/frontend/git-ui/src/lib/services/worktree.service.ts
+++ b/libs/frontend/git-ui/src/lib/services/worktree.service.ts
@@ -321,10 +321,16 @@ export class WorktreeService implements MessageHandler {
     if (payload.action === 'created') {
       void this.loadWorktrees();
     } else if (payload.action === 'removed') {
-      void this.reconcileRemovedWorktree(payload.path).catch(() => {
-        // Git already removed this worktree. Keep the still-open workspace and
-        // let the user close it after active sessions or transient RPC failure.
-      });
+      void this.reconcileRemovedWorktree(payload.path).catch(
+        (error: unknown) => {
+          // Git already removed this worktree. Keep the still-open workspace and
+          // let the user close it after active sessions or transient RPC failure.
+          console.error(
+            '[WorktreeService] Failed to close removed worktree workspace',
+            error,
+          );
+        },
+      );
     }
   }
 }

--- a/libs/frontend/git-ui/src/lib/services/worktree.service.ts
+++ b/libs/frontend/git-ui/src/lib/services/worktree.service.ts
@@ -120,7 +120,6 @@ export class WorktreeService implements MessageHandler {
     if (!ack.data.pending) {
       this.cancelPendingOperation(operationId);
       if (ack.data.success && ack.data.worktreePath) {
-        await this.layoutService.addFolderByPath(ack.data.worktreePath);
         await this.loadWorktrees();
         this._isLoading.set(false);
         return { success: true };
@@ -134,7 +133,6 @@ export class WorktreeService implements MessageHandler {
 
     const outcome = await pendingPromise;
     if (outcome.success && outcome.path) {
-      await this.layoutService.addFolderByPath(outcome.path);
       await this.loadWorktrees();
       this._isLoading.set(false);
       return { success: true };
@@ -177,6 +175,7 @@ export class WorktreeService implements MessageHandler {
       this.cancelPendingOperation(operationId);
       if (ack.data.success) {
         this.removeWorktreeLocally(path);
+        await this.unregisterOpenWorktree(path);
         this._isLoading.set(false);
         return { success: true };
       }
@@ -190,6 +189,7 @@ export class WorktreeService implements MessageHandler {
     const outcome = await pendingPromise;
     if (outcome.success) {
       this.removeWorktreeLocally(path);
+      await this.unregisterOpenWorktree(path);
       this._isLoading.set(false);
       return { success: true };
     }
@@ -202,10 +202,36 @@ export class WorktreeService implements MessageHandler {
 
   private removeWorktreeLocally(path: string): void {
     this._worktrees.update((worktrees) =>
-      worktrees.filter((w) => w.path !== path),
+      worktrees.filter((w) => !this.pathsEqual(w.path, path)),
     );
   }
 
+  /**
+   * Unregister a removed worktree only when the user had explicitly opened it.
+   * Creation notifications never register folders; selecting a row is the sole
+   * opt-in path into ElectronLayoutService.addFolderByPath().
+   */
+  private async unregisterOpenWorktree(path: string): Promise<void> {
+    const index = this.layoutService
+      .workspaceFolders()
+      .findIndex((folder) => this.pathsEqual(folder.path, path));
+    if (index >= 0) {
+      await this.layoutService.removeFolder(index);
+    }
+  }
+
+  private pathsEqual(left: string, right: string): boolean {
+    const normalize = (value: string): string =>
+      value.replace(/\\/g, '/').replace(/\/+$/, '').toLowerCase();
+    return normalize(left) === normalize(right);
+  }
+
+  private async reconcileRemovedWorktree(path?: string): Promise<void> {
+    if (path) {
+      await this.unregisterOpenWorktree(path);
+    }
+    await this.loadWorktrees();
+  }
   private generateOperationId(): string {
     const cryptoRef = globalThis.crypto as Crypto | undefined;
     if (cryptoRef?.randomUUID) {
@@ -242,8 +268,8 @@ export class WorktreeService implements MessageHandler {
    *
    * A push carrying an `operationId` settles the matching pending operation
    * and stops there — {@link addWorktree} / {@link removeWorktree} own the
-   * follow-up. An uncorrelated push (another surface created or removed a
-   * worktree) reconciles the local list instead.
+   * follow-up. An uncorrelated push reconciles the local list; a removed path
+   * is also unregistered if the user had explicitly opened that worktree.
    */
   handleMessage(message: { type: string; payload?: unknown }): void {
     if (message.type !== WORKTREE_CHANGED_MESSAGE_TYPE) return;
@@ -263,17 +289,14 @@ export class WorktreeService implements MessageHandler {
           error: payload.error,
           path: payload.path,
         });
+        return;
       }
-      return;
     }
 
     if (payload.action === 'created') {
-      if (payload.path) {
-        void this.layoutService.addFolderByPath(payload.path);
-      }
       void this.loadWorktrees();
     } else if (payload.action === 'removed') {
-      void this.loadWorktrees();
+      void this.reconcileRemovedWorktree(payload.path);
     }
   }
 }

--- a/libs/frontend/git-ui/src/lib/worktree/worktree-section.component.spec.ts
+++ b/libs/frontend/git-ui/src/lib/worktree/worktree-section.component.spec.ts
@@ -35,9 +35,11 @@ const FEATURE = worktree('D:\\repos\\app-feature', 'feature/x', false);
 describe('WorktreeSectionComponent — active highlight tracks ElectronLayoutService', () => {
   let fixture: ComponentFixture<WorktreeSectionComponent>;
   let activeWorkspace: ReturnType<typeof signal<WorkspaceFolder | null>>;
+  let addFolderByPath: jest.Mock;
 
   beforeEach(async () => {
     activeWorkspace = signal<WorkspaceFolder | null>(null);
+    addFolderByPath = jest.fn(async () => undefined);
 
     const worktreeStub = {
       worktrees: signal<GitWorktreeInfo[]>([MAIN, FEATURE]),
@@ -49,7 +51,7 @@ describe('WorktreeSectionComponent — active highlight tracks ElectronLayoutSer
 
     const layoutStub = {
       activeWorkspace,
-      addFolderByPath: jest.fn(async () => undefined),
+      addFolderByPath,
     } as unknown as ElectronLayoutService;
 
     await TestBed.configureTestingModule({
@@ -106,6 +108,22 @@ describe('WorktreeSectionComponent — active highlight tracks ElectronLayoutSer
     expect(activeRowBranches()).toEqual([`Switch to ${FEATURE.path}`]);
   });
 
+  it('opens a worktree only after the user explicitly clicks its row', async () => {
+    activeWorkspace.set({ path: MAIN.path, name: 'app' });
+    fixture.detectChanges();
+
+    expect(addFolderByPath).not.toHaveBeenCalled();
+    const featureRow = Array.from(
+      fixture.nativeElement.querySelectorAll('button[title^="Switch to "]'),
+    ).find(
+      (row) => (row as HTMLButtonElement).title === `Switch to ${FEATURE.path}`,
+    ) as HTMLButtonElement;
+    featureRow.click();
+    await fixture.whenStable();
+
+    expect(addFolderByPath).toHaveBeenCalledTimes(1);
+    expect(addFolderByPath).toHaveBeenCalledWith(FEATURE.path);
+  });
   it('falls back to the main worktree when there is no active workspace', () => {
     activeWorkspace.set(null);
     fixture.detectChanges();

--- a/libs/frontend/git-ui/src/lib/worktree/worktree-section.component.ts
+++ b/libs/frontend/git-ui/src/lib/worktree/worktree-section.component.ts
@@ -153,6 +153,7 @@ import type { GitWorktreeInfo } from '@ptah-extension/shared';
                      hover:bg-base-content/10 transition-colors border-b border-base-content/5"
               [class.bg-primary/10]="isActiveWorktree(wt)"
               [title]="'Switch to ' + wt.path"
+              [attr.aria-label]="'Switch to ' + wt.path"
               (click)="onWorktreeSelect(wt)"
             >
               <lucide-angular

--- a/libs/shared/src/lib/types/rpc/rpc-git.types.ts
+++ b/libs/shared/src/lib/types/rpc/rpc-git.types.ts
@@ -82,7 +82,7 @@ export interface GitWorktreesResult {
 export interface GitAddWorktreeParams {
   /** Branch name to checkout in the new worktree */
   branch: string;
-  /** Optional custom path for the worktree directory (defaults to ../<branch>) */
+  /** Optional custom path for the worktree directory. */
   path?: string;
   /** Whether to create a new branch (vs checkout existing) */
   createBranch?: boolean;


### PR DESCRIPTION
## Summary
- Keep agent worktree creation in the background; open/register only on explicit user action.
- Default MCP worktrees to nested paths and enforce boundary-safe agent working directories.
- Document dependency resolution without automatic dependency, secret, cache, or output links.
- Includes the requested initial carryover commit: 28 existing agent configuration and task-document files, including functional task-ID allocation rules.

## Test plan
- Implementation agent reports 44 focused tests passing and TypeScript/Angular checks passing.
- ESLint: zero errors, three pre-existing warnings. Nx boundary check unavailable without cached graph.
- Whitespace validation passed; working tree clean after commit.
- Electron E2E regression added but NOT executed: required build artifacts absent.
- Ptah diagnostics timed out; direct compiler checks used instead.
- Independent review remains in progress.

Original workspace edits preserved. Separate carryover and implementation commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62204698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/ptah-orchestra/-/pull-requests/hive-academy/ptah-extension/483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 2/5</h2>

The PR is not safe to merge until agent cwd containment, default worktree-name compatibility, and failed workspace-unregistration handling are corrected.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;<img alt="Security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top">&nbsp;**Real\-path containment is lost** <a href="https://github.com/Hive-Academy/ptah-extension/pull/483#discussion_r3971147017">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Default worktree names collide** <a href="https://github.com/Hive-Academy/ptah-extension/pull/483#discussion_r3971147024">▶</a>
3. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Workspace unregistration silently aborts** <a href="https://github.com/Hive-Academy/ptah-extension/pull/483#discussion_r3971147028">▶</a>
4. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Generated agent files edited directly** <a href="https://github.com/Hive-Academy/ptah-extension/pull/483#discussion_r3971147041">▶</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
libs/backend/cli-agent-runtime/src/lib/cli-agents/agent-process-manager.service.ts:2104
When an agent working directory is inside the workspace only through a symlink or junction whose target is outside it, `isPathWithinRoots` accepts the lexical path and the adapters launch the process with an out-of-workspace cwd, allowing commands to read or modify files beyond the authorized checkout.

**How this was verified:** The previous `realpath` check was replaced by a helper documented to use lexical `path.resolve` containment, and the validated directory is passed directly to the spawned process as its cwd.

### Issue 2
libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.ts:50-70
When the optional path is omitted, valid Git branches containing non-ASCII characters or more than 64 normalized characters are rejected before Git runs, while distinct branches such as `feature/a-b` and `feature/a/b` map to the same directory and make the second worktree creation fail.

### Issue 3
libs/frontend/git-ui/src/lib/services/worktree.service.ts:214-220
When the removed worktree has an active stream and the close prompt is cancelled, or `workspace:removeFolder` rejects or throws, `removeFolder` returns without unregistering it but this service still reports success, leaving a deleted checkout registered or active as a stale workspace folder.

### Issue 4
.codex/agents/backend-developer.toml:47-51
These task-ID instructions are changed across generated `.codex/agents` TOML files without updating their `.claude/agents` sources, contrary to `AGENTS.md`; the next synchronization can overwrite the changes and leave Codex agents using inconsistent allocation rules.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<details><summary><h3>Summary</h3></summary>

- Adds safe-name/default-path handling for MCP-created worktrees.
- Stops automatic workspace registration when a worktree is created.
- Reconciles removed worktrees with registered workspace folders.
- Updates worktree documentation, RPC comments, focused tests, and agent task-allocation instructions.
</details>

<details><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Create worktree request] --> B{Explicit path?}
  B -- No --> C[Generate nested default path]
  B -- Yes --> D[Resolve requested path]
  C --> E[git worktree add]
  D --> E
  E --> F[Refresh worktree list only]
  F --> G{User selects row?}
  G -- Yes --> H[Register and switch workspace]
  G -- No --> I[Keep checkout in background]
  H --> J[Remove worktree]
  I --> J
  J --> K[Attempt workspace unregistration]
```
</details>

<!-- /greptile_comment -->