### PR TITLE
fix(agent-sdk): preserve optional isolation and portable worktree paths

### DIFF
--- a/apps/ptah-extension-vscode/src/rpc-host-profile.ts
+++ b/apps/ptah-extension-vscode/src/rpc-host-profile.ts
@@ -38,7 +38,7 @@ export function createVscodeRpcHostProfile(logger: Logger): HostProfile {
           const crossSpawn = await import('cross-spawn');
           const child = crossSpawn.default(
             'git',
-            ['worktree', 'list', '--porcelain'],
+            ['worktree', 'list', '--porcelain', '-z'],
             { cwd: data.cwd, stdio: ['pipe', 'pipe', 'pipe'] },
           );
           const chunks: Buffer[] = [];

--- a/libs/backend/agent-sdk/src/lib/helpers/session-lifecycle/session-query-executor.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/session-lifecycle/session-query-executor.service.spec.ts
@@ -138,14 +138,12 @@ function makeHarness(globalPermissionLevel: PermissionLevel): Harness {
   } as unknown as SdkQueryOptionsBuilder;
 
   const messageFactory = {
-    createUserMessage: jest
-      .fn()
-      .mockResolvedValue({
-        type: 'user',
-        session_id: 's',
-        message: { role: 'user', content: 'hello' },
-        parent_tool_use_id: null,
-      }),
+    createUserMessage: jest.fn().mockResolvedValue({
+      type: 'user',
+      session_id: 's',
+      message: { role: 'user', content: 'hello' },
+      parent_tool_use_id: null,
+    }),
   } as unknown as SdkMessageFactory;
 
   const authEnv = {} as AuthEnv;
@@ -428,9 +426,11 @@ describe('real watchdog query ownership regressions', () => {
       {} as SdkMessageFactory,
     );
     result.activityWatchdog.start();
-    const iterator = pump
-      .createUserMessageStream('pump' as SessionId, result.abortController)
-      [Symbol.asyncIterator]();
+    const stream = pump.createUserMessageStream(
+      'pump' as SessionId,
+      result.abortController,
+    );
+    const iterator = stream[Symbol.asyncIterator]();
     await iterator.next();
     expect(registry.find('pump')?.turnInFlight).toBe(true);
     result.activityWatchdog.hold();
@@ -468,12 +468,20 @@ describe('real watchdog query ownership regressions', () => {
         mode === 'reject'
           ? jest.fn().mockRejectedValue(new Error('transport failed'))
           : jest.fn().mockReturnValue(new Promise(() => undefined));
-      const cleanup = jest.fn(() => { if (mode === 'reject') throw new Error('cleanup failed'); });
-      const children = { beginSessionTeardown: jest.fn(), markAllInterrupted: jest.fn(), endSessionTeardown: jest.fn() };
+      const cleanup = jest.fn(() => {
+        if (mode === 'reject') throw new Error('cleanup failed');
+      });
+      const children = {
+        beginSessionTeardown: jest.fn(),
+        markAllInterrupted: jest.fn(),
+        endSessionTeardown: jest.fn(),
+      };
       const control = new SessionControl(
         makeLogger(),
         registry,
-        { cleanupPendingPermissions: cleanup } as unknown as ISdkPermissionHandler,
+        {
+          cleanupPendingPermissions: cleanup,
+        } as unknown as ISdkPermissionHandler,
         children as unknown as SubagentRegistryService,
         {} as IModelResolver,
         {} as SessionEndCallbackRegistry,

--- a/libs/backend/agent-sdk/src/lib/helpers/worktree-hook-handler.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/worktree-hook-handler.spec.ts
@@ -1,6 +1,8 @@
 import 'reflect-metadata';
 import * as path from 'path';
 import type { Logger, GitInfoService } from '@ptah-extension/vscode-core';
+import { worktreeDirectoryName } from '@ptah-extension/vscode-core';
+import { parseWorktreeList } from '@ptah-extension/shared';
 import { WorktreeHookHandler } from './worktree-hook-handler';
 import type {
   HookInput,
@@ -9,15 +11,38 @@ import type {
 
 describe('WorktreeHookHandler', () => {
   let logger: jest.Mocked<Logger>;
-  let gitInfo: { addWorktree: jest.Mock };
+  let gitInfo: { addWorktree: jest.Mock; getWorktrees: jest.Mock };
   let handler: WorktreeHookHandler;
 
-  const REPO = 'D:/repo';
+  const REPO = 'D:\\repo';
   const NAME = 'agent-ad9423367fb06a608';
-  const expectedPath = path.join(REPO, '.claude-worktrees', NAME);
+  const expectedPath = path.win32.join(
+    REPO,
+    '.claude-worktrees',
+    worktreeDirectoryName(NAME),
+  );
+  const pathCases = [
+    {
+      platform: 'Windows',
+      pathApi: path.win32,
+      repositoryRoot: 'D:\\projects\\ptah-extension',
+    },
+    {
+      platform: 'Ubuntu/Linux',
+      pathApi: path.posix,
+      repositoryRoot: '/home/dev/projects/ptah-extension',
+    },
+    {
+      platform: 'macOS',
+      pathApi: path.posix,
+      repositoryRoot: '/Users/dev/projects/ptah-extension',
+    },
+  ] as const;
 
   function invokeCreate(
     onCreated?: Parameters<WorktreeHookHandler['createHooks']>[0],
+    cwd = REPO,
+    inputOverride?: Partial<HookInput>,
   ): Promise<HookJSONOutput> {
     const hooks = handler.createHooks(onCreated);
     const hook = hooks.WorktreeCreate?.[0]?.hooks?.[0];
@@ -26,8 +51,9 @@ describe('WorktreeHookHandler', () => {
       hook_event_name: 'WorktreeCreate',
       session_id: 's1',
       transcript_path: '',
-      cwd: REPO,
+      cwd,
       name: NAME,
+      ...inputOverride,
     } as unknown as HookInput;
     return hook(input, undefined, {
       signal: new AbortController().signal,
@@ -41,7 +67,18 @@ describe('WorktreeHookHandler', () => {
       error: jest.fn(),
       debug: jest.fn(),
     } as unknown as jest.Mocked<Logger>;
-    gitInfo = { addWorktree: jest.fn() };
+    gitInfo = {
+      addWorktree: jest.fn(),
+      getWorktrees: jest.fn().mockResolvedValue([
+        {
+          path: REPO,
+          head: 'abcdef12',
+          branch: 'main',
+          isMain: true,
+          isBare: false,
+        },
+      ]),
+    };
     handler = new WorktreeHookHandler(
       logger,
       gitInfo as unknown as GitInfoService,
@@ -74,25 +111,175 @@ describe('WorktreeHookHandler', () => {
     );
   });
 
-  it('falls back to continue:true with no path when worktree creation fails', async () => {
+  it.each(pathCases)(
+    'places a $platform child beside its linked parent under the main repository root',
+    async ({ pathApi, repositoryRoot }) => {
+      const linked = pathApi.join(
+        repositoryRoot,
+        '.claude-worktrees',
+        'parent',
+      );
+      const sibling = pathApi.join(
+        repositoryRoot,
+        '.claude-worktrees',
+        worktreeDirectoryName(NAME),
+      );
+      gitInfo.getWorktrees.mockResolvedValue([
+        {
+          path: repositoryRoot,
+          head: 'abcdef12',
+          branch: 'main',
+          isMain: true,
+          isBare: false,
+        },
+        {
+          path: linked,
+          head: '12345678',
+          branch: 'parent',
+          isMain: false,
+          isBare: false,
+        },
+      ]);
+      gitInfo.addWorktree.mockResolvedValue({
+        success: true,
+        worktreePath: sibling,
+      });
+
+      const result = await invokeCreate(undefined, linked);
+
+      expect(gitInfo.getWorktrees).toHaveBeenCalledWith(linked);
+      expect(gitInfo.addWorktree).toHaveBeenCalledWith(linked, {
+        branch: NAME,
+        path: sibling,
+        createBranch: true,
+      });
+      expect(pathApi.isAbsolute(sibling)).toBe(true);
+      expect(pathApi.dirname(sibling)).toBe(
+        pathApi.join(repositoryRoot, '.claude-worktrees'),
+      );
+      expect(sibling).not.toContain(
+        pathApi.join('parent', '.claude-worktrees'),
+      );
+      expect(result).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'WorktreeCreate',
+          worktreePath: sibling,
+        },
+        continue: true,
+      });
+    },
+  );
+
+  it.each([
+    {
+      platform: 'POSIX',
+      pathApi: path.posix,
+      repositoryRoot: '/home/zoë/projects/研究\nrepository ',
+    },
+    {
+      platform: 'Windows',
+      pathApi: path.win32,
+      repositoryRoot: 'D:\\Users\\Renée\\研究\nrepository ',
+    },
+  ] as const)(
+    'uses the lossless parser result for a $platform sibling path',
+    async ({ pathApi, repositoryRoot }) => {
+      const linked = pathApi.join(
+        repositoryRoot,
+        '.claude-worktrees',
+        'parent',
+      );
+      const parsed = parseWorktreeList(
+        [
+          `worktree ${repositoryRoot}`,
+          'HEAD abcdef1234567890',
+          'branch refs/heads/main',
+          '',
+          `worktree ${linked}`,
+          'HEAD 1234567890abcdef',
+          'branch refs/heads/parent',
+          '',
+          '',
+        ].join('\0'),
+      );
+      const sibling = pathApi.join(
+        repositoryRoot,
+        '.claude-worktrees',
+        worktreeDirectoryName(NAME),
+      );
+      gitInfo.getWorktrees.mockResolvedValue(parsed);
+      gitInfo.addWorktree.mockResolvedValue({
+        success: true,
+        worktreePath: sibling,
+      });
+
+      const result = await invokeCreate(undefined, linked);
+
+      expect(gitInfo.addWorktree).toHaveBeenCalledWith(linked, {
+        branch: NAME,
+        path: sibling,
+        createBranch: true,
+      });
+      expect(result).toEqual({
+        hookSpecificOutput: {
+          hookEventName: 'WorktreeCreate',
+          worktreePath: sibling,
+        },
+        continue: true,
+      });
+    },
+  );
+
+  it('propagates the real git failure instead of returning pathless success', async () => {
     gitInfo.addWorktree.mockResolvedValue({
       success: false,
       error: 'not a git repository',
     });
     const onCreated = jest.fn();
 
-    const result = await invokeCreate(onCreated);
-
-    expect(result).toEqual({ continue: true });
+    await expect(invokeCreate(onCreated)).rejects.toThrow(
+      'not a git repository',
+    );
     expect(onCreated).not.toHaveBeenCalled();
   });
 
-  it('never throws when git worktree creation rejects', async () => {
+  it('propagates exceptions from worktree creation', async () => {
     gitInfo.addWorktree.mockRejectedValue(new Error('git exploded'));
 
-    const result = await invokeCreate();
-
-    expect(result).toEqual({ continue: true });
+    await expect(invokeCreate()).rejects.toThrow('git exploded');
     expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('fails when the main repository worktree cannot be resolved', async () => {
+    gitInfo.getWorktrees.mockResolvedValue([]);
+
+    await expect(invokeCreate()).rejects.toThrow(
+      'Unable to resolve the main repository worktree',
+    );
+    expect(gitInfo.addWorktree).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-absolute main worktree path before invoking git add', async () => {
+    gitInfo.getWorktrees.mockResolvedValue([
+      {
+        path: 'relative/repository',
+        head: 'abcdef12',
+        branch: 'main',
+        isMain: true,
+        isBare: false,
+      },
+    ]);
+
+    await expect(invokeCreate()).rejects.toThrow(
+      'Main repository worktree path must be absolute',
+    );
+    expect(gitInfo.addWorktree).not.toHaveBeenCalled();
+  });
+
+  it('rejects unexpected WorktreeCreate input instead of returning success', async () => {
+    await expect(
+      invokeCreate(undefined, REPO, { hook_event_name: 'WorktreeRemove' }),
+    ).rejects.toThrow('Unexpected hook input for WorktreeCreate');
+    expect(gitInfo.addWorktree).not.toHaveBeenCalled();
   });
 });

--- a/libs/backend/agent-sdk/src/lib/helpers/worktree-hook-handler.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/worktree-hook-handler.ts
@@ -6,8 +6,8 @@
  * the session host so the frontend can refresh its worktree list.
  *
  * Key behaviors:
- * - Hook NEVER throws (would break SDK)
- * - Always returns { continue: true } for non-blocking
+ * - WorktreeCreate returns a concrete path or throws the underlying failure
+ * - Child worktrees are siblings beneath the repository's main worktree
  * - Uses callback pattern (EventBus is deleted from codebase)
  * - Logging for worktree events (info level)
  *
@@ -16,14 +16,18 @@
  * 2. WorktreeHookHandler receives hook input with worktree details
  * 3. Callback is invoked to notify session host of worktree change
  * 4. Session host sends RPC notification to frontend
- * 5. Hook returns { continue: true } to allow SDK to proceed
+ * 5. Hook returns the created path required by the SDK contract
  *
  */
 
 import * as path from 'path';
 import { injectable, inject } from 'tsyringe';
 import type { Logger, GitInfoService } from '@ptah-extension/vscode-core';
-import { TOKENS } from '@ptah-extension/vscode-core';
+import {
+  resolveWorktreePath,
+  worktreeDirectoryName,
+  TOKENS,
+} from '@ptah-extension/vscode-core';
 import type {
   HookCallbackMatcher,
   HookEvent,
@@ -63,6 +67,29 @@ export type WorktreeRemovedCallback = (data: {
   timestamp: number;
 }) => void;
 
+function resolveSiblingWorktreePath(
+  repositoryRoot: string,
+  branch: string,
+): string {
+  const pathApi = path.posix.isAbsolute(repositoryRoot)
+    ? path.posix
+    : path.win32.isAbsolute(repositoryRoot)
+      ? path.win32
+      : null;
+  if (!pathApi) {
+    throw new Error(
+      `Main repository worktree path must be absolute: ${repositoryRoot}`,
+    );
+  }
+
+  const absoluteTarget = pathApi.join(
+    repositoryRoot,
+    '.claude-worktrees',
+    worktreeDirectoryName(branch),
+  );
+  return resolveWorktreePath(repositoryRoot, branch, absoluteTarget);
+}
+
 /**
  * WorktreeHookHandler Service
  *
@@ -97,13 +124,13 @@ export class WorktreeHookHandler {
    * Create hooks configuration for SDK query options
    *
    * Returns a hooks object that can be merged with existing hooks (like subagent
-   * and compaction hooks). The hook callbacks are wrapped with error handling
-   * to ensure the SDK is never blocked by hook failures.
+   * and compaction hooks). WorktreeCreate owns creation, so failures must reject
+   * instead of masquerading as a successful response without a worktree path.
    *
    * Note: The AbortSignal parameter is part of the SDK hook callback signature
    * but is intentionally not used in worktree hooks. WorktreeCreate/Remove events
-   * are informational and complete instantly - there's no long-running
-   * operation to abort. The signal is preserved for SDK API compliance.
+   * are short operations delegated to GitInfoService. The signal is preserved
+   * for SDK API compliance.
    *
    * @param onWorktreeCreated - Callback to invoke when a worktree is created (optional)
    * @param onWorktreeRemoved - Callback to invoke when a worktree is removed (optional)
@@ -146,12 +173,26 @@ export class WorktreeHookHandler {
                       received: input.hook_event_name,
                     },
                   );
-                  return { continue: true };
+                  throw new Error(
+                    `Unexpected hook input for WorktreeCreate: ${input.hook_event_name}`,
+                  );
                 }
 
-                const worktreePath = path.join(
-                  input.cwd,
-                  '.claude-worktrees',
+                const worktrees = await this.gitInfo.getWorktrees(input.cwd);
+                const repositoryRoot = worktrees.find(
+                  (worktree) => worktree.isMain,
+                )?.path;
+                if (!repositoryRoot) {
+                  throw new Error(
+                    `Unable to resolve the main repository worktree from ${input.cwd}`,
+                  );
+                }
+
+                // Resolve beneath the main worktree, but execute from the parent
+                // session cwd so `git worktree add -b` bases the branch on the
+                // parent's current HEAD, including when the parent is linked.
+                const worktreePath = resolveSiblingWorktreePath(
+                  repositoryRoot,
                   input.name,
                 );
                 const result = await this.gitInfo.addWorktree(input.cwd, {
@@ -162,7 +203,7 @@ export class WorktreeHookHandler {
 
                 if (!result.success || !result.worktreePath) {
                   this.logger.warn(
-                    '[WorktreeHookHandler] Failed to create worktree — subagent will run without isolation',
+                    '[WorktreeHookHandler] Failed to create worktree',
                     {
                       sessionId: input.session_id,
                       name: input.name,
@@ -170,7 +211,10 @@ export class WorktreeHookHandler {
                       error: result.error,
                     },
                   );
-                  return { continue: true };
+                  throw new Error(
+                    result.error ??
+                      `Git did not return a worktree path for ${input.name}`,
+                  );
                 }
 
                 this.logger.info('[WorktreeHookHandler] Worktree created', {
@@ -214,12 +258,14 @@ export class WorktreeHookHandler {
                   continue: true,
                 };
               } catch (error) {
+                const failure =
+                  error instanceof Error ? error : new Error(String(error));
                 this.logger.error(
                   '[WorktreeHookHandler] Error in WorktreeCreate hook',
-                  error instanceof Error ? error : new Error(String(error)),
+                  failure,
                 );
+                throw failure;
               }
-              return { continue: true };
             },
           ],
         },

--- a/libs/backend/auth-providers/src/lib/providers/codex/codex-translation-proxy.spec.ts
+++ b/libs/backend/auth-providers/src/lib/providers/codex/codex-translation-proxy.spec.ts
@@ -8,22 +8,62 @@ import type { Logger } from '@ptah-extension/vscode-core';
 import { CodexTranslationProxy } from './codex-translation-proxy';
 import type { ICodexAuthService } from './codex-provider.types';
 
-const response = { status: 'completed', output: [{ type: 'message', content: [
-  { type: 'output_text', text: 'summary' },
-] }], usage: { input_tokens: 10, output_tokens: 2 } };
+const response = {
+  status: 'completed',
+  output: [
+    { type: 'message', content: [{ type: 'output_text', text: 'summary' }] },
+  ],
+  usage: { input_tokens: 10, output_tokens: 2 },
+};
 
-function post(url: string, stream: boolean | undefined) {
-  return new Promise<{ body: string; type: string | undefined }>((resolve, reject) => {
-    const req = http.request(`${url}/v1/messages`, { method: 'POST' }, (res) => {
-      let body = '';
-      res.setEncoding('utf8');
-      res.on('data', (chunk: string) => { body += chunk; });
-      res.on('end', () => resolve({ body, type: res.headers['content-type'] }));
-      res.on('error', reject);
-    });
-    req.on('error', reject);
-    req.end(JSON.stringify({ model: 'gpt-test', messages: [{ role: 'user', content: 'hi' }], max_tokens: 50, stream }));
-  });
+function post(
+  url: string,
+  stream: boolean | undefined,
+  requestBody: Record<string, unknown> = {},
+) {
+  return new Promise<{ body: string; type: string | undefined }>(
+    (resolve, reject) => {
+      const req = http.request(
+        `${url}/v1/messages`,
+        { method: 'POST' },
+        (res) => {
+          let body = '';
+          res.setEncoding('utf8');
+          res.on('data', (chunk: string) => {
+            body += chunk;
+          });
+          res.on('end', () =>
+            resolve({ body, type: res.headers['content-type'] }),
+          );
+          res.on('error', reject);
+        },
+      );
+      req.on('error', reject);
+      req.end(
+        JSON.stringify({
+          model: 'gpt-test',
+          messages: [{ role: 'user', content: 'hi' }],
+          max_tokens: 50,
+          stream,
+          ...requestBody,
+        }),
+      );
+    },
+  );
+}
+
+function createAuth(endpoint: string): ICodexAuthService {
+  return {
+    getApiEndpoint: () => endpoint,
+    getHeaders: async () => ({ 'content-type': 'application/json' }),
+    ensureTokensFresh: async () => false,
+    isAuthenticated: async () => true,
+    listModels: async () => [],
+    clearCache: () => undefined,
+    getTokenStatus: async () => ({ authenticated: true, stale: false }),
+    startWatchingAuthFile: () => undefined,
+    stopWatchingAuthFile: () => undefined,
+  };
 }
 
 describe('Codex upstream transport selection', () => {
@@ -37,49 +77,162 @@ describe('Codex upstream transport selection', () => {
     ['https://api.openai.com/v1', undefined, false],
     ['https://example.com/backend-api/codex', false, false],
     ['https://chatgpt.com/other', false, false],
-  ] as const)('%s caller stream=%s upstream stream=%s', async (endpoint, stream, upstreamStream) => {
-    let body = '';
-    const fakeRequest = new EventEmitter() as EventEmitter & {
-      write: (chunk: string) => void; end: () => void; destroy: () => void;
-    };
-    fakeRequest.write = (chunk) => { body += chunk; };
-    fakeRequest.destroy = () => { fakeRequest.emit('close'); };
-    jest.spyOn(https, 'request').mockImplementation((...args: unknown[]) => {
-      const callback = args[2] as (res: http.IncomingMessage) => void;
-      fakeRequest.end = () => {
-        const upstream = new PassThrough() as PassThrough & { statusCode: number; headers: object };
-        upstream.statusCode = 200;
-        upstream.headers = {};
-        callback(upstream as unknown as http.IncomingMessage);
-        if (upstreamStream) {
-          upstream.end('data: {"type":"response.output_text.delta","delta":"summary"}\n\n' +
-            `data: ${JSON.stringify({ type: 'response.completed', response })}\n\n`);
-        } else upstream.end(JSON.stringify(response));
+  ] as const)(
+    '%s caller stream=%s upstream stream=%s',
+    async (endpoint, stream, upstreamStream) => {
+      let body = '';
+      const fakeRequest = new EventEmitter() as EventEmitter & {
+        write: (chunk: string) => void;
+        end: () => void;
+        destroy: () => void;
       };
-      return fakeRequest as unknown as http.ClientRequest;
-    });
-    const auth: ICodexAuthService = {
-      getApiEndpoint: () => endpoint,
-      getHeaders: async () => ({ 'content-type': 'application/json' }),
-      ensureTokensFresh: async () => false,
-      isAuthenticated: async () => true,
-      listModels: async () => [], clearCache: () => undefined,
-      getTokenStatus: async () => ({ authenticated: true, stale: false }),
-      startWatchingAuthFile: () => undefined, stopWatchingAuthFile: () => undefined,
-    };
-    const proxy = new CodexTranslationProxy(createMockLogger() as unknown as Logger, auth);
-    try {
-      const { url } = await proxy.start();
-      const result = await post(url, stream);
-      expect(JSON.parse(body).stream).toBe(upstreamStream ? true : undefined);
-      if (stream) {
-        expect(result.type).toBe('text/event-stream');
-        expect(result.body).toContain('event: message_stop');
-      } else {
-        expect(result.type).toContain('application/json');
-        expect(JSON.parse(result.body)).toMatchObject({ content: [{ type: 'text', text: 'summary' }],
-          stop_reason: 'end_turn', usage: { input_tokens: 10, output_tokens: 2 } });
+      fakeRequest.write = (chunk) => {
+        body += chunk;
+      };
+      fakeRequest.destroy = () => {
+        fakeRequest.emit('close');
+      };
+      jest.spyOn(https, 'request').mockImplementation((...args: unknown[]) => {
+        const callback = args[2] as (res: http.IncomingMessage) => void;
+        fakeRequest.end = () => {
+          const upstream = new PassThrough() as PassThrough & {
+            statusCode: number;
+            headers: object;
+          };
+          upstream.statusCode = 200;
+          upstream.headers = {};
+          callback(upstream as unknown as http.IncomingMessage);
+          if (upstreamStream) {
+            upstream.end(
+              'data: {"type":"response.output_text.delta","delta":"summary"}\n\n' +
+                `data: ${JSON.stringify({ type: 'response.completed', response })}\n\n`,
+            );
+          } else upstream.end(JSON.stringify(response));
+        };
+        return fakeRequest as unknown as http.ClientRequest;
+      });
+      const auth = createAuth(endpoint);
+      const proxy = new CodexTranslationProxy(
+        createMockLogger() as unknown as Logger,
+        auth,
+      );
+      try {
+        const { url } = await proxy.start();
+        const result = await post(url, stream);
+        expect(JSON.parse(body).stream).toBe(upstreamStream ? true : undefined);
+        if (stream) {
+          expect(result.type).toBe('text/event-stream');
+          expect(result.body).toContain('event: message_stop');
+        } else {
+          expect(result.type).toContain('application/json');
+          expect(JSON.parse(result.body)).toMatchObject({
+            content: [{ type: 'text', text: 'summary' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 10, output_tokens: 2 },
+          });
+        }
+      } finally {
+        await proxy.stop();
       }
-    } finally { await proxy.stop(); }
-  });
+    },
+  );
+
+  it.each([
+    ['omitted', { description: 'inspect', prompt: 'check it' }],
+    [
+      'explicit worktree',
+      { description: 'inspect', prompt: 'check it', isolation: 'worktree' },
+    ],
+  ] as const)(
+    'preserves optional Agent isolation in the final request and %s input in the response',
+    async (_label, agentInput) => {
+      let outboundBody = '';
+      const fakeRequest = new EventEmitter() as EventEmitter & {
+        write: (chunk: string) => void;
+        end: () => void;
+        destroy: () => void;
+      };
+      fakeRequest.write = (chunk) => {
+        outboundBody += chunk;
+      };
+      fakeRequest.destroy = () => {
+        fakeRequest.emit('close');
+      };
+      jest.spyOn(https, 'request').mockImplementation((...args: unknown[]) => {
+        const callback = args[2] as (res: http.IncomingMessage) => void;
+        fakeRequest.end = () => {
+          const upstream = new PassThrough() as PassThrough & {
+            statusCode: number;
+            headers: object;
+          };
+          upstream.statusCode = 200;
+          upstream.headers = {};
+          callback(upstream as unknown as http.IncomingMessage);
+          upstream.end(
+            JSON.stringify({
+              status: 'completed',
+              output: [
+                {
+                  type: 'function_call',
+                  call_id: 'call_agent',
+                  name: 'Agent',
+                  arguments: JSON.stringify(agentInput),
+                },
+              ],
+              usage: { input_tokens: 10, output_tokens: 2 },
+            }),
+          );
+        };
+        return fakeRequest as unknown as http.ClientRequest;
+      });
+
+      const proxy = new CodexTranslationProxy(
+        createMockLogger() as unknown as Logger,
+        createAuth('https://api.openai.com/v1'),
+      );
+      try {
+        const { url } = await proxy.start();
+        const result = await post(url, false, {
+          tools: [
+            {
+              name: 'Agent',
+              description: 'Launch an agent',
+              input_schema: {
+                type: 'object',
+                properties: {
+                  description: { type: 'string' },
+                  prompt: { type: 'string' },
+                  isolation: {
+                    type: 'string',
+                    enum: ['worktree', 'remote'],
+                  },
+                },
+                required: ['description', 'prompt'],
+              },
+            },
+          ],
+        });
+
+        const outbound = JSON.parse(outboundBody);
+        expect(outbound.tools[0]).toMatchObject({
+          name: 'Agent',
+          strict: false,
+          parameters: { required: ['description', 'prompt'] },
+        });
+        expect(outbound.tools[0].parameters.required).not.toContain(
+          'isolation',
+        );
+
+        const inbound = JSON.parse(result.body);
+        expect(inbound.content[0]).toMatchObject({
+          type: 'tool_use',
+          name: 'Agent',
+          input: agentInput,
+        });
+        expect(inbound.content[0].input).toEqual(agentInput);
+      } finally {
+        await proxy.stop();
+      }
+    },
+  );
 });

--- a/libs/backend/auth-providers/src/lib/translation/responses-request-translator.spec.ts
+++ b/libs/backend/auth-providers/src/lib/translation/responses-request-translator.spec.ts
@@ -52,6 +52,7 @@ describe('translateToolsForResponses', () => {
         name: 'lookup',
         description: 'Find things',
         parameters: { type: 'object' },
+        strict: false,
       },
     ]);
   });
@@ -66,6 +67,52 @@ describe('translateToolsForResponses', () => {
     // parameters is an empty object per the spread-guard behaviour (schema
     // is non-null but empty — we still emit parameters: {}).
     expect(out.parameters).toEqual({});
+    expect(out.strict).toBe(false);
+  });
+
+  it('preserves required and optional properties while disabling the Responses strict default', () => {
+    const agentSchema = {
+      type: 'object',
+      properties: {
+        description: { type: 'string' },
+        prompt: { type: 'string' },
+        isolation: { type: 'string', enum: ['worktree', 'remote'] },
+      },
+      required: ['description', 'prompt'],
+    };
+    const lookupSchema = {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        limit: { type: 'number' },
+      },
+      required: ['query'],
+    };
+
+    const translated = translateToolsForResponses([
+      { name: 'Agent', input_schema: agentSchema },
+      { name: 'lookup', input_schema: lookupSchema },
+    ]);
+
+    expect(translated).toEqual([
+      {
+        type: 'function',
+        name: 'Agent',
+        parameters: agentSchema,
+        strict: false,
+      },
+      {
+        type: 'function',
+        name: 'lookup',
+        parameters: lookupSchema,
+        strict: false,
+      },
+    ]);
+    expect(
+      (translated[0].parameters?.['required'] as string[]).includes(
+        'isolation',
+      ),
+    ).toBe(false);
   });
 });
 
@@ -162,6 +209,7 @@ describe('translateAnthropicToResponses (end-to-end round-trip)', () => {
       "parameters": {
         "type": "object",
       },
+      "strict": false,
       "type": "function",
     },
   ],

--- a/libs/backend/auth-providers/src/lib/translation/responses-request-translator.ts
+++ b/libs/backend/auth-providers/src/lib/translation/responses-request-translator.ts
@@ -94,6 +94,12 @@ export interface ResponsesToolDefinition {
   name: string;
   description?: string;
   parameters?: Record<string, unknown>;
+  /**
+   * Anthropic tool schemas express optional properties by omitting them from
+   * `required`. Responses defaults this flag to true, which changes those
+   * semantics, so translated tools must opt out explicitly.
+   */
+  strict: false;
 }
 
 /** OpenAI Responses API request body */
@@ -246,6 +252,7 @@ export function translateToolsForResponses(
     name: tool.name,
     ...(tool.description != null ? { description: tool.description } : {}),
     ...(tool.input_schema != null ? { parameters: tool.input_schema } : {}),
+    strict: false as const,
   }));
 }
 

--- a/libs/backend/vscode-core/src/services/git-info.service.spec.ts
+++ b/libs/backend/vscode-core/src/services/git-info.service.spec.ts
@@ -118,6 +118,33 @@ describe('GitInfoService — new git methods (TASK_2026_111)', () => {
   // ==========================================================================
 
   describe('worktree paths', () => {
+    it('requests NUL-delimited porcelain and preserves the returned path', async () => {
+      const repositoryPath = '/home/zoë/projects/研究\nrepository ';
+      mockSpawn.mockImplementation(() =>
+        makeSpawnResult({
+          stdout: [
+            `worktree ${repositoryPath}`,
+            'HEAD abcdef1234567890',
+            'branch refs/heads/main',
+            '',
+            '',
+          ].join('\0'),
+          exitCode: 0,
+        }),
+      );
+
+      const [worktree] = await service.getWorktrees(WS);
+
+      expect(mockSpawn.mock.calls[0][1]).toEqual([
+        'worktree',
+        'list',
+        '--porcelain',
+        '-z',
+      ]);
+      expect(worktree.path).toBe(repositoryPath);
+      expect(worktree.isMain).toBe(true);
+    });
+
     it('uses the shared nested default for UI/backend creation', async () => {
       mockSpawn.mockImplementation(() =>
         makeSpawnResult({ stdout: '', exitCode: 0 }),
@@ -427,7 +454,7 @@ describe('GitInfoService — new git methods (TASK_2026_111)', () => {
       [['symbolic-ref', '--short', 'HEAD']],
       [['stash', 'list', '--format=x']],
       [['stash', 'show']],
-      [['worktree', 'list', '--porcelain']],
+      [['worktree', 'list', '--porcelain', '-z']],
       [['tag', '--sort=-creatordate', '--format=x']],
       [['remote', '-v']],
       [['remote']],

--- a/libs/backend/vscode-core/src/services/git-info.service.ts
+++ b/libs/backend/vscode-core/src/services/git-info.service.ts
@@ -408,7 +408,7 @@ export class GitInfoService {
   async getWorktrees(workspacePath: string): Promise<GitWorktreeInfo[]> {
     try {
       const { stdout, exitCode } = await this.execGit(
-        ['worktree', 'list', '--porcelain'],
+        ['worktree', 'list', '--porcelain', '-z'],
         workspacePath,
         { timeoutMs: WORKTREE_GIT_TIMEOUT_MS },
       );

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.spec.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.spec.ts
@@ -175,7 +175,8 @@ describe('buildGitNamespace — worktreeList', () => {
         'HEAD abc123',
         'branch refs/heads/main',
         '',
-      ].join('\n'),
+        '',
+      ].join('\0'),
       exitCode: 0,
     });
 
@@ -183,6 +184,12 @@ describe('buildGitNamespace — worktreeList', () => {
     expect(out.error).toBeUndefined();
     expect(out.worktrees.length).toBeGreaterThanOrEqual(1);
     expect(out.worktrees[0].path).toBe('D:/ws');
+    expect(crossSpawnMock.mock.calls[0][1]).toEqual([
+      'worktree',
+      'list',
+      '--porcelain',
+      '-z',
+    ]);
   });
 
   it('returns error + [] when git exits non-zero', async () => {

--- a/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.ts
+++ b/libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.ts
@@ -78,6 +78,7 @@ export function buildGitNamespace(
           'worktree',
           'list',
           '--porcelain',
+          '-z',
         ]);
 
         if (exitCode !== 0) {

--- a/libs/shared/src/lib/utils/git.utils.spec.ts
+++ b/libs/shared/src/lib/utils/git.utils.spec.ts
@@ -63,6 +63,51 @@ describe('parseWorktreeList', () => {
     expect(result[1].head).toBe('12345678');
   });
 
+  it('preserves a non-ASCII POSIX path containing a newline in NUL mode', () => {
+    const mainPath = '/home/zoë/projects/研究\nrepository ';
+    const output = [
+      `worktree ${mainPath}`,
+      'HEAD abcdef1234567890',
+      'branch refs/heads/main',
+      '',
+      '',
+    ].join('\0');
+
+    const [worktree] = parseWorktreeList(output);
+
+    expect(worktree.path).toBe(mainPath);
+    expect(worktree.isMain).toBe(true);
+  });
+
+  it('preserves a non-ASCII Windows path with backslashes and newline in NUL mode', () => {
+    const mainPath = 'D:\\Users\\Renée\\研究\nrepository ';
+    const output = [
+      `worktree ${mainPath}`,
+      'HEAD abcdef1234567890',
+      'branch refs/heads/main',
+      '',
+      '',
+    ].join('\0');
+
+    const [worktree] = parseWorktreeList(output);
+
+    expect(worktree.path).toBe(mainPath);
+    expect(worktree.isMain).toBe(true);
+  });
+
+  it('does not trim path characters in legacy line mode', () => {
+    const mainPath = '/home/user/repository ';
+    const output = [
+      `worktree ${mainPath}`,
+      'HEAD abcdef1234567890',
+      'branch refs/heads/main',
+    ].join('\n');
+
+    const [worktree] = parseWorktreeList(output);
+
+    expect(worktree.path).toBe(mainPath);
+  });
+
   it('marks detached HEAD with special branch label', () => {
     const output = [
       'worktree /home/user/project',

--- a/libs/shared/src/lib/utils/git.utils.ts
+++ b/libs/shared/src/lib/utils/git.utils.ts
@@ -10,6 +10,9 @@ import type { GitWorktreeInfo } from '../types/rpc/rpc-git.types';
 /**
  * Parse `git worktree list --porcelain` output into GitWorktreeInfo[].
  *
+ * NUL-delimited (`-z`) output is preferred because Git emits paths verbatim in
+ * that mode. The line-delimited form remains supported for existing callers.
+ *
  * Format (blocks separated by blank lines):
  *   worktree <path>
  *   HEAD <sha>
@@ -22,12 +25,16 @@ import type { GitWorktreeInfo } from '../types/rpc/rpc-git.types';
  */
 export function parseWorktreeList(output: string): GitWorktreeInfo[] {
   const worktrees: GitWorktreeInfo[] = [];
-  const blocks = output.replace(/\r\n/g, '\n').trim().split('\n\n');
+  const nulDelimited = output.includes('\0');
+  const normalizedOutput = nulDelimited
+    ? output
+    : output.replace(/\r\n/g, '\n');
+  const blocks = normalizedOutput.split(nulDelimited ? '\0\0' : '\n\n');
 
   for (const block of blocks) {
-    if (!block.trim()) continue;
+    if (!block) continue;
 
-    const lines = block.trim().split('\n');
+    const lines = block.split(nulDelimited ? '\0' : '\n');
     let wtPath = '';
     let head = '';
     let branch = '';
@@ -43,9 +50,9 @@ export function parseWorktreeList(output: string): GitWorktreeInfo[] {
         branch = ref.startsWith('refs/heads/')
           ? ref.substring('refs/heads/'.length)
           : ref;
-      } else if (line.trim() === 'bare') {
+      } else if (line === 'bare') {
         isBare = true;
-      } else if (line.trim() === 'detached') {
+      } else if (line === 'detached') {
         branch = 'HEAD (detached)';
       }
     }


### PR DESCRIPTION
Preserve optional SDK arguments through Responses translation, avoid nested worktree paths, and propagate creation failures with lossless Git paths.