### PR TITLE
feat(electron): add safe local production workflow

### DIFF
--- a/apps/ptah-electron/electron-builder.local-production.cjs
+++ b/apps/ptah-electron/electron-builder.local-production.cjs
@@ -1,0 +1,27 @@
+const gitSha = process.env.PTAH_LOCAL_PRODUCTION_GIT_SHA;
+
+if (!/^[0-9a-f]{40}$/.test(gitSha ?? '')) {
+  throw new Error('PTAH_LOCAL_PRODUCTION_GIT_SHA must be a full Git SHA');
+}
+
+module.exports = {
+  extends: './electron-builder.yml',
+  // Keep the production app identity and package identity. This intentionally
+  // installs over/alongside the normal Ptah profile instead of creating a fork.
+  appId: 'com.ptah.desktop',
+  productName: 'Ptah',
+  directories: {
+    output: '../../release/local-production',
+  },
+  artifactName: `Ptah-Local-${gitSha.slice(0, 12)}-\${version}.\${ext}`,
+  extraMetadata: {
+    ptahBuildIdentity: {
+      kind: 'local-production',
+      gitSha,
+    },
+  },
+  forceCodeSigning: false,
+  mac: { identity: null },
+  win: { sign: null },
+  publish: null,
+};

--- a/apps/ptah-electron/project.json
+++ b/apps/ptah-electron/project.json
@@ -323,6 +323,24 @@
         "parallel": false
       }
     },
+    "package-local-production": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "dependsOn": ["build", "copy-renderer", "rebuild-native"],
+      "outputs": ["{workspaceRoot}/dist/release/local-production"],
+      "options": {
+        "commands": [
+          "node scripts/copy-wasm.js dist/apps/ptah-electron",
+          "node apps/ptah-electron/scripts/patch-transformers-onnx-dep.js",
+          "node apps/ptah-electron/scripts/prune-dist-deps.js",
+          "node apps/ptah-electron/scripts/package-local-production.js",
+          "node apps/ptah-electron/scripts/verify-packed-native.js",
+          "node apps/ptah-electron/scripts/verify-packed-wasm.js",
+          "node apps/ptah-electron/scripts/verify-packed-onnx.js"
+        ],
+        "parallel": false
+      }
+    },
     "typecheck": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/ptah-electron/scripts/backup-local-production-data.js
+++ b/apps/ptah-electron/scripts/backup-local-production-data.js
@@ -5,6 +5,9 @@ const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const {
+  resolveWindowsSystemExecutable,
+} = require('./windows-system-executable.js');
 
 const EXCLUDED_DIRECTORY_NAMES = new Set([
   'cache',
@@ -69,17 +72,114 @@ function assertSourceRootsAreDirectories(sources) {
   }
 }
 
-function assertPtahClosed() {
-  if (process.platform !== 'win32') {
+const VSCODE_PROCESS_NAMES = new Set([
+  'code.exe',
+  'code - insiders.exe',
+  'vscodium.exe',
+]);
+const NODE_PROCESS_NAMES = new Set(['node.exe', 'node']);
+const PTAH_CLI_ENTRY =
+  /[\\/](@hive-academy[\\/]ptah-cli|dist[\\/]apps[\\/]ptah-(cli|tui)|apps[\\/]ptah-(cli|tui)[\\/]src)[\\/](main|tui)\.(mjs|js|tsx?)(?:["'\s]|$)/i;
+
+const WINDOWS_OFFLINE_INSPECTION =
+  "$ErrorActionPreference='Stop';$paths=@(ConvertFrom-Json $env:PTAH_BACKUP_DB_PATHS_JSON);$locked=@();foreach($file in $paths){try{$handle=[IO.File]::Open($file,[IO.FileMode]::Open,[IO.FileAccess]::ReadWrite,[IO.FileShare]::None);$handle.Dispose()}catch{$locked+=$file}};$processes=@(Get-CimInstance Win32_Process|Select-Object ProcessId,Name,ExecutablePath,CommandLine);[pscustomobject]@{Processes=$processes;LockedDatabaseFiles=$locked}|ConvertTo-Json -Depth 3 -Compress";
+
+function findPotentialWriters(processes) {
+  const writers = [];
+  for (const processRecord of processes) {
+    if (
+      !processRecord ||
+      typeof processRecord.ProcessId !== 'number' ||
+      typeof processRecord.Name !== 'string' ||
+      !(
+        processRecord.CommandLine === null ||
+        typeof processRecord.CommandLine === 'string'
+      ) ||
+      !(
+        processRecord.ExecutablePath === null ||
+        typeof processRecord.ExecutablePath === 'string'
+      )
+    ) {
+      throw new Error('Windows process inspection returned malformed data');
+    }
+
+    const name = processRecord.Name.toLowerCase();
+    if (name === 'ptah.exe' || VSCODE_PROCESS_NAMES.has(name)) {
+      writers.push(processRecord);
+      continue;
+    }
+    if (NODE_PROCESS_NAMES.has(name)) {
+      if (processRecord.CommandLine === null) {
+        throw new Error(
+          `Cannot verify whether Node process ${processRecord.ProcessId} is a Ptah writer`,
+        );
+      }
+      if (PTAH_CLI_ENTRY.test(processRecord.CommandLine)) {
+        writers.push(processRecord);
+      }
+    }
+  }
+  return writers;
+}
+
+function assertPtahClosed(
+  sources,
+  run = execFileSync,
+  resolveExecutable = resolveWindowsSystemExecutable,
+  platform = process.platform,
+) {
+  if (platform !== 'win32') {
     throw new Error('This backup command currently supports Windows only');
   }
-  const output = execFileSync(
-    'tasklist.exe',
-    ['/FI', 'IMAGENAME eq Ptah.exe', '/FO', 'CSV', '/NH'],
-    { encoding: 'utf8', windowsHide: true },
-  );
-  if (/"Ptah\.exe"/i.test(output)) {
-    throw new Error('Ptah is running. Close it completely before backing up');
+  const databasePaths = [...snapshotDatabaseFiles(sources).keys()];
+  let inspection;
+  try {
+    const powershell = resolveExecutable(
+      path.win32.join('System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    );
+    const output = run(
+      powershell,
+      ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_OFFLINE_INSPECTION],
+      {
+        encoding: 'utf8',
+        windowsHide: true,
+        env: {
+          ...process.env,
+          PTAH_BACKUP_DB_PATHS_JSON: JSON.stringify(databasePaths),
+        },
+      },
+    );
+    inspection = JSON.parse(output);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Could not verify that Ptah data is offline: ${detail}`);
+  }
+  if (
+    !inspection ||
+    !Array.isArray(inspection.Processes) ||
+    !Array.isArray(inspection.LockedDatabaseFiles)
+  ) {
+    throw new Error('Windows process inspection returned malformed data');
+  }
+
+  const writers = findPotentialWriters(inspection.Processes);
+  if (writers.length > 0) {
+    const details = writers
+      .map((record) => `${record.Name} (PID ${record.ProcessId})`)
+      .join(', ');
+    throw new Error(
+      `Ptah data may be in use by ${details}. Close Ptah, Ptah CLI/TUI, and all VS Code windows before backing up`,
+    );
+  }
+  if (
+    inspection.LockedDatabaseFiles.some((file) => typeof file !== 'string')
+  ) {
+    throw new Error('Windows process inspection returned malformed data');
+  }
+  if (inspection.LockedDatabaseFiles.length > 0) {
+    throw new Error(
+      `Ptah database files are locked; close every process using Ptah data: ${inspection.LockedDatabaseFiles.join(', ')}`,
+    );
   }
 }
 
@@ -133,7 +233,6 @@ function createBackup({
   sources,
   checkClosed = assertPtahClosed,
 }) {
-  checkClosed();
   assertOutsideSources(destination, sources);
   if (fs.existsSync(destination))
     throw new Error('Backup destination already exists');
@@ -141,6 +240,7 @@ function createBackup({
   if (available.length === 0)
     throw new Error('No Ptah data directories were found');
   assertSourceRootsAreDirectories(available);
+  checkClosed(available);
 
   const before = snapshotDatabaseFiles(available);
   const staging = `${destination}.incomplete-${process.pid}`;
@@ -207,6 +307,7 @@ module.exports = {
   assertPtahClosed,
   assertSourceRootsAreDirectories,
   createBackup,
+  findPotentialWriters,
   isExcluded,
 };
 

--- a/apps/ptah-electron/scripts/backup-local-production-data.js
+++ b/apps/ptah-electron/scripts/backup-local-production-data.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('node:child_process');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const EXCLUDED_DIRECTORY_NAMES = new Set([
+  'cache',
+  'code cache',
+  'gpucache',
+  'dawncache',
+  'crashpad',
+  'logs',
+  'models',
+  '.cache',
+  'backups',
+]);
+
+function isExcluded(relativePath, entry) {
+  if (!entry.isDirectory()) return false;
+  const name = entry.name.toLowerCase();
+  return (
+    EXCLUDED_DIRECTORY_NAMES.has(name) ||
+    /(^|[-_.])backup(s)?($|[-_.])/.test(name)
+  );
+}
+
+function resolveThroughExistingAncestor(input) {
+  let current = path.resolve(input);
+  const missing = [];
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    missing.unshift(path.basename(current));
+    current = parent;
+  }
+  const resolved = fs.existsSync(current)
+    ? fs.realpathSync.native(current)
+    : current;
+  return path.resolve(resolved, ...missing);
+}
+
+function pathKey(input) {
+  const resolved = path.resolve(input);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+function assertOutsideSources(destination, sources) {
+  const target = pathKey(resolveThroughExistingAncestor(destination));
+  for (const source of sources) {
+    const root = pathKey(resolveThroughExistingAncestor(source.path));
+    if (target === root || target.startsWith(`${root}${path.sep}`)) {
+      throw new Error(`Backup destination must not be inside ${source.label}`);
+    }
+  }
+}
+
+function assertSourceRootsAreDirectories(sources) {
+  for (const source of sources) {
+    const stat = fs.lstatSync(source.path);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Refusing symbolic source root: ${source.path}`);
+    }
+    if (!stat.isDirectory()) {
+      throw new Error(`Backup source is not a directory: ${source.path}`);
+    }
+  }
+}
+
+function assertPtahClosed() {
+  if (process.platform !== 'win32') {
+    throw new Error('This backup command currently supports Windows only');
+  }
+  const output = execFileSync(
+    'tasklist.exe',
+    ['/FI', 'IMAGENAME eq Ptah.exe', '/FO', 'CSV', '/NH'],
+    { encoding: 'utf8', windowsHide: true },
+  );
+  if (/"Ptah\.exe"/i.test(output)) {
+    throw new Error('Ptah is running. Close it completely before backing up');
+  }
+}
+
+function snapshotDatabaseFiles(sources) {
+  const result = new Map();
+  const visit = (current) => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) visit(full);
+      else if (/\.(db|sqlite)(-(wal|shm))?$/i.test(entry.name)) {
+        const stat = fs.statSync(full);
+        result.set(full, `${stat.size}:${stat.mtimeMs}`);
+      }
+    }
+  };
+  for (const source of sources)
+    if (fs.existsSync(source.path)) visit(source.path);
+  return result;
+}
+
+function copyTree(source, destination, hashes, relativeRoot = '') {
+  fs.mkdirSync(destination, { recursive: true });
+  for (const entry of fs.readdirSync(source, { withFileTypes: true })) {
+    const relative = path.join(relativeRoot, entry.name);
+    if (isExcluded(relative, entry)) continue;
+    const from = path.join(source, entry.name);
+    const to = path.join(destination, entry.name);
+    if (entry.isSymbolicLink())
+      throw new Error(`Refusing to follow symlink: ${from}`);
+    if (entry.isDirectory()) copyTree(from, to, hashes, relative);
+    else if (entry.isFile()) {
+      fs.copyFileSync(from, to, fs.constants.COPYFILE_EXCL);
+      const sourceHash = crypto
+        .createHash('sha256')
+        .update(fs.readFileSync(from))
+        .digest('hex');
+      const copyHash = crypto
+        .createHash('sha256')
+        .update(fs.readFileSync(to))
+        .digest('hex');
+      if (sourceHash !== copyHash)
+        throw new Error(`Backup verification failed: ${from}`);
+      hashes[path.join(relativeRoot, entry.name).replaceAll('\\', '/')] =
+        sourceHash;
+    }
+  }
+}
+
+function createBackup({
+  destination,
+  sources,
+  checkClosed = assertPtahClosed,
+}) {
+  checkClosed();
+  assertOutsideSources(destination, sources);
+  if (fs.existsSync(destination))
+    throw new Error('Backup destination already exists');
+  const available = sources.filter((source) => fs.existsSync(source.path));
+  if (available.length === 0)
+    throw new Error('No Ptah data directories were found');
+  assertSourceRootsAreDirectories(available);
+
+  const before = snapshotDatabaseFiles(available);
+  const staging = `${destination}.incomplete-${process.pid}`;
+  if (fs.existsSync(staging))
+    throw new Error(`Staging path already exists: ${staging}`);
+  try {
+    fs.mkdirSync(staging, { recursive: false });
+    const manifest = {
+      createdAt: new Date().toISOString(),
+      sources: [],
+      files: {},
+    };
+    for (const source of available) {
+      const target = path.join(staging, source.label);
+      const hashes = {};
+      copyTree(source.path, target, hashes);
+      manifest.sources.push({
+        label: source.label,
+        source: path.resolve(source.path),
+      });
+      for (const [file, hash] of Object.entries(hashes)) {
+        manifest.files[`${source.label}/${file}`] = hash;
+      }
+    }
+    const after = snapshotDatabaseFiles(available);
+    if (JSON.stringify([...before]) !== JSON.stringify([...after])) {
+      throw new Error('Database files changed during backup; backup refused');
+    }
+    fs.writeFileSync(
+      path.join(staging, 'manifest.json'),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      { flag: 'wx' },
+    );
+    fs.renameSync(staging, destination);
+    return manifest;
+  } catch (error) {
+    fs.rmSync(staging, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function main(args = process.argv.slice(2)) {
+  const index = args.indexOf('--destination');
+  const supplied = index >= 0 ? args[index + 1] : undefined;
+  if (!supplied)
+    throw new Error(
+      'Usage: npm run electron:backup:production-data -- --destination <new-directory>',
+    );
+  const destination = path.resolve(supplied);
+  const appData = process.env.APPDATA;
+  if (!appData) throw new Error('APPDATA is not defined');
+  const sources = [
+    { label: 'electron-user-data', path: path.join(appData, 'Ptah') },
+    { label: 'ptah-home', path: path.join(os.homedir(), '.ptah') },
+  ];
+  const manifest = createBackup({ destination, sources });
+  console.log(
+    `[backup] verified ${Object.keys(manifest.files).length} files at ${destination}`,
+  );
+}
+
+module.exports = {
+  assertOutsideSources,
+  assertPtahClosed,
+  assertSourceRootsAreDirectories,
+  createBackup,
+  isExcluded,
+};
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(
+      `[backup] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  }
+}

--- a/apps/ptah-electron/scripts/package-local-production.js
+++ b/apps/ptah-electron/scripts/package-local-production.js
@@ -33,7 +33,7 @@ function validateBaseConfig(configText) {
     );
   }
   for (const hook of FORBIDDEN_HOOKS) {
-    if (new RegExp(`^\\s*${hook}\\s*:`, 'm').test(configText)) {
+    if (new RegExp(String.raw`^\s*${hook}\s*:`, 'm').test(configText)) {
       throw new Error(
         `Production builder hook ${hook} could sign or mutate artifacts`,
       );

--- a/apps/ptah-electron/scripts/package-local-production.js
+++ b/apps/ptah-electron/scripts/package-local-production.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+const { execFileSync, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const BASE_CONFIG = path.join(__dirname, '..', 'electron-builder.yml');
+const OVERLAY_CONFIG = path.join(
+  __dirname,
+  '..',
+  'electron-builder.local-production.cjs',
+);
+const FORBIDDEN_HOOKS = [
+  'beforeBuild',
+  'beforePack',
+  'afterPack',
+  'afterSign',
+  'artifactBuildStarted',
+  'artifactBuildCompleted',
+  'afterAllArtifactBuild',
+];
+const SIGNING_ENV =
+  /^(CSC_|WIN_CSC_|APPLE_|AZURE_|SIGNING_|SIGNTOOL_|SSL_COM_|ESIGNER_|SM_|CERTIFICATE_)/i;
+
+function validateBaseConfig(configText) {
+  if (
+    !/^appId:\s*com\.ptah\.desktop\s*$/m.test(configText) ||
+    !/^productName:\s*Ptah\s*$/m.test(configText)
+  ) {
+    throw new Error(
+      'Production appId/productName changed; local packaging refused',
+    );
+  }
+  for (const hook of FORBIDDEN_HOOKS) {
+    if (new RegExp(`^\\s*${hook}\\s*:`, 'm').test(configText)) {
+      throw new Error(
+        `Production builder hook ${hook} could sign or mutate artifacts`,
+      );
+    }
+  }
+}
+
+function sanitizedEnvironment(source, gitSha) {
+  const clean = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (!SIGNING_ENV.test(key) && value !== undefined) clean[key] = value;
+  }
+  return {
+    ...clean,
+    CSC_IDENTITY_AUTO_DISCOVERY: 'false',
+    PTAH_LOCAL_PRODUCTION_GIT_SHA: gitSha,
+  };
+}
+
+function readCleanGitSha(run = execFileSync, root = ROOT) {
+  const sha = run('git', ['rev-parse', 'HEAD'], {
+    cwd: root,
+    encoding: 'utf8',
+  }).trim();
+  const dirty = run('git', ['status', '--porcelain=v1'], {
+    cwd: root,
+    encoding: 'utf8',
+  }).trim();
+  if (dirty) {
+    throw new Error(
+      'Local-production packaging requires a clean checkout so its Git SHA fully identifies the source',
+    );
+  }
+  if (!/^[0-9a-f]{40}$/.test(sha))
+    throw new Error('Could not resolve a full Git SHA');
+  return sha;
+}
+
+function main() {
+  validateBaseConfig(fs.readFileSync(BASE_CONFIG, 'utf8'));
+  const gitSha = readCleanGitSha();
+  const startedAt = Date.now();
+  const builderCli = require.resolve('electron-builder/cli.js');
+  const result = spawnSync(
+    process.execPath,
+    [
+      builderCli,
+      '--config',
+      OVERLAY_CONFIG,
+      '--project',
+      path.join(ROOT, 'dist', 'apps', 'ptah-electron'),
+      '--publish',
+      'never',
+      '--win',
+    ],
+    {
+      cwd: ROOT,
+      env: sanitizedEnvironment(process.env, gitSha),
+      stdio: 'inherit',
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exit(result.status ?? 1);
+
+  execFileSync(
+    process.execPath,
+    [
+      path.join(__dirname, 'verify-local-production-unsigned.js'),
+      '--since',
+      String(startedAt),
+      '--sha',
+      gitSha,
+    ],
+    { cwd: ROOT, stdio: 'inherit' },
+  );
+}
+
+module.exports = { readCleanGitSha, sanitizedEnvironment, validateBaseConfig };
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(
+      `[local-production] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  }
+}

--- a/apps/ptah-electron/scripts/verify-local-production-unsigned.js
+++ b/apps/ptah-electron/scripts/verify-local-production-unsigned.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const asar = require('@electron/asar');
+
+const ROOT = path.resolve(__dirname, '..', '..', '..');
+const OUTPUT = path.join(ROOT, 'dist', 'release', 'local-production');
+
+function collectExecutables(root) {
+  const results = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) results.push(...collectExecutables(full));
+    else if (entry.name.toLowerCase().endsWith('.exe')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function assertUnsignedStatuses(records, expectedPaths) {
+  const byPath = new Map(
+    records.map((record) => [path.resolve(record.Path), record.Status]),
+  );
+  for (const executable of expectedPaths) {
+    if (byPath.get(path.resolve(executable)) !== 'NotSigned') {
+      throw new Error(`Expected unsigned executable: ${executable}`);
+    }
+  }
+}
+
+function main(args = process.argv.slice(2)) {
+  if (process.platform !== 'win32')
+    throw new Error('Windows signature verification is required');
+  const sinceIndex = args.indexOf('--since');
+  const shaIndex = args.indexOf('--sha');
+  const since = Number(args[sinceIndex + 1]);
+  const sha = args[shaIndex + 1];
+  if (!Number.isFinite(since) || !/^[0-9a-f]{40}$/.test(sha ?? '')) {
+    throw new Error(
+      'Verifier requires --since <epoch-ms> and --sha <full-sha>',
+    );
+  }
+  const unpacked = path.join(OUTPUT, 'win-unpacked');
+  const appExecutable = path.join(unpacked, 'Ptah.exe');
+  const installerPrefix = `Ptah-Local-${sha.slice(0, 12)}-`;
+  const installers = fs
+    .readdirSync(OUTPUT, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        entry.name.startsWith(installerPrefix) &&
+        entry.name.toLowerCase().endsWith('.exe'),
+    )
+    .map((entry) => path.join(OUTPUT, entry.name));
+  // NTFS timestamps can be coarser than Date.now(); the two-second allowance
+  // prevents a fresh artifact from being rejected at a timestamp boundary.
+  const freshEnough = (file) => fs.statSync(file).mtimeMs >= since - 2_000;
+  if (
+    installers.length !== 1 ||
+    !freshEnough(installers[0]) ||
+    !fs.existsSync(appExecutable) ||
+    !freshEnough(appExecutable)
+  ) {
+    throw new Error('Fresh installer and Ptah.exe were not both found');
+  }
+  // Copied dependencies can preserve source mtimes. Check every executable in
+  // the newly packed app, not only files whose timestamps look fresh.
+  const executables = [installers[0], ...collectExecutables(unpacked)];
+
+  const command =
+    '$p=ConvertFrom-Json $env:PTAH_VERIFY_PATHS_JSON;$r=@($p|ForEach-Object{$s=Get-AuthenticodeSignature -LiteralPath $_;[pscustomobject]@{Path=$s.Path;Status=$s.Status.ToString()}});$r|ConvertTo-Json -Compress';
+  const raw = execFileSync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', command],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PTAH_VERIFY_PATHS_JSON: JSON.stringify(executables),
+      },
+    },
+  );
+  const parsed = JSON.parse(raw);
+  const records = Array.isArray(parsed) ? parsed : [parsed];
+  assertUnsignedStatuses(records, executables);
+
+  const packageJson = JSON.parse(
+    asar
+      .extractFile(
+        path.join(OUTPUT, 'win-unpacked', 'resources', 'app.asar'),
+        'package.json',
+      )
+      .toString('utf8'),
+  );
+  const identity = packageJson.ptahBuildIdentity;
+  if (identity?.kind !== 'local-production' || identity.gitSha !== sha) {
+    throw new Error(
+      'Packaged app is missing the expected local-production identity',
+    );
+  }
+  console.log(
+    `[verify] unsigned local-production installer and app verified (${executables.length} executables)`,
+  );
+}
+
+module.exports = { assertUnsignedStatuses, collectExecutables };
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(
+      `[verify] ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  }
+}

--- a/apps/ptah-electron/scripts/verify-local-production-unsigned.js
+++ b/apps/ptah-electron/scripts/verify-local-production-unsigned.js
@@ -4,6 +4,9 @@ const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 const asar = require('@electron/asar');
+const {
+  resolveWindowsSystemExecutable,
+} = require('./windows-system-executable.js');
 
 const ROOT = path.resolve(__dirname, '..', '..', '..');
 const OUTPUT = path.join(ROOT, 'dist', 'release', 'local-production');
@@ -73,7 +76,9 @@ function main(args = process.argv.slice(2)) {
   const command =
     '$p=ConvertFrom-Json $env:PTAH_VERIFY_PATHS_JSON;$r=@($p|ForEach-Object{$s=Get-AuthenticodeSignature -LiteralPath $_;[pscustomobject]@{Path=$s.Path;Status=$s.Status.ToString()}});$r|ConvertTo-Json -Compress';
   const raw = execFileSync(
-    'powershell.exe',
+    resolveWindowsSystemExecutable(
+      path.win32.join('System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    ),
     ['-NoProfile', '-NonInteractive', '-Command', command],
     {
       encoding: 'utf8',

--- a/apps/ptah-electron/scripts/windows-system-executable.js
+++ b/apps/ptah-electron/scripts/windows-system-executable.js
@@ -1,0 +1,51 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function windowsPathKey(value) {
+  return path.win32.normalize(value).toLowerCase();
+}
+
+function resolveWindowsSystemExecutable(
+  relativePath,
+  {
+    platform = process.platform,
+    environment = process.env,
+    existsSync = fs.existsSync,
+    statSync = fs.statSync,
+    realpathSync = fs.realpathSync.native,
+  } = {},
+) {
+  if (platform !== 'win32') {
+    throw new Error('Windows system executable resolution requires Windows');
+  }
+  if (path.win32.isAbsolute(relativePath)) {
+    throw new Error('Windows system executable path must be relative');
+  }
+
+  const roots = [environment.SystemRoot, environment.WINDIR].filter(Boolean);
+  if (roots.length === 0 || roots.some((root) => !path.win32.isAbsolute(root))) {
+    throw new Error('SystemRoot/WINDIR must identify an absolute Windows directory');
+  }
+  if (roots.some((root) => windowsPathKey(root) !== windowsPathKey(roots[0]))) {
+    throw new Error('SystemRoot and WINDIR disagree');
+  }
+
+  const systemRoot = roots[0];
+  const executable = path.win32.resolve(systemRoot, relativePath);
+  const expectedPrefix = `${windowsPathKey(systemRoot)}\\`;
+  if (!windowsPathKey(executable).startsWith(expectedPrefix)) {
+    throw new Error('Windows system executable resolved outside SystemRoot');
+  }
+  if (!existsSync(executable) || !statSync(executable).isFile()) {
+    throw new Error(`Required Windows system executable was not found: ${executable}`);
+  }
+
+  const canonicalRoot = windowsPathKey(realpathSync(systemRoot));
+  const canonicalExecutable = windowsPathKey(realpathSync(executable));
+  if (!canonicalExecutable.startsWith(`${canonicalRoot}\\`)) {
+    throw new Error('Windows system executable resolves outside SystemRoot');
+  }
+  return executable;
+}
+
+module.exports = { resolveWindowsSystemExecutable };

--- a/apps/ptah-electron/src/config/build-identity.spec.ts
+++ b/apps/ptah-electron/src/config/build-identity.spec.ts
@@ -1,0 +1,34 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readBuildIdentity } from './build-identity';
+
+describe('readBuildIdentity', () => {
+  it('accepts the immutable local-production metadata', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ptah-build-identity-'));
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({
+        ptahBuildIdentity: {
+          kind: 'local-production',
+          gitSha: 'a'.repeat(40),
+        },
+      }),
+    );
+
+    expect(readBuildIdentity(dir)).toEqual({
+      kind: 'local-production',
+      gitSha: 'a'.repeat(40),
+    });
+  });
+
+  it.each([
+    {},
+    { ptahBuildIdentity: { kind: 'production', gitSha: 'a'.repeat(40) } },
+    { ptahBuildIdentity: { kind: 'local-production', gitSha: 'short' } },
+  ])('treats absent or invalid metadata as production', (manifest) => {
+    const dir = mkdtempSync(join(tmpdir(), 'ptah-build-identity-'));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify(manifest));
+    expect(readBuildIdentity(dir)).toBeNull();
+  });
+});

--- a/apps/ptah-electron/src/config/build-identity.ts
+++ b/apps/ptah-electron/src/config/build-identity.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { app } from 'electron';
+import { z } from 'zod';
+
+const BuildIdentitySchema = z.object({
+  kind: z.literal('local-production'),
+  gitSha: z.string().regex(/^[0-9a-f]{40}$/),
+});
+
+const PackageMetadataSchema = z.object({
+  ptahBuildIdentity: BuildIdentitySchema.optional(),
+});
+
+export type BuildIdentity = z.infer<typeof BuildIdentitySchema>;
+
+/**
+ * Reads the immutable identity embedded by electron-builder in the packaged
+ * app's package.json. Missing or invalid metadata means the normal production
+ * build; no environment variable can opt a packaged build into this mode.
+ */
+export function readBuildIdentity(
+  appPath = app.getAppPath(),
+): BuildIdentity | null {
+  try {
+    const raw: unknown = JSON.parse(
+      readFileSync(join(appPath, 'package.json'), 'utf8'),
+    );
+    return PackageMetadataSchema.parse(raw).ptahBuildIdentity ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function isLocalProductionBuild(): boolean {
+  return readBuildIdentity()?.kind === 'local-production';
+}

--- a/apps/ptah-electron/src/config/local-production-build.spec.ts
+++ b/apps/ptah-electron/src/config/local-production-build.spec.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const project = JSON.parse(
+  readFileSync(join(__dirname, '..', '..', 'project.json'), 'utf8'),
+);
+const rootPackage = JSON.parse(
+  readFileSync(join(__dirname, '..', '..', '..', '..', 'package.json'), 'utf8'),
+);
+
+describe('local-production packaging configuration', () => {
+  it('is an uncached additive target with isolated output and the production dependencies', () => {
+    const target = project.targets['package-local-production'];
+    expect(target.cache).toBe(false);
+    expect(target.outputs).toEqual([
+      '{workspaceRoot}/dist/release/local-production',
+    ]);
+    expect(target.dependsOn).toEqual([
+      'build',
+      'copy-renderer',
+      'rebuild-native',
+    ]);
+    expect(target.options.commands).toEqual([
+      'node scripts/copy-wasm.js dist/apps/ptah-electron',
+      'node apps/ptah-electron/scripts/patch-transformers-onnx-dep.js',
+      'node apps/ptah-electron/scripts/prune-dist-deps.js',
+      'node apps/ptah-electron/scripts/package-local-production.js',
+      'node apps/ptah-electron/scripts/verify-packed-native.js',
+      'node apps/ptah-electron/scripts/verify-packed-wasm.js',
+      'node apps/ptah-electron/scripts/verify-packed-onnx.js',
+    ]);
+  });
+
+  it('leaves the production package target and root command unchanged', () => {
+    expect(project.targets.package.options.commands).toEqual([
+      'node scripts/copy-wasm.js dist/apps/ptah-electron',
+      'node apps/ptah-electron/scripts/patch-transformers-onnx-dep.js',
+      'node apps/ptah-electron/scripts/prune-dist-deps.js',
+      'electron-builder --config electron-builder.yml --project dist/apps/ptah-electron',
+      'node apps/ptah-electron/scripts/verify-packed-native.js',
+      'node apps/ptah-electron/scripts/verify-packed-wasm.js',
+      'node apps/ptah-electron/scripts/verify-packed-onnx.js',
+    ]);
+    expect(rootPackage.scripts['electron:package']).toBe(
+      'nx package ptah-electron',
+    );
+  });
+});

--- a/apps/ptah-electron/src/config/local-production-guard.spec.ts
+++ b/apps/ptah-electron/src/config/local-production-guard.spec.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const { readCleanGitSha, sanitizedEnvironment, validateBaseConfig } =
+  require('../../scripts/package-local-production.js') as {
+    readCleanGitSha: (
+      run: (file: string, args: string[]) => string,
+      root: string,
+    ) => string;
+    sanitizedEnvironment: (
+      source: NodeJS.ProcessEnv,
+      sha: string,
+    ) => Record<string, string>;
+    validateBaseConfig: (config: string) => void;
+  };
+const { assertUnsignedStatuses } =
+  require('../../scripts/verify-local-production-unsigned.js') as {
+    assertUnsignedStatuses: (
+      records: Array<{ Path: string; Status: string }>,
+      paths: string[],
+    ) => void;
+  };
+
+describe('local-production packaging guard', () => {
+  it('preserves production identity and rejects signing hooks', () => {
+    const config = readFileSync(
+      join(__dirname, '..', '..', 'electron-builder.yml'),
+      'utf8',
+    );
+    expect(() => validateBaseConfig(config)).not.toThrow();
+    expect(() =>
+      validateBaseConfig(
+        'appId: com.ptah.desktop\nproductName: Ptah\nafterSign: ./sign.js\n',
+      ),
+    ).toThrow('afterSign');
+    expect(() =>
+      validateBaseConfig(
+        'appId: com.ptah.desktop\nproductName: Ptah\n  afterAllArtifactBuild : ./mutate.js\n',
+      ),
+    ).toThrow('afterAllArtifactBuild');
+  });
+
+  it('removes inherited signing credentials without exposing their values', () => {
+    const env = sanitizedEnvironment(
+      {
+        PATH: 'safe',
+        CSC_LINK: 'secret-one',
+        WIN_CSC_KEY_PASSWORD: 'secret-two',
+        AZURE_CLIENT_SECRET: 'secret-three',
+        SSL_COM_PASSWORD: 'secret-four',
+      },
+      'a'.repeat(40),
+    );
+    expect(env).toEqual({
+      PATH: 'safe',
+      CSC_IDENTITY_AUTO_DISCOVERY: 'false',
+      PTAH_LOCAL_PRODUCTION_GIT_SHA: 'a'.repeat(40),
+    });
+  });
+
+  it('refuses a dirty checkout and accepts only a full SHA', () => {
+    const run = jest
+      .fn()
+      .mockReturnValueOnce(`${'a'.repeat(40)}\n`)
+      .mockReturnValueOnce(' M source.ts\n');
+    expect(() => readCleanGitSha(run, 'C:\\repo')).toThrow('clean checkout');
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it('requires every packaged Windows executable to be unsigned', () => {
+    const files = [
+      'C:\\out\\Ptah Setup.exe',
+      'C:\\out\\win-unpacked\\Ptah.exe',
+    ];
+    expect(() =>
+      assertUnsignedStatuses(
+        files.map((Path) => ({ Path, Status: 'NotSigned' })),
+        files,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertUnsignedStatuses(
+        [
+          { Path: files[0], Status: 'Valid' },
+          { Path: files[1], Status: 'NotSigned' },
+        ],
+        files,
+      ),
+    ).toThrow('Expected unsigned');
+  });
+});

--- a/apps/ptah-electron/src/config/local-production-guard.spec.ts
+++ b/apps/ptah-electron/src/config/local-production-guard.spec.ts
@@ -20,6 +20,19 @@ const { assertUnsignedStatuses } =
       paths: string[],
     ) => void;
   };
+const { resolveWindowsSystemExecutable } =
+  require('../../scripts/windows-system-executable.js') as {
+    resolveWindowsSystemExecutable: (
+      relativePath: string,
+      options: {
+        platform: NodeJS.Platform;
+        environment: NodeJS.ProcessEnv;
+        existsSync: (file: string) => boolean;
+        statSync: (file: string) => { isFile: () => boolean };
+        realpathSync: (file: string) => string;
+      },
+    ) => string;
+  };
 
 describe('local-production packaging guard', () => {
   it('preserves production identity and rejects signing hooks', () => {
@@ -87,5 +100,35 @@ describe('local-production packaging guard', () => {
         files,
       ),
     ).toThrow('Expected unsigned');
+  });
+
+  it('resolves system tools below matching absolute Windows roots only', () => {
+    const options = {
+      platform: 'win32' as NodeJS.Platform,
+      environment: {
+        SystemRoot: 'C:\\Windows',
+        WINDIR: 'c:\\windows',
+      },
+      existsSync: () => true,
+      statSync: () => ({ isFile: () => true }),
+      realpathSync: (file: string) => file,
+    };
+    expect(
+      resolveWindowsSystemExecutable(
+        'System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+        options,
+      ),
+    ).toBe(
+      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+    );
+    expect(() =>
+      resolveWindowsSystemExecutable('..\\fake.exe', options),
+    ).toThrow('outside SystemRoot');
+    expect(() =>
+      resolveWindowsSystemExecutable('System32\\tool.exe', {
+        ...options,
+        environment: { SystemRoot: 'relative-windows' },
+      }),
+    ).toThrow('absolute Windows directory');
   });
 });

--- a/apps/ptah-electron/src/config/production-data-backup.spec.ts
+++ b/apps/ptah-electron/src/config/production-data-backup.spec.ts
@@ -9,14 +9,38 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const { createBackup } =
+const { assertPtahClosed, createBackup, findPotentialWriters } =
   require('../../scripts/backup-local-production-data.js') as {
+    assertPtahClosed: (
+      sources: Array<{ label: string; path: string }>,
+      run: (
+        file: string,
+        args: string[],
+        options: { env: NodeJS.ProcessEnv },
+      ) => string,
+      resolveExecutable: (relativePath: string) => string,
+      platform: NodeJS.Platform,
+    ) => void;
     createBackup: (options: {
       destination: string;
       sources: Array<{ label: string; path: string }>;
       checkClosed: () => void;
     }) => { files: Record<string, string> };
+    findPotentialWriters: (
+      processes: Array<{
+        ProcessId: number;
+        Name: string;
+        ExecutablePath: string | null;
+        CommandLine: string | null;
+      }>,
+    ) => Array<{ ProcessId: number; Name: string }>;
   };
+
+const processRecord = (
+  Name: string,
+  CommandLine: string | null,
+  ProcessId = 42,
+) => ({ ProcessId, Name, ExecutablePath: null, CommandLine });
 
 describe('production data backup', () => {
   it('copies profile, settings, database and WAL together while excluding caches/backups', () => {
@@ -126,5 +150,130 @@ describe('production data backup', () => {
       }),
     ).toThrow('Ptah is running');
     expect(existsSync(join(root, 'backup'))).toBe(false);
+  });
+
+  it.each([
+    ['Electron', processRecord('Ptah.exe', '"C:\\Program Files\\Ptah\\Ptah.exe"')],
+    [
+      'installed CLI',
+      processRecord(
+        'node.exe',
+        'node "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\@hive-academy\\ptah-cli\\main.mjs" session',
+      ),
+    ],
+    [
+      'workspace TUI',
+      processRecord(
+        'node.exe',
+        'node D:\\repo\\dist\\apps\\ptah-tui\\tui.mjs',
+      ),
+    ],
+    [
+      'workspace TUI source',
+      processRecord(
+        'node.exe',
+        'node D:\\repo\\apps\\ptah-tui\\src\\main.tsx',
+      ),
+    ],
+    [
+      'VS Code host',
+      processRecord('Code.exe', 'Code.exe --type=utility'),
+    ],
+  ])('identifies the %s host as a potential writer', (_label, record) => {
+    expect(findPotentialWriters([record])).toEqual([record]);
+  });
+
+  it('refuses unavailable Node command lines and malformed process records', () => {
+    expect(() =>
+      findPotentialWriters([processRecord('node.exe', null)]),
+    ).toThrow('Cannot verify whether Node process');
+    expect(() =>
+      findPotentialWriters([
+        {
+          ...processRecord('node.exe', 'node harmless.js'),
+          ProcessId: 'not-a-pid',
+        } as never,
+      ]),
+    ).toThrow('malformed data');
+  });
+
+  it('uses an absolute system PowerShell path and accepts a healthy offline fixture', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ptah-backup-test-'));
+    const state = join(root, 'state');
+    mkdirSync(state);
+    const database = join(state, 'ptah.sqlite');
+    writeFileSync(database, 'fixture');
+    const resolveExecutable = jest.fn(
+      () => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+    );
+    const run = jest.fn(
+      (_file: string, _args: string[], options: { env: NodeJS.ProcessEnv }) => {
+        const databasePathsJson = options.env['PTAH_BACKUP_DB_PATHS_JSON'];
+        expect(databasePathsJson).toBeDefined();
+        expect(JSON.parse(databasePathsJson ?? '')).toEqual([database]);
+        return JSON.stringify({
+          Processes: [processRecord('node.exe', 'node harmless.js')],
+          LockedDatabaseFiles: [],
+        });
+      },
+    );
+
+    expect(() =>
+      assertPtahClosed(
+        [{ label: 'ptah-home', path: root }],
+        run,
+        resolveExecutable,
+        'win32',
+      ),
+    ).not.toThrow();
+    expect(run).toHaveBeenCalledWith(
+      expect.stringMatching(/^C:\\Windows\\System32\\/),
+      expect.any(Array),
+      expect.any(Object),
+    );
+    expect(resolveExecutable).toHaveBeenCalledWith(
+      'System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+    );
+  });
+
+  it('fails closed when inspection fails, is malformed, or finds a database lock', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ptah-backup-test-'));
+    const source = [{ label: 'ptah-home', path: root }];
+    const executable = () =>
+      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
+
+    expect(() =>
+      assertPtahClosed(
+        source,
+        () => {
+          throw new Error('CIM unavailable');
+        },
+        executable,
+        'win32',
+      ),
+    ).toThrow('Could not verify that Ptah data is offline');
+    expect(() =>
+      assertPtahClosed(source, () => '{bad json', executable, 'win32'),
+    ).toThrow('Could not verify that Ptah data is offline');
+    expect(() =>
+      assertPtahClosed(
+        source,
+        () => JSON.stringify({ Processes: {}, LockedDatabaseFiles: [] }),
+        executable,
+        'win32',
+      ),
+    ).toThrow('malformed data');
+    expect(() =>
+      assertPtahClosed(
+        source,
+        () =>
+          JSON.stringify({
+            Processes: [],
+            LockedDatabaseFiles: ['C:\\Users\\me\\.ptah\\state\\ptah.sqlite'],
+          }),
+        executable,
+        'win32',
+      ),
+    ).toThrow('database files are locked');
   });
 });

--- a/apps/ptah-electron/src/config/production-data-backup.spec.ts
+++ b/apps/ptah-electron/src/config/production-data-backup.spec.ts
@@ -1,0 +1,130 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const { createBackup } =
+  require('../../scripts/backup-local-production-data.js') as {
+    createBackup: (options: {
+      destination: string;
+      sources: Array<{ label: string; path: string }>;
+      checkClosed: () => void;
+    }) => { files: Record<string, string> };
+  };
+
+describe('production data backup', () => {
+  it('copies profile, settings, database and WAL together while excluding caches/backups', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ptah-backup-test-'));
+    const profile = join(root, 'profile');
+    const ptahHome = join(root, 'ptah-home');
+    mkdirSync(join(profile, 'Cache'), { recursive: true });
+    mkdirSync(join(ptahHome, 'models'), { recursive: true });
+    mkdirSync(join(ptahHome, 'backups'), { recursive: true });
+    writeFileSync(join(profile, 'Local State'), 'account');
+    writeFileSync(join(profile, 'Cache', 'cache.bin'), 'skip');
+    writeFileSync(join(ptahHome, 'settings.json'), '{"theme":"dark"}');
+    writeFileSync(join(ptahHome, 'ptah.db'), 'db');
+    writeFileSync(join(ptahHome, 'ptah.db-wal'), 'wal');
+    writeFileSync(join(ptahHome, 'ptah.db-shm'), 'shm');
+    writeFileSync(join(ptahHome, 'models', 'model.bin'), 'skip');
+    const destination = join(root, 'backup-result');
+
+    const manifest = createBackup({
+      destination,
+      sources: [
+        { label: 'electron-user-data', path: profile },
+        { label: 'ptah-home', path: ptahHome },
+      ],
+      checkClosed: () => undefined,
+    });
+
+    expect(
+      readFileSync(join(destination, 'ptah-home', 'ptah.db-wal'), 'utf8'),
+    ).toBe('wal');
+    expect(existsSync(join(destination, 'electron-user-data', 'Cache'))).toBe(
+      false,
+    );
+    expect(existsSync(join(destination, 'ptah-home', 'models'))).toBe(false);
+    expect(existsSync(join(destination, 'ptah-home', 'backups'))).toBe(false);
+    expect(Object.keys(manifest.files)).toEqual(
+      expect.arrayContaining([
+        'ptah-home/ptah.db',
+        'ptah-home/ptah.db-wal',
+        'ptah-home/ptah.db-shm',
+      ]),
+    );
+  });
+
+  it('refuses a destination inside production data before copying', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ptah-backup-test-'));
+    const profile = join(root, 'profile');
+    mkdirSync(profile);
+    writeFileSync(join(profile, 'state.json'), '{}');
+    const destination = join(profile, 'backups', 'bad');
+
+    expect(() =>
+      createBackup({
+        destination,
+        sources: [{ label: 'electron-user-data', path: profile }],
+        checkClosed: () => undefined,
+      }),
+    ).toThrow('must not be inside');
+    expect(existsSync(destination)).toBe(false);
+  });
+
+  it('resolves an existing symlink when checking for recursive destinations', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ptah-backup-test-'));
+    const profile = join(root, 'profile');
+    const alias = join(root, 'profile-alias');
+    mkdirSync(profile);
+    writeFileSync(join(profile, 'state.json'), '{}');
+    symlinkSync(profile, alias, 'junction');
+
+    expect(() =>
+      createBackup({
+        destination: join(alias, 'nested-backup'),
+        sources: [{ label: 'electron-user-data', path: profile }],
+        checkClosed: () => undefined,
+      }),
+    ).toThrow('must not be inside');
+  });
+
+  it('refuses a symbolic source root', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ptah-backup-test-'));
+    const profile = join(root, 'profile');
+    const alias = join(root, 'profile-alias');
+    mkdirSync(profile);
+    symlinkSync(profile, alias, 'junction');
+
+    expect(() =>
+      createBackup({
+        destination: join(root, 'backup'),
+        sources: [{ label: 'electron-user-data', path: alias }],
+        checkClosed: () => undefined,
+      }),
+    ).toThrow('Refusing symbolic source root');
+  });
+
+  it('refuses the backup when the app-closed check fails', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ptah-backup-test-'));
+    const profile = join(root, 'profile');
+    mkdirSync(profile);
+
+    expect(() =>
+      createBackup({
+        destination: join(root, 'backup'),
+        sources: [{ label: 'electron-user-data', path: profile }],
+        checkClosed: () => {
+          throw new Error('Ptah is running');
+        },
+      }),
+    ).toThrow('Ptah is running');
+    expect(existsSync(join(root, 'backup'))).toBe(false);
+  });
+});

--- a/apps/ptah-electron/src/services/update/update-manager.spec.ts
+++ b/apps/ptah-electron/src/services/update/update-manager.spec.ts
@@ -22,14 +22,19 @@ jest.mock('electron', () => ({
   app: { getVersion: jest.fn(() => '0.1.48') },
   net: { fetch: jest.fn() },
 }));
+jest.mock('../../config/build-identity', () => ({
+  isLocalProductionBuild: jest.fn(() => false),
+}));
 
 import { app, net } from 'electron';
 import { UpdateManager } from './update-manager';
 import type { UpdateLifecycleState } from '@ptah-extension/shared';
 import { MESSAGE_TYPES } from '@ptah-extension/shared';
+import { isLocalProductionBuild } from '../../config/build-identity';
 
 const getVersion = app.getVersion as jest.Mock;
 const netFetch = net.fetch as unknown as jest.Mock;
+const localProductionBuild = isLocalProductionBuild as jest.Mock;
 
 // Mirrors the private constants in update-manager.ts.
 const INITIAL_CHECK_DELAY_MS = 10_000;
@@ -171,6 +176,7 @@ function setPlatform(value: NodeJS.Platform) {
 }
 
 beforeEach(() => {
+  localProductionBuild.mockReturnValue(false);
   getVersion.mockReturnValue('0.1.48');
   setPlatform('win32');
   delete process.env['NODE_ENV'];
@@ -195,6 +201,30 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('UpdateManager', () => {
+  describe('local-production gate', () => {
+    it('does not schedule automatic checks', async () => {
+      localProductionBuild.mockReturnValue(true);
+      const { manager, logger } = createUpdateManager();
+
+      await manager.start();
+
+      expect(manager.getCheckInterval()).toBeNull();
+      expect(netFetch).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('local-production'),
+      );
+    });
+
+    it('does not run a manual check', async () => {
+      localProductionBuild.mockReturnValue(true);
+      const { manager } = createUpdateManager();
+
+      await manager.triggerCheck();
+
+      expect(netFetch).not.toHaveBeenCalled();
+      expect(manager.getCurrentState()).toEqual({ state: 'idle' });
+    });
+  });
   describe('dev-mode gate', () => {
     it('returns early without fetching or setting an interval when NODE_ENV=development', async () => {
       process.env['NODE_ENV'] = 'development';

--- a/apps/ptah-electron/src/services/update/update-manager.ts
+++ b/apps/ptah-electron/src/services/update/update-manager.ts
@@ -17,6 +17,7 @@ import { TOKENS } from '@ptah-extension/vscode-core';
 import type { Logger } from '@ptah-extension/vscode-core';
 import { MESSAGE_TYPES } from '@ptah-extension/shared';
 import type { UpdateLifecycleState } from '@ptah-extension/shared';
+import { isLocalProductionBuild } from '../../config/build-identity';
 
 const GITHUB_RELEASES_URL =
   'https://api.github.com/repos/Hive-Academy/ptah-extension/releases';
@@ -126,6 +127,10 @@ export class UpdateManager implements IAppUpdater {
    * `PTAH_E2E_ALLOW_UPDATE_CHECK: '1'` through `launchPtah`'s `opts.env`.
    */
   async start(): Promise<void> {
+    if (isLocalProductionBuild()) {
+      this.logger.info('[UpdateManager] Skipped — local-production build');
+      return;
+    }
     if (process.env['NODE_ENV'] === 'development') {
       this.logger.info('[UpdateManager] Skipped — development mode');
       return;
@@ -156,6 +161,12 @@ export class UpdateManager implements IAppUpdater {
 
   /** On-demand check (called by the update:check-now RPC handler). */
   async triggerCheck(): Promise<void> {
+    if (isLocalProductionBuild()) {
+      this.logger.info(
+        '[UpdateManager] Manual check skipped — local-production build',
+      );
+      return;
+    }
     await this.checkViaGitHub();
   }
 

--- a/docs/development/electron-local-production.md
+++ b/docs/development/electron-local-production.md
@@ -1,0 +1,58 @@
+# Local production Electron installer
+
+This path builds an unsigned Windows installer from a clean local checkout. It
+uses the production app ID (`com.ptah.desktop`), product/package identity,
+version, API, account, `%APPDATA%\Ptah` profile, and `~/.ptah` data. It does not
+change `NODE_ENV`, redirect `userData`, publish, or use signing credentials.
+
+## 1. Back up production data while Ptah is closed
+
+Close Ptah completely, choose a new destination outside both production data
+directories, then run:
+
+```powershell
+npm run electron:backup:production-data -- --destination D:\ptah-backups\before-local-2026-09-09
+```
+
+The command refuses to run while `Ptah.exe` is present, refuses an existing or
+recursive destination, copies the Electron profile and `~/.ptah`, includes the
+SQLite database with its WAL/SHM files, hashes every copied file, and refuses a
+backup if database files change during the copy. Rebuildable caches, logs,
+downloaded models, and nested backup directories are excluded. Treat the backup
+as sensitive because it can contain account/session material.
+
+Never install a local build without its paired backup. Forward database or
+settings migrations may make data unreadable by an older production build; an
+installer rollback does not reverse those migrations. Restoring the paired
+backup must be done with Ptah closed and is intentionally a manual operation.
+
+## 2. Build the installer
+
+Commit or stash every change first; the command deliberately has no dirty-tree
+override. Then run:
+
+```powershell
+npm run electron:package:local-production
+```
+
+Artifacts are isolated under `dist/release/local-production`. The target uses
+the normal production build, renderer copy, Electron native rebuild, and packed
+native/WASM/ONNX gates. Its packaging guard passes `--publish never`, removes
+signing-related environment variables, disables certificate autodiscovery and
+refuses custom packaging hooks, embeds the full Git SHA as `ptahBuildIdentity`, and
+requires Windows Authenticode status `NotSigned` for every generated executable.
+
+The embedded identity disables both scheduled and manual update checks. Normal
+production builds have no marker and retain their existing updater behavior.
+
+## 3. Install and roll back
+
+The local installer deliberately retains the source package version. Check that
+version against the installed Ptah version yourself; this workflow does not
+claim or synthesize a newer release number and does not automate downgrades.
+Windows may warn because the installer is unsigned.
+
+To return to a public build, reinstall the desired official installer. If the
+local build ran any forward migration, reinstalling alone is insufficient:
+restore the matching pre-install backup with Ptah closed. There is no automatic
+downgrade or data rollback command.

--- a/docs/development/electron-local-production.md
+++ b/docs/development/electron-local-production.md
@@ -5,21 +5,36 @@ uses the production app ID (`com.ptah.desktop`), product/package identity,
 version, API, account, `%APPDATA%\Ptah` profile, and `~/.ptah` data. It does not
 change `NODE_ENV`, redirect `userData`, publish, or use signing credentials.
 
-## 1. Back up production data while Ptah is closed
+## 1. Back up production data while every Ptah host is closed
 
-Close Ptah completely, choose a new destination outside both production data
-directories, then run:
+Close the Ptah desktop app, every Ptah CLI/TUI process, and all VS Code windows
+before starting the backup. VS Code must be fully closed because Windows process
+metadata cannot prove whether the Ptah extension is active in an extension host.
+Choose a new destination outside both production data directories, then run:
 
 ```powershell
 npm run electron:backup:production-data -- --destination D:\ptah-backups\before-local-2026-09-09
 ```
 
-The command refuses to run while `Ptah.exe` is present, refuses an existing or
-recursive destination, copies the Electron profile and `~/.ptah`, includes the
-SQLite database with its WAL/SHM files, hashes every copied file, and refuses a
-backup if database files change during the copy. Rebuildable caches, logs,
-downloaded models, and nested backup directories are excluded. Treat the backup
-as sensitive because it can contain account/session material.
+The command inspects Windows processes without terminating them. It refuses a
+desktop process, any VS Code-family process, an identifiable packaged or
+workspace Ptah CLI/TUI process, a Node process whose command line cannot be
+inspected, or any malformed/failed inspection. It also requires every discovered
+SQLite database, WAL, and SHM file to be exclusively openable before copying.
+An existing or recursive destination is refused. The Electron profile and
+`~/.ptah` are copied together; hashes verify that each copied file matches the
+bytes read from its source, while a database size/mtime comparison is only a
+secondary change detector and is not treated as proof of consistency.
+Rebuildable caches, logs, downloaded models, and nested backup directories are
+excluded. Treat the backup as sensitive because it can contain account/session
+material.
+
+This is a conservative offline preflight, not a filesystem snapshot: another
+writer could still be launched after inspection begins, and an unrelated process
+that edits these directories may not identify itself as Ptah. Do not start Ptah,
+the CLI/TUI, VS Code, or another writer until the command finishes. If the command
+cannot verify safety, keep the existing data untouched, close the reported
+processes, and retry; do not work around the guard.
 
 Never install a local build without its paired backup. Forward database or
 settings migrations may make data unreadable by an older production build; an

--- a/libs/backend/agent-sdk/src/lib/session-importer.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/session-importer.service.spec.ts
@@ -935,19 +935,23 @@ describe('SessionImporterService', () => {
             'file-history-snapshot',
             { type: 'file-history-snapshot', files: { 'a.ts': 'abc123' } },
           ],
-        ])('prunes an entry whose backing file is a %s sidecar', async (
-          label,
-          record,
-        ) => {
-          await store.create(`sidecar-${label}`, WORKSPACE, 'Session 1/1/2026');
+        ])(
+          'prunes an entry whose backing file is a %s sidecar',
+          async (label, record) => {
+            await store.create(
+              `sidecar-${label}`,
+              WORKSPACE,
+              'Session 1/1/2026',
+            );
 
-          primePruneOnlyScan();
-          mockPositionalRead(Buffer.from(JSON.stringify(record) + '\n'));
+            primePruneOnlyScan();
+            mockPositionalRead(Buffer.from(JSON.stringify(record) + '\n'));
 
-          await importer.scanAndImport(WORKSPACE);
+            await importer.scanAndImport(WORKSPACE);
 
-          expect(await store.getForWorkspace(WORKSPACE)).toEqual([]);
-        });
+            expect(await store.getForWorkspace(WORKSPACE)).toEqual([]);
+          },
+        );
 
         it('keeps a real session whose leading summary parses but whose first turn is cut off', async () => {
           // The reason the widened sidecar rule ALSO demands a short read.
@@ -982,6 +986,62 @@ describe('SessionImporterService', () => {
 
           const all = await store.getForWorkspace(WORKSPACE);
           expect(all.map((m) => m.sessionId)).toEqual(['summary-then-cut']);
+        });
+
+        it('keeps a titled real session whose oversized first user record is cut off', async () => {
+          // Production-shaped regression for the 2026-09-09 deletion: the
+          // prefix contains a parseable ai-title and queue records, while the
+          // first user record is much larger than the remaining 8 KB. The old
+          // predicate saw the title, dropped the cut user line and deleted the
+          // metadata as a title-only phantom.
+          await store.create('title-then-cut', WORKSPACE, 'Real titled work');
+          const content = Buffer.from(
+            JSON.stringify({ type: 'ai-title', title: 'Real titled work' }) +
+              '\n' +
+              JSON.stringify({
+                type: 'queue-operation',
+                operation: 'enqueue',
+              }) +
+              '\n' +
+              JSON.stringify({
+                type: 'queue-operation',
+                operation: 'dequeue',
+              }) +
+              '\n' +
+              JSON.stringify({
+                type: 'user',
+                message: { role: 'user', content: 'P'.repeat(20_000) },
+              }) +
+              '\n',
+          );
+          expect(content.length).toBeGreaterThan(8192);
+
+          primePruneOnlyScan();
+          mockPositionalRead(content);
+
+          await importer.scanAndImport(WORKSPACE);
+
+          const all = await store.getForWorkspace(WORKSPACE);
+          expect(all.map((m) => m.sessionId)).toEqual(['title-then-cut']);
+        });
+
+        it('keeps metadata when the transcript probe read fails and closes the file', async () => {
+          await store.create('read-failed', WORKSPACE, 'Real work');
+          const close = jest.fn(async () => undefined);
+
+          primePruneOnlyScan();
+          fsPromises.open.mockResolvedValue({
+            read: jest.fn(async () => {
+              throw new Error('EIO');
+            }),
+            close,
+          } as unknown as Awaited<ReturnType<typeof fsPromises.open>>);
+
+          await importer.scanAndImport(WORKSPACE);
+
+          const all = await store.getForWorkspace(WORKSPACE);
+          expect(all.map((m) => m.sessionId)).toEqual(['read-failed']);
+          expect(close).toHaveBeenCalledTimes(1);
         });
 
         it('keeps a REAL session whose stored name is "Session <date>"', async () => {

--- a/libs/backend/agent-sdk/src/lib/session-importer.service.ts
+++ b/libs/backend/agent-sdk/src/lib/session-importer.service.ts
@@ -352,9 +352,12 @@ export class SessionImporterService {
     }
 
     if (pruned > 0) {
-      this.logger.info('[SessionImporter] Pruned contentless phantom sessions', {
-        pruned,
-      });
+      this.logger.info(
+        '[SessionImporter] Pruned contentless phantom sessions',
+        {
+          pruned,
+        },
+      );
     }
 
     return pruned;
@@ -421,8 +424,14 @@ export class SessionImporterService {
     try {
       const fd = await fs.promises.open(filePath, 'r');
       const buffer = Buffer.alloc(METADATA_PREFIX_BYTES);
-      const { bytesRead } = await fd.read(buffer, 0, METADATA_PREFIX_BYTES, 0);
-      await fd.close();
+      let bytesRead: number;
+      try {
+        ({ bytesRead } = await fd.read(buffer, 0, METADATA_PREFIX_BYTES, 0));
+      } finally {
+        // A failed read makes the probe inconclusive, but must not leave one
+        // file handle behind for every stored session examined on a scan.
+        await fd.close();
+      }
 
       // A full read cannot prove the whole file is in the buffer (a file of
       // exactly METADATA_PREFIX_BYTES also fills it), so anything concluded

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "electron:build": "nx build ptah-electron --skip-nx-cache",
     "electron:build:dev": "nx build-dev ptah-electron",
     "electron:package": "nx package ptah-electron",
+    "electron:package:local-production": "nx package-local-production ptah-electron",
+    "electron:backup:production-data": "node apps/ptah-electron/scripts/backup-local-production-data.js",
     "electron:rebuild": "node apps/ptah-electron/scripts/rebuild-native.js",
     "postinstall": "node apps/ptah-electron/scripts/rebuild-native.js && node apps/ptah-electron/scripts/patch-transformers-onnx-dep.js",
     "cli:build": "nx build ptah-cli",


### PR DESCRIPTION
## Summary

- preserve stored session metadata when the 8 KiB probe truncates an oversized first user record, and always close the probe file handle
- add an unsigned Windows local-production packaging path that keeps the production identity, embeds an immutable Git SHA marker, disables update checks, strips signing credentials, refuses packaging hooks, and never publishes
- add a verified production-data backup command with database consistency, process, recursion, and symlink/junction guards
- document backup, packaging, install, and manual rollback expectations

## Test plan

- `session-importer.service.spec.ts`: 45 passed
- local-production configuration/guard/backup plus `update-manager.spec.ts`: 51 passed across 5 suites
- scoped Nx lint: 2 projects passed (0 errors; 42 pre-existing warnings outside changed lines)
- exact changed-file ESLint: passed
- script syntax and resolved builder-overlay assertions: passed
- `ptah-electron:validate-deps`: passed; 35/35 external imports covered
- `di-lint:lint`: passed; 1,442 injection sites resolved
- commitlint: both commits passed
- `ptah-electron:typecheck`: still fails on the pre-existing missing Jest globals in `src/config/build-artifact-gate.ts` (six TS2503/TS2593 errors); no suppression or bypass was added
- actual installer build/install/rollback acceptance was intentionally not run; no installer was built, signed, published, or installed, and no live Ptah data was backed up or modified

This PR does not claim that any previously deleted/original session was restored; it prevents the unsafe metadata pruning case and adds regression coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a guarded Windows local-production workflow and preserves session metadata when an oversized first record exceeds the importer probe.
- Adds unsigned, non-publishing Electron packaging with immutable build identity and disabled update checks.
- Adds verified production-data backup with process, database-lock, recursion, and symlink protections.
- Extends importer, packaging, backup, identity, and update-manager regression coverage.
- Documents backup, installation, and rollback procedures.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/ptah-electron/scripts/backup-local-production-data.js | Adds fail-closed writer and database-lock inspection, guarded recursive copying, hash verification, and atomic backup publication; the previously reported CLI-writer gap is addressed for the repository’s installed and built entry points. |
| apps/ptah-electron/scripts/package-local-production.js | Adds clean-checkout enforcement, signing-environment sanitization, non-publishing Windows packaging, and post-build verification. |
| apps/ptah-electron/scripts/verify-local-production-unsigned.js | Verifies artifact freshness, unsigned executable status, and embedded local-production identity. |
| apps/ptah-electron/src/services/update/update-manager.ts | Prevents local-production builds from starting automatic update checks. |
| libs/backend/agent-sdk/src/lib/session-importer.service.ts | Preserves stored session metadata when the bounded first-record probe cannot parse a truncated oversized record and ensures the probe handle is closed. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Request local-production package] --> B{Git checkout clean?}
  B -- No --> X[Refuse packaging]
  B -- Yes --> C[Build with production identity]
  C --> D[Strip signing credentials]
  D --> E[Package without publishing]
  E --> F{Artifacts unsigned and identity valid?}
  F -- No --> X
  F -- Yes --> G[Local installer ready]
  H[Request production-data backup] --> I{Writers absent and databases unlocked?}
  I -- No --> Y[Refuse backup]
  I -- Yes --> J[Copy into staging directory]
  J --> K{Hashes and database snapshots stable?}
  K -- No --> Y
  K -- Yes --> L[Atomically publish backup]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(electron): harden local production s..."](https://github.com/hive-academy/ptah-extension/commit/712d9cd80280ff7d473e2f32f60b9f340654b483) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62240778)</sub>

<!-- /greptile_comment -->