### PR TITLE
fix: preserve Codex usage and current-context stats

### DIFF
--- a/.ptah/specs/TASK_2026_408/task.md
+++ b/.ptah/specs/TASK_2026_408/task.md
@@ -1,5 +1,5 @@
 ---
-status: backlog
+status: in_progress
 type: BUGFIX
 title: Fix Codex proxy cache accounting and verify context and skill invocation
 description: >-

--- a/.ptah/specs/TASK_2026_410/agent-output-root.md
+++ b/.ptah/specs/TASK_2026_410/agent-output-root.md
@@ -1,0 +1,20 @@
+# Agent output: root
+
+Implemented the focused TASK_2026_410 worktree bugfix directly on `main`.
+
+Child Agent worktrees now resolve as siblings beneath the repository's main `.claude-worktrees` directory while preserving native Windows or POSIX absolute paths. Branch creation still runs from the parent session cwd and therefore uses the parent `HEAD`. Hook failures reject with their real error instead of returning successful pathless output.
+
+The Git worktree-list boundary is now lossless: all production callers request NUL-delimited porcelain, and the shared parser preserves non-ASCII, backslash, newline, and trailing path characters without trimming or hand-unescaping. Parser-to-hook coverage proves the exact parsed root drives sibling placement.
+
+Latest verification: 167 focused tests passed across 4 suites on Windows, including simulated Windows, Ubuntu/Linux, and macOS path fixtures. Changed-file ESLint reported 0 errors and `git diff --check` passed. See `worktree-fix-report.md` for exact commands and remaining risks.
+
+## Codex auth proxy schema follow-up
+
+Fixed the independent Responses API schema bug at the translation owner. Ptah
+now sends `strict: false` for Anthropic-derived Responses function tools, so
+optional Agent `isolation` remains optional while explicit `worktree` and
+declared required arguments remain unchanged.
+
+Verification: 23 focused tests passed across 2 suites; the accidentally broader
+auth-providers run also passed 669/669 tests. See `codex-schema-fix-report.md`
+for the established cause, official sources, exact commands, and uncertainties.

--- a/.ptah/specs/TASK_2026_410/codex-schema-fix-report.md
+++ b/.ptah/specs/TASK_2026_410/codex-schema-fix-report.md
@@ -1,0 +1,119 @@
+# Codex auth proxy schema fix report
+
+Date: 2026-09-10  
+Scope: Codex Responses request translation and associated tests only.
+
+## Outcome
+
+Fixed the Codex auth proxy so Anthropic tool schemas retain their original
+optional-property semantics at the final OpenAI Responses API boundary.
+Translated function tools now send `strict: false` explicitly. The translator
+does not add to, remove from, or otherwise rewrite each schema's `required`
+array, and response translation does not add omitted tool arguments or remove
+explicit ones.
+
+No worktree-hook-handler file, existing worktree, git configuration, build,
+package, dependency, commit, or push was touched.
+
+## Established cause
+
+The full local request path is:
+
+1. Claude Agent SDK sends an Anthropic Messages request containing tool
+   `input_schema` values to Ptah's local translation proxy.
+2. `TranslationProxyBase` selects the Responses path for Codex and calls
+   `translateAnthropicToResponses`.
+3. `translateToolsForResponses` copies `input_schema` to the outgoing
+   Responses function tool's `parameters` unchanged.
+4. `TranslationProxyBase.forwardToResponsesApi` serializes that translated
+   object directly into the upstream HTTP request body.
+
+Before this fix, the outgoing function tool omitted `strict`. OpenAI's official
+Responses API reference documents `strict` as defaulting to `true`. That differs
+from the Chat Completions function-tool default (`false`). Strict Structured
+Outputs requires every object property to be listed in `required`; optionality
+must otherwise be modeled with nullable values. The Claude Agent SDK schema
+uses ordinary JSON Schema optionality: `isolation` exists in `properties` but is
+absent from `required`. Allowing Responses to default to strict therefore
+changed the meaning of the schema at the provider boundary and exposed the
+optional enum as required.
+
+This establishes the previously hypothetical strict-default cause without
+requiring a paid request. The owner is the Responses request translator: it is
+the layer that converts an Anthropic tool definition into a Responses function
+tool and previously failed to state the validation mode needed to preserve the
+source contract.
+
+## Sources
+
+- OpenAI Responses API reference, function tool `strict`: default `true`:
+  <https://platform.openai.com/docs/api-reference/responses-streaming?lang=python>
+- OpenAI Chat Completions API reference, function tool `strict`: optional and
+  defaults to `false`:
+  <https://platform.openai.com/docs/api-reference/chat/message-list?lang=ruby>
+- Installed Claude Agent SDK declaration inspected in the prior investigation:
+  `node_modules/@anthropic-ai/claude-agent-sdk/sdk-tools.d.ts` declares
+  `isolation?: "worktree"`.
+- Prior repository trace:
+  `.claude-worktrees/task-410-background-agent-execution/.ptah/specs/TASK_2026_410/worktree-spawn-investigation.md`.
+
+## Files changed
+
+- `libs/backend/auth-providers/src/lib/translation/responses-request-translator.ts`
+  - Added `strict: false` to the Responses function-tool contract and emitted
+    value.
+- `libs/backend/auth-providers/src/lib/translation/responses-request-translator.spec.ts`
+  - Updated the existing request shape expectations.
+  - Added a two-tool regression proving `Agent.isolation` and an unrelated
+    tool's `limit` stay optional while declared required arguments stay
+    required.
+- `libs/backend/auth-providers/src/lib/providers/codex/codex-translation-proxy.spec.ts`
+  - Added mocked HTTPS boundary tests that inspect the final serialized Codex
+    request.
+  - Round-tripped an Agent call with omitted isolation and one with explicit
+    `isolation: "worktree"`.
+
+## Regression guarantees
+
+The tests now assert all requested behavior:
+
+- Final mocked outbound Codex request contains `strict: false`.
+- Final outbound Agent schema keeps `required: ["description", "prompt"]` and
+  does not add `isolation`.
+- Inbound Agent arguments with omitted isolation remain omitted.
+- Explicit `isolation: "worktree"` remains explicit and unchanged.
+- Required arguments remain required.
+- A second tool's unrelated optional `limit` property remains optional.
+- The translator does not silently strip any explicit isolation value.
+
+## Test evidence
+
+Focused direct runs:
+
+1. `npx jest --config libs/backend/auth-providers/jest.config.ts --runTestsByPath libs/backend/auth-providers/src/lib/translation/responses-request-translator.spec.ts --runInBand`
+   - 1 suite passed; 14 tests passed; 1 snapshot passed.
+2. `npx jest --config libs/backend/auth-providers/jest.config.ts --runTestsByPath libs/backend/auth-providers/src/lib/providers/codex/codex-translation-proxy.spec.ts --runInBand`
+   - 1 suite passed; 9 tests passed; 0 snapshots.
+
+Total intended focused verification: **2 suites, 23 tests, all passed**.
+
+An initial Nx invocation with two paths forwarded only the Codex spec: 1 suite,
+9 tests passed. A follow-up Nx invocation intended for one path discarded the
+path filter and ran the entire `@ptah-extension/auth-providers` library: 37
+suites, 669 tests, and 2 snapshots passed. Direct Jest invocations above were
+then used to obtain unambiguous focused results. All runs emitted the existing
+non-fatal warning about loading the TypeScript Jest config as an ES module.
+
+`git diff --check` passed. Per task constraints, no build, packaging, install,
+full-workspace test, Nx reset, or live paid provider request was run.
+
+## Uncertainties and residual scope
+
+- No live Codex request was sent. The regression proves the exact serialized
+  body at Ptah's HTTPS boundary and relies on the provider's documented strict
+  default.
+- The separate WorktreeCreate hook behavior is outside this authorized change
+  and was not modified.
+- Version skew between the pinned Agent SDK and a separately detected Claude
+  Code executable remains outside this focused fix. It does not alter the
+  established strict-default defect in Ptah's outgoing Responses request.

--- a/.ptah/specs/TASK_2026_410/task.md
+++ b/.ptah/specs/TASK_2026_410/task.md
@@ -1,0 +1,25 @@
+---
+id: TASK_2026_410
+status: in_progress
+type: BUGFIX
+title: Make background agents open live execution views
+depends_on: []
+created: '2026-09-09T23:22:11.466Z'
+updated: '2026-09-09T23:22:24.154Z'
+description: >-
+  Repair background-agent tray clicks and identity reconciliation; expose text
+  and tools live across parent-turn completion with bounded retention and
+  historical backfill.
+executor: software-architect
+estimate: L
+labels:
+  - ux
+relates_to:
+  - TASK_2026_376
+---
+
+<!-- Ptah carrier: machine-owned metadata. Ptah rewrites the frontmatter above. Do NOT write prose here — prose belongs in ./context.md. -->
+
+Repair background-agent tray clicks and identity reconciliation; expose text and tools live across parent-turn completion with bounded retention and historical backfill.
+
+Full context, plan and discussion live in [./context.md](./context.md).

--- a/.ptah/specs/TASK_2026_410/worktree-fix-report.md
+++ b/.ptah/specs/TASK_2026_410/worktree-fix-report.md
@@ -1,0 +1,97 @@
+# Worktree creation fix report
+
+Date: 2026-09-10
+
+## Outcome
+
+Fixed background Agent worktree creation from linked worktrees.
+
+`WorktreeHookHandler` now asks `GitInfoService.getWorktrees()` for the repository's main worktree and resolves the child target beneath that root. It selects `path.win32` for drive/UNC roots and `path.posix` for `/home/...` and `/Users/...` roots, so returned paths retain the absolute syntax supplied by Git on Windows, Ubuntu/Linux, and macOS. The `git worktree add -b` operation still runs with the parent session's `cwd`, preserving the existing rule that the child branch starts from the parent's current `HEAD`.
+
+The hook now rejects invalid input, Git failures, missing worktree paths, and exceptions. It no longer returns `{ continue: true }` without `hookSpecificOutput.worktreePath`. Successful creation still returns the required `WorktreeCreate` output and still invokes the existing UI notification callback; no frontend/background-mode behavior changed.
+
+The target path uses the established `worktreeDirectoryName()` and `resolveWorktreePath()` helpers. This keeps the generated directory name bounded and contained under `<main-worktree>/.claude-worktrees`. A non-absolute main-worktree path is rejected before `git worktree add`. Existing relative custom-path escape rejection and explicit absolute custom-path behavior were not changed.
+
+The portability review found that ordinary `git worktree list --porcelain` may C-quote non-ASCII paths and cannot represent embedded newlines losslessly. All three production parser callers now request `--porcelain -z`. `parseWorktreeList()` detects and parses NUL-delimited fields without trimming or unescaping path text, while retaining its existing line-mode API for compatibility. The `GitInfoService` result used by the hook therefore carries the exact absolute path Git emitted.
+
+## Modified files
+
+- `libs/backend/agent-sdk/src/lib/helpers/worktree-hook-handler.ts`
+  - Resolve the primary repository worktree through `GitInfoService`.
+  - Create sibling child worktrees under the primary root.
+  - Preserve Windows and POSIX absolute-path syntax independently of the test host.
+  - Preserve the linked parent cwd for branch-base semantics.
+  - Propagate real hook/Git failures.
+- `libs/backend/agent-sdk/src/lib/helpers/worktree-hook-handler.spec.ts`
+  - Cover primary-root success output.
+  - Cover linked/nested Windows, Ubuntu/Linux, and macOS paths and parent-cwd preservation.
+  - Cover returned absolute path semantics.
+  - Cover Git failure, thrown exception, unresolved/non-absolute main worktree, and unexpected input.
+  - Cover real parser output flowing into sibling resolution for non-ASCII, newline-containing POSIX and Windows paths.
+- `libs/shared/src/lib/utils/git.utils.ts`
+  - Parse preferred NUL-delimited porcelain output losslessly.
+  - Keep legacy line-delimited input compatible without trimming path characters.
+- `libs/shared/src/lib/utils/git.utils.spec.ts`
+  - Cover NUL-delimited non-ASCII and embedded-newline POSIX and Windows paths.
+  - Cover trailing path-character preservation in legacy line mode.
+- `libs/backend/vscode-core/src/services/git-info.service.ts`
+  - Request `git worktree list --porcelain -z` for the hook's Git service boundary.
+- `libs/backend/vscode-core/src/services/git-info.service.spec.ts`
+  - Pin the `-z` argv and exact lossless path result.
+- `libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.ts`
+- `libs/backend/vscode-lm-tools/src/lib/code-execution/namespace-builders/git-namespace.builder.spec.ts`
+  - Move the MCP worktree-list caller and fixture to NUL-delimited porcelain.
+- `apps/ptah-extension-vscode/src/rpc-host-profile.ts`
+  - Move the VS Code worktree lookup caller to NUL-delimited porcelain.
+- `.ptah/specs/TASK_2026_410/worktree-fix-report.md`
+- `.ptah/specs/TASK_2026_410/agent-output-root.md`
+
+## Latest focused verification
+
+- `npx nx test @ptah-extension/shared --skip-nx-cache --runInBand --testPathPatterns=git.utils.spec.ts`
+  - PASS: 1 suite, 15 tests.
+- `npx nx test @ptah-extension/vscode-core --skip-nx-cache --runInBand --testPathPatterns=git-info.service.spec.ts`
+  - PASS: 1 suite, 122 tests.
+- `npx nx test @ptah-extension/vscode-lm-tools --skip-nx-cache --runInBand --testPathPatterns=git-namespace.builder.spec.ts`
+  - PASS: 1 suite, 19 tests.
+- `npx nx test @ptah-extension/agent-sdk --skip-nx-cache --runInBand --testPathPatterns=worktree-hook-handler.spec.ts`
+  - PASS: 1 suite, 11 tests.
+- Changed-file ESLint over the nine source/spec files listed above
+  - PASS: 0 errors. Two pre-existing warnings remain in `git-info.service.ts`: `max-lines` and a non-null assertion outside this change.
+- `git diff --check`
+  - PASS. Git printed line-ending notices for unrelated proxy-translator files and `git.utils.ts`; no whitespace error was reported.
+
+Total latest focused coverage: 4 suites, 167 tests passed.
+
+### Platform-test scope
+
+- The commands above ran on the actual Windows host.
+- The hook suite executes three host-portable, simulated Git path fixtures using the matching Node path implementation: `D:\projects\ptah-extension` with `path.win32`, `/home/dev/projects/ptah-extension` with `path.posix`, and `/Users/dev/projects/ptah-extension` with `path.posix`.
+- Parser and parser-to-hook tests additionally use raw NUL-delimited non-ASCII paths containing embedded newlines for POSIX and Windows.
+- The shared parser suite independently retains coverage for legacy POSIX line output and Windows CRLF/backslash output.
+- No native Ubuntu/Linux or macOS runner was available, so those two operating systems were not executed directly; their path contracts are simulated on Windows.
+
+Additional broad checks:
+
+- Full `@ptah-extension/agent-sdk` test target did not complete successfully because an unrelated internal-query test hit `InternalQueryQueueTimeoutError: Internal query waited longer than 60000ms for a concurrency slot.` The focused worktree suite passed before and after this run.
+- Project-wide `@ptah-extension/agent-sdk` lint remains blocked by the pre-existing `no-unexpected-multiline` error in `session-query-executor.service.spec.ts:433`, plus existing warnings. Neither file is part of this fix.
+
+## Evidence and preserved behavior
+
+- Application log line 3925 shows the failing hook ran from `D:\projects\ptah-extension\.claude-worktrees\task-410-background-agent-execution` and Git failed checkout with `Filename too long` before the old hook claimed the subagent could continue without isolation.
+- Windows, Ubuntu/Linux, and macOS linked-worktree regressions assert the new target is directly under the main repository's `.claude-worktrees`, not under the parent's nested `.claude-worktrees` directory.
+- The same three regressions assert `GitInfoService.addWorktree()` receives the linked parent as its `workspacePath`, preserving the current parent `HEAD` as the implicit branch start point.
+- Every platform fixture asserts the returned `hookSpecificOutput.worktreePath` is absolute under its native path implementation.
+- Parser-to-hook coverage proves Git's raw NUL-delimited path survives parsing unchanged and becomes the sibling target root.
+- All three production `parseWorktreeList()` callers were inspected and now request `--porcelain -z`: `GitInfoService`, the MCP Git namespace, and the VS Code host worktree resolver.
+- Existing callback behavior was retained, so the host continues to refresh the worktree UI only after successful creation.
+- Concurrent proxy-translator changes in `libs/backend/auth-providers` were preserved and not edited.
+
+## Remaining risks
+
+- No live Agent spawn was performed, in accordance with the instruction not to spawn helpers. Validation is unit-level plus typecheck/lint.
+- Ubuntu/Linux and macOS behavior is covered with simulated native path strings and `path.posix`, not real OS executions.
+- Legacy non-`-z` callers still receive the compatible line parser, which deliberately does not attempt to decode Git C-quoted strings. Every production caller currently uses `-z`; an external future line-mode caller must opt into `-z` for lossless unusual paths.
+- Historical failed branches and partially created nested worktree directories were not removed.
+- If `git worktree list --porcelain` cannot identify a main worktree, the hook now fails explicitly with the cwd in its error. `GitInfoService.getWorktrees()` currently normalizes command failure to an empty list, so that particular resolution error cannot include raw Git stderr.
+- No production build, install, app stop, commit, or push was performed. The local production build remains for Main after review.

--- a/.ptah/specs/TASK_2026_410/worktree-fix-review.md
+++ b/.ptah/specs/TASK_2026_410/worktree-fix-review.md
@@ -1,0 +1,38 @@
+# Worktree hook patch review
+
+Date: 2026-09-10
+
+Verdict: **changes requested**. One portability defect is confirmed. The core sibling-placement logic, parent-`HEAD` base, and explicit failure behavior are otherwise consistent with the current Git and SDK contracts.
+
+## Confirmed defect
+
+### P1 — Git-quoted main paths are rejected instead of decoded
+
+- Evidence: `libs/backend/agent-sdk/src/lib/helpers/worktree-hook-handler.ts:181-190` now obtains the destination root from `GitInfoService.getWorktrees()` and passes its parsed `path` to `resolveSiblingWorktreePath()`. `libs/shared/src/lib/utils/git.utils.ts:25-38` parses non-`-z` `git worktree list --porcelain` output by copying the text after `worktree ` verbatim; it does not unquote Git's C-style path representation. `libs/backend/vscode-core/src/services/git-info.service.ts:410-420` invokes `git worktree list --porcelain` without `-z`.
+- Scenario: with default `core.quotePath=true`, a repository whose absolute path contains non-ASCII bytes or other characters Git quotes can be emitted as a quoted/escaped value such as `"D:/Users/.../\NNN.../repo"`. The parser retains the quotes and escapes. Neither `path.posix.isAbsolute()` nor `path.win32.isAbsolute()` recognizes that string, so `worktree-hook-handler.ts:72-78` throws `Main repository worktree path must be absolute` and every SDK worktree creation fails. Newline-containing paths are also not safely representable without `-z`.
+- Why the tests miss it: `worktree-hook-handler.spec.ts:126-141` bypasses the real parser with already-decoded mock objects. `git.utils.spec.ts:101-117` covers only an ASCII Windows path and CRLF normalization, not quoted or non-ASCII paths. The three simulated OS cases therefore do not exercise the newly introduced parser-to-path integration.
+- Required direction: make the `GitInfoService` boundary return lossless paths, preferably using `git worktree list --porcelain -z` with a NUL-aware parser, and add an integration-level regression that feeds the real parser output into the handler path decision. Hand-decoding only this call is less robust because Git quoting rules and embedded newlines must both be handled.
+
+## Verified behavior
+
+- `git worktree list --porcelain` run from the existing linked TASK_2026_410 worktree returned the primary worktree first. This matches the parser's `isMain: worktrees.length === 0` assumption for the normal non-bare repository case.
+- `resolveSiblingWorktreePath()` recognizes current Windows Git output (`D:/...`) through `path.win32.isAbsolute`, uses `worktreeDirectoryName()` for a single bounded segment, and constructs the child beneath the primary root's `.claude-worktrees` directory.
+- Passing `input.cwd` to `GitInfoService.addWorktree()` preserves the linked parent's implicit `HEAD` as the start point for `git worktree add -b`; only the destination path is rooted at the primary worktree.
+- `GitInfoService.addWorktree()` treats the constructed absolute path as an explicit absolute target. Consequently, `resolveWorktreePath()` does not perform its relative-path containment branch. This is not a traversal defect here because the only appended segment comes from `worktreeDirectoryName()`, but the helper call itself is not an additional containment check.
+- Rejecting the hook promise is an explicit SDK failure: the installed SDK awaits the callback and serializes rejection as an error control response. The patch no longer reports pathless success when Git fails or omits `worktreePath`.
+
+## Test evidence and gaps
+
+Fresh focused runs with `--skip-nx-cache` where needed passed:
+
+- `@ptah-extension/agent-sdk`: 1 suite, 9 tests.
+- `@ptah-extension/vscode-core`: 1 suite, 7 tests.
+- `@ptah-extension/shared`: 1 suite, 12 tests.
+- Total: 3 suites, 28 tests.
+- `git diff --check` for the two reviewed files passed.
+
+The tests substantiate callback success, sibling target calculation for supplied Windows/POSIX strings, forwarding the linked parent cwd, and rejection on the modeled failure paths. They do **not** substantiate an end-to-end `GitInfoService.getWorktrees()` parse into the handler, a real `git worktree add -b` parent-`HEAD` result, or SDK/CLI presentation of a rejected create hook.
+
+Native platform coverage remains missing: execution occurred on Windows. Linux and macOS cases use `path.posix` fixtures on Windows; no native Linux or macOS Git/filesystem behavior was exercised.
+
+No source files, proxy-schema work, builds, commits, worktrees, or existing worktree artifacts were modified.

--- a/.ptah/specs/TASK_2026_411/context.md
+++ b/.ptah/specs/TASK_2026_411/context.md
@@ -1,0 +1,42 @@
+# TASK_2026_411 — Large-profile performance and Codex usage
+
+## User request and workflow
+
+User requested `/orchestrate a fix for this in a new worktree please` following the completed read-only diagnosis of installed Electron startup/profile freezes, slow compaction, and dashboard session:stats-batch timeout under Codex subscription auth.
+
+BUGFIX, full validation depth. Prior diagnosis substitutes for repeated broad research. Sequence: software-architect -> user architecture review -> team-leader batches -> specialist developers -> tests/reviews. No implementation before architecture approval. CLI delegation: disabled by explicit user choice (specialist subagents only). No commits/push/install/restart authorized.
+
+## Worktree and ownership
+
+- Source/base: codex/fix-local-production-build, 01155ae3c8b0dfcd58a6ea31292da084be4d262b.
+- Created branch: fix/task-411-profile-performance.
+- Implementation worktree: D:/projects/ptah-extension/.claude/worktrees/task-411-profile-performance.
+- Canonical task artifacts: D:/projects/ptah-extension/.ptah/specs/TASK_2026_411 (host task board allocated atomically).
+- TASK_2026_410 is unrelated concurrent background-agent execution work; do not change it.
+- Use absolute worktree paths for all source reads/writes and commands. Parent session worktree-entry tool rejected schema arguments; do not assume parent cwd switched.
+
+## Verified diagnosis
+
+Installed ASAR identity v0.1.70 local-production gitSha 1ea605915cc481d788c8f63263fff09c6292f6e9. Hash equivalence unverified. Logs: C:/Users/abdal/AppData/Roaming/Ptah/logs/Ptah Electron-2026-09-10.log (events September 9 UTC).
+
+### Startup
+
+Active workspace-state.json at C:/Users/abdal/AppData/Roaming/Ptah/workspace-storage/RDpccHJvamVjdHNccHRhaC1leHRlbnNpb24/workspace-state.json is 255,969,538 bytes. External read-only measurements: read 722ms, parse 779ms, stringify 999ms before write. 174 per-agent output keys; 43 historical fat references retain 214,837 inline events. ElectronStateStorage synchronously loads and serializes whole state on each update: libs/backend/platform-electron/src/implementations/electron-state-storage.ts:18-20,28-38,55-73. Sequential session imports amplify writes: libs/backend/agent-sdk/src/lib/session-importer.service.ts:638-675; session-metadata-store.ts:295-324,458-462,1020-1059. Existing lean migration only cleans written records and separate output keys still share physical JSON. Main-loop stalls 2-5.9s observed, high-confidence bottleneck but individual spikes not stack-sampled. One-time migration42 backup 13.179s off-process is readiness delay, not continuous UI block. Integrity/backup fixes are present.
+
+### Dashboard
+
+Actual stats-batch 48,928.8ms (log:2889), client default 30s; unrelated RPC delays too. Dashboard default7d cap200 sessions, one uncached-ID batch: libs/frontend/dashboard/src/lib/services/session-analytics-state.service.ts:225-276. Default RPC timeout libs/frontend/core/src/lib/services/claude-rpc.service.ts:136,155-168. Backend chunks5 but full history per ID: libs/backend/rpc-handlers/src/lib/handlers/session-rpc.handlers.ts:826-838,924-931. History reader replays UI events and loads subagents despite stats caller discarding events: libs/backend/agent-sdk/src/lib/session-history-reader.service.ts:166-196. Nested agent counts19-37 observed. Legacy repeated scan defect jsonl-reader.service.ts:684-755 is latent; zero legacy files in this run, not incident cause. Need stats-only bounded reader/cache with valid invalidation and progressive UI, not timeout extension alone.
+
+### Codex usage
+
+Streaming responses translator emits start counters zero, stores completed input/output, then emits only output. libs/backend/auth-providers/src/lib/translation/responses-stream-translator.ts:145-159,449-456,492-499. Cache detail absent. Nonstream collector:191-196 preserves input minus cached, output, cache_read_input_tokens. Test actual SDK SSE consumer parity, not just translator JSON shape.
+
+Subscription account allowance is DIFFERENT from per-response token accounting and local session analytics. Current translation-proxy-base.ts:254-285 routes health/models/messages only. Slash usage is generic SDK query; provider-quota.store.ts holds reactive429 cooldown, not consumed allowance. Verify authoritative Codex subscription account usage contract and add separate port/RPC/UI if supported; no guessed endpoint or credential logging. Current dollar numbers are rate-card estimates, not actual subscription invoices. Ancillary issues to assess scope: current auth used in historical costing; parent stats only after compact boundary vs all subagents; date filter lastActive not message time; UI cache stale by ID and range switch race.
+
+### Compaction
+
+Pre/Post first23:08:58.064->23:12:34.101 UTC216.037s6882output tokens; second23:14:27.811->23:18:00.989 213.178s6839tokens. Watchdog overdue at180s continues correctly; no first interval lag, proxy forward+84ms, history reload after Post34ms resume path. Latency inside SDK/upstream summarization, not UI reload or 180s abort. No correlated per-request first-byte/terminal/EOF so provider vs retries/buffering not proven. Other concurrent requests must not be attributed as retries. Translator responses-request-translator.ts:100-156 omits reasoning effort and output limits; do not blindly send max_output_tokens to subscription route (may reject). Proxy forces SSE; nonstream collector waits terminal plus EOF. Add metadata-only correlation/timing and capability-verified controls; preserve successful watchdog behavior and summary quality. Do not promise arbitrary latency improvement or change model silently. Previous compaction task is TASK_2026_400 (renumbered from391).
+
+## Safety and acceptance direction
+
+No live profile modifications or history deletion. Implement crash-safe/idempotent migration with retained source until durable verification; all performance tests on generated fixtures/temp profiles. Preserve hexagonal host contracts and all three surfaces. No merely moving expensive sync reads into another main-thread service. Read code and scoped CLAUDE instructions before proposing specifics. Test migration crash/retry and old outputs readability; large-profile responsiveness and write amplification; stats correctness/cache/workspace boundaries; streamed usage SDK consumption; supported/unsupported Codex account usage; no watchdog regression; honest instrumentation. Tests/builds must run from worktree; never nx reset other active worktrees. No commits unless user explicitly authorizes.

--- a/.ptah/specs/TASK_2026_411/task.md
+++ b/.ptah/specs/TASK_2026_411/task.md
@@ -1,0 +1,26 @@
+---
+id: TASK_2026_411
+status: in_progress
+type: BUGFIX
+title: Fix large-profile startup stalls and Codex usage analytics
+depends_on: []
+created: '2026-09-09T23:36:57.572Z'
+updated: '2026-09-09T23:38:13.330Z'
+description: >-
+  Preserve history while removing whole-profile startup serialization stalls,
+  optimize session analytics, repair Codex usage reporting, and diagnose and
+  reduce supported compaction overhead.
+executor: software-architect
+estimate: XL
+labels:
+  - performance
+relates_to:
+  - TASK_2026_380
+  - TASK_2026_400
+---
+
+<!-- Ptah carrier: machine-owned metadata. Ptah rewrites the frontmatter above. Do NOT write prose here — prose belongs in ./context.md. -->
+
+Preserve history while removing whole-profile startup serialization stalls, optimize session analytics, repair Codex usage reporting, and diagnose and reduce supported compaction overhead.
+
+Full context, plan and discussion live in [./context.md](./context.md).

--- a/.ptah/specs/TASK_2026_413/context.md
+++ b/.ptah/specs/TASK_2026_413/context.md
@@ -1,0 +1,54 @@
+# Restore Git controls and complete change-review UX
+
+## User authorization
+
+The user requested a new worktree and Codex CLI execution to fix the reviewed Git UI gaps. Ollama Cloud may be used at the orchestrator's discretion. No commits, pushes, PR creation, destructive Git operations, or dependency upgrades are authorized.
+
+## Execution
+
+- Strategy: FEATURE with regression repairs, Full workflow.
+- Primary executor: installed Codex CLI, default configured model.
+- Optional independent reviewer: Ollama Cloud, provider pc-85830910-3d81-4248-84c1-4fa52752dd19.
+- Worktree: D:/projects/ptah-extension/.claude/worktrees/git-review-controls
+- Branch: fix/git-review-controls
+- Task: TASK_2026_413, child of TASK_2026_386.
+- First phase: requirements and architecture/batch plan only; present for user approval before product code changes.
+- Keep main checkout's existing worktree-hook and auth-translation modifications untouched.
+
+## Verified background
+
+TASK_2026_111, commit 37ee79b8, provided branch search, recent/local/remote groups, create/checkout with dirty-tree confirmation, and branch details (commit, stash, remote). PR #465 deleted these components in 05e725865, replacing the editor with a minimal Git dock. GitBranchesService capability survives.
+
+PR #476 added folder hierarchy, closable diff tabs and a working split toggle. PR #477 added editor launcher adapters, RPCs and OpenInButtonComponent, but explicitly left the component unmounted. Final launcher supports verified executable routes; historical deep-link documentation is stale. Supported IDs are vscode, cursor, antigravity, zed; Kiro is absent.
+
+Current file rows declare openFile but never emit it. Dock fallback sends workspace-relative paths to file:open; implementation must resolve against the displayed workspace, not process CWD. Header push handler discards failure results. Existing tests bypass actual rendering/click paths.
+
+## Requested outcome
+
+1. Restore branch picker and details within Git header, preserving workspace scoping and safe checkout behavior.
+2. Wire detected-editor Open In actions for workspace and file rows, remembered choice, errors and empty detection state. Add Kiro through typed contracts, schema, verified detection and adapters.
+3. Build the supplied screenshot's Git-review experience: branch/base selection, aggregate and per-file additions/deletions, collapsible review rows/diffs, searchable changed-files tree, viewed/unviewed state, clear commit/push controls.
+4. Distinguish working-tree/index mutations from read-only branch comparisons. Never stage/discard historical changes as if they were current working changes.
+5. Test real rendered controls at default dock width and workspace switching; do not widen the UI to conceal hunk-action overlap.
+
+The reference screenshot shows a branch/base header, total +/- counts, file rows with status and per-file +/- counts, a right-side folder tree with Filter files, Mark as viewed action, and Commit or push control. Use existing Angular signals, OnPush and Ptah theme tokens. Do not recreate a full IDE.
+
+## Scope boundaries
+
+Do not silently expand into all of TASK_2026_386: CodeMirror migration, spot editor, transcript turn cards, task/worktree binding, merge and PR creation are not required for these fixes unless an explicit approved plan establishes necessity. Retain existing Monaco diff and hunk safeguards initially. No terminal resurrection.
+
+## Evidence
+
+- .ptah/specs/TASK_2026_385/batch-3.1-report.md
+- .ptah/specs/TASK_2026_385/future-enhancements.md
+- .ptah/specs/TASK_2026_386/context.md
+- .ptah/specs/TASK_2026_386/design-spec.md
+- .ptah/specs/TASK_2026_386/agent-output-root.md
+- libs/frontend/git-ui/src/lib/git-dock/git-dock-header.component.ts
+- libs/frontend/git-ui/src/lib/open-in/open-in-button.component.ts
+- libs/frontend/git-ui/src/lib/source-control/source-control-file.component.ts
+- libs/shared/src/lib/types/rpc/rpc-git.types.ts
+
+## Tracking
+
+Task carrier allocated atomically through Ptah in the primary workspace. The executor should copy this task's carrier and context into the isolated worktree without overwriting any existing files, then place all deliverables there. Do not allocate another task ID. Primary workspace record remains the discovery pointer; product implementation belongs only in the isolated worktree.

--- a/.ptah/specs/TASK_2026_413/task.md
+++ b/.ptah/specs/TASK_2026_413/task.md
@@ -1,0 +1,24 @@
+---
+id: TASK_2026_413
+status: backlog
+type: FEATURE
+title: Restore Git controls and complete change-review UX
+depends_on: []
+created: '2026-09-10T01:41:22.781Z'
+updated: '2026-09-10T01:41:22.781Z'
+description: 'Restore branch controls, mount external-editor launcher with Kiro support, and complete screenshot-driven Git change review.'
+executor: codex
+parent: TASK_2026_386
+estimate: XL
+labels:
+  - git
+  - ux
+relates_to:
+  - TASK_2026_385
+---
+
+<!-- Ptah carrier: machine-owned metadata. Ptah rewrites the frontmatter above. Do NOT write prose here — prose belongs in ./context.md. -->
+
+Restore branch controls, mount external-editor launcher with Kiro support, and complete screenshot-driven Git change review.
+
+Full context, plan and discussion live in [./context.md](./context.md).

--- a/.ptah/specs/TASK_2026_414/batches.md
+++ b/.ptah/specs/TASK_2026_414/batches.md
@@ -1,0 +1,213 @@
+# TASK_2026_414 — Implementation batches
+
+Design and evidence: `implementation-plan.md` in this folder. Read it before you start any batch.
+
+Rules for every batch:
+
+- Worktree: `D:/projects/ptah-extension/.claude-worktrees/compaction-ui-consistency` (branch `fix/compaction-ui-consistency`). Never touch the root checkout.
+- Executor: Ollama Cloud CLI, ptahCliId `pc-85830910-3d81-4248-84c1-4fa52752dd19`. No substitute provider without user consent.
+- No commits, no pushes, no `git reset`, no bare `git stash`. No app restart, no live session-log edits.
+- Batches run in order. One batch at a time. Each batch ends with the review/test gate in section 7.
+- Test with `npx nx run-many`, never `nx test a b c`. Verify the `Running target test for N projects` header shows the N you requested.
+- No `project.json` edits planned. If a batch must edit one, run `npx nx reset` first, and only when no other executor works in the worktree.
+- Leave the `[compaction-diag]` `console.warn` blocks alone unless your change touches those exact lines.
+
+---
+
+## Batch 1 — Backend: single snapshot + compaction readiness + stale flag
+
+Goal. One transcript parse feeds events, messages, and stats. The reader verifies the expected compaction boundary with a bounded retry. `chat:resume` reports a stale parse instead of returning it as if valid.
+
+Files:
+
+1. `libs/shared/src/lib/types/rpc/rpc-chat.types.ts`
+   - Add optional `staleSnapshot?: boolean` to `ChatResumeResult` with a doc comment: true only when a recent compaction was known and the new boundary did not appear within the bounded retry budget.
+2. `libs/backend/agent-sdk/src/lib/helpers/compaction-readiness-registry.ts` (new)
+   - Bounded insertion-ordered map, 64 entries, LRU evict on insert past the bound.
+   - `record(sessionId, entry: { boundaryRecordedAt: number })`.
+   - `latest(sessionId)` returns the entry, or `null` when absent or older than `COMPACTION_READINESS_WINDOW_MS = 15 * 60_000`.
+   - `clear()` for tests.
+3. `libs/backend/agent-sdk/src/lib/message-transform/transformer-helpers.ts`
+   - Add `readonly compactionReadiness: CompactionReadinessRegistry` to `TransformerHelpers`.
+4. `libs/backend/agent-sdk/src/lib/message-transform/system-message.transformer.ts`
+   - In `transformCompactBoundary` (lines 32-96): after the sessionId-resolve guard (lines 66-78), call `helpers.compactionReadiness.record(sessionId, { boundaryRecordedAt: Date.now() })`. Skip the record exactly when emission is skipped.
+5. `libs/backend/agent-sdk/src/lib/di/tokens.ts` + `libs/backend/agent-sdk/src/lib/di/register.ts` (or the lib's registration file per the existing pattern)
+   - `SDK_COMPACTION_READINESS_REGISTRY: Symbol.for('SdkCompactionReadinessRegistry')`, singleton registration. Follow the `SDK_LIVE_USAGE_TRACKER` pattern.
+6. `libs/backend/agent-sdk/src/lib/session-history-reader.service.ts`
+   - Extract the boundary-scan + filter core of `readHistoryMessages` (lines 332-430) into a private `projectSimpleMessages(rawMessages, extractContent)`. `readHistoryMessages` calls it; behavior identical.
+   - `readSessionHistory` (lines 135-214): new optional param `options?: { awaitCompactionBoundary?: boolean }`.
+     - Add `messages` to the return value, computed from the SAME `mainMessages` array with `projectSimpleMessages`.
+     - When `awaitCompactionBoundary` is true and the registry holds a recent entry for the session: scan the parse for the last `compact_boundary` line timestamp. Accept when it is at or after `entry.boundaryRecordedAt - COMPACTION_READINESS_SLACK_MS` (60 s). When not accepted: retry up to `MAX_COMPACTION_READINESS_ATTEMPTS = 5`, delay `COMPACTION_READINESS_RETRY_DELAY_MS = 150` between attempts, re-calling `readJsonlMessages` each time (the `(size, mtimeMs)` memo makes unchanged attempts free). After the last failed attempt, proceed with what was read and set `staleSnapshot: true` on the return value.
+     - No registry entry, or entry outside the window: today's path, `staleSnapshot` absent.
+   - Update the two-parse doc comment at `libs/backend/agent-sdk/src/lib/helpers/history/jsonl-reader.service.ts:348-349` to the single-snapshot rule.
+7. `libs/backend/rpc-handlers/src/lib/chat/session/chat-session.service.ts`
+   - `resumeSession`: pass `{ awaitCompactionBoundary: true }` at line 798. Delete the `readHistoryAsMessages` call at line 805 and use `result.messages`. Thread `staleSnapshot` into the result.
+8. Specs:
+   - `libs/shared/src/lib/types/wire-parsers.equivalence.spec.ts` — check whether it pins `ChatResumeResult` fields; update it if it does.
+   - `libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts` — extend: (a) events and messages in the return come from one parse and share one boundary drop; (b) stale-then-ready JSONL: registry entry exists, first parse lacks the new boundary, retry loop observes the file change and returns ready; (c) budget exhausted → `staleSnapshot: true`; (d) no registry entry → flag absent; (e) boundary line written at completion time does not break the slack comparison (217 s compaction duration case).
+   - New `compaction-readiness-registry.spec.ts`: LRU bound, recency window, `latest` after `clear`.
+   - `libs/backend/agent-sdk/src/lib/message-transform/` transformer spec: `transformCompactBoundary` records only when a session id resolves.
+   - `libs/backend/rpc-handlers` existing resume spec (`chat-session-resume-activate.spec.ts`): update for the single-read call shape and `staleSnapshot` passthrough.
+
+Constraints:
+
+- Do not change `ChatResumeParams`, `chat-rpc.schema.ts`, or the stats-only caller at `session-rpc.handlers.ts:834`.
+- Do not delete `readHistoryAsMessages`. Add a doc note: `chat:resume` must not call it.
+- Keep `readHistoryForCuration` behavior identical.
+- No arbitrary sleep outside the bounded retry loop.
+
+Test gate:
+
+```bash
+npx nx run-many -t test -p @ptah-extension/shared @ptah-extension/agent-sdk @ptah-extension/rpc-handlers
+npx nx affected -t typecheck
+```
+
+Review gate: code-logic-reviewer + code-style-reviewer on the diff. Focus points: memo interaction with the retry loop, registry window math, single-parse guarantee, additive contract only.
+
+---
+
+## Batch 2 — Frontend: stale-snapshot guard in the compaction reload
+
+Goal. A stale resume result never replaces the visible tab state. The tab stays on its compacted marker and reloads clean data on the next session switch.
+
+Depends on: Batch 1 (the `staleSnapshot` field).
+
+Files:
+
+1. `libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts`
+   - In `switchSession` after the `chat:resume` result and the second `requireTargetTab` (line 670-672), before the apply block (line 697): when `opts?.reason === 'compaction'` AND `resumeResult.data?.staleSnapshot === true`, do not apply events, messages, or stats. Restore the tab: status `loaded`, `markTabIdle`, keep the `preloadedStats` that `applyCompactionComplete` installed. Warn once. Return normally so the pending-settle counter still clears compaction state.
+   - Do not change the non-compaction resume path.
+2. `libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts`
+   - New cases: (a) compaction reload with `staleSnapshot: true` → no event/message/stats apply, tab restored, state not 'resuming'; (b) compaction reload with flag absent → normal apply; (c) normal resume with `staleSnapshot: true` (defensive) → normal apply (flag consumed only on compaction reason); (d) pin the existing dedup: two concurrent `switchSession` calls with the same `${sessionId}:${targetTabId}` share one in-flight load; (e) pin `requireTargetTab`: a tab that no longer owns the session throws.
+
+Constraints:
+
+- Do not add sleeps or re-try loops on the frontend. The bounded backend retry is the only retry.
+- Do not touch `_inFlightSessions` semantics, `requireTargetTab`, `clearPendingUpdates`, or turn-state floors.
+
+Test gate:
+
+```bash
+npx nx run-many -t test -p @ptah-extension/chat @ptah-extension/chat-state
+npx nx affected -t typecheck
+```
+
+Review gate: code-logic-reviewer + code-style-reviewer. Focus points: pending-settle counter still clears, no stuck 'resuming' state, guard scoped to reason 'compaction'.
+
+---
+
+## Batch 3 — Frontend: per-session compaction timers
+
+Goal. Two concurrent compactions keep independent safety timers. Every exit path cleans its own timer.
+
+Depends on: Batch 2 (same file family; avoids merge conflicts in `compaction-lifecycle.service.ts`).
+
+Files:
+
+1. `libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts`
+   - Replace `compactionTimeoutId` (line 57) with `private readonly compactionTimers = new Map<string, { timeoutId: ReturnType<typeof setTimeout>; tabIds: string[]; convIds: string[] }>()`.
+   - `handleCompactionStart` (lines 110-152): clear and re-arm only the entry for that session id. The callback closes over that session's `tabIds` and `convIds`, re-verifies each tab still binds the session, then applies the timeout reset. The callback deletes its own map entry.
+   - `handleCompactionComplete` (lines 261-427): clear only the entry for `result.compactionSessionId` (lines 268-271 replacement).
+   - `clearCompactionState(tabId?)` (lines 526-547): with a tab id, clear entries whose `convIds` include that tab's conversation. Without a tab id, clear all entries. Keep both external callers working: `chat-lifecycle.service.ts:277` (sweep) and `session-stats-aggregator.service.ts:85` (tab-scoped).
+2. `libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts`
+   - New cases: (a) two sessions start compaction → two live timers, neither cancels the other; (b) session A completes → only A's timer cleared, B's still armed; (c) timeout fires for A → only A's tabs get the reset; (d) `clearCompactionState()` clears all; (e) `clearCompactionState(tabId)` clears only entries bound to that tab's conversation; (f) timeout callback skips a tab that closed or re-bound during the wait.
+
+Constraints:
+
+- Keep `COMPACTION_SAFETY_TIMEOUT_MS = 600000` unchanged.
+- Do not change `handleCompactionComplete` fan-out logic, marker stamping, or the reload-target selection. Only the timer bookkeeping changes.
+- Do not remove the `[compaction-diag]` warns unless your edit rewrites those exact lines.
+
+Test gate:
+
+```bash
+npx nx run-many -t test -p @ptah-extension/chat @ptah-extension/chat-state
+npx nx affected -t typecheck
+```
+
+Review gate: code-logic-reviewer + code-style-reviewer. Focus points: every exit path deletes its entry (complete, per-tab clear, sweep, timeout fire), no timer leak on repeated starts of the same session.
+
+---
+
+## Batch 4 — Frontend: post-compaction context seed + neutral marker wording
+
+Goal. After compaction, the context display shows the SDK-reported post-compaction size when it is known and stays blank when it is not. The marker never claims a shrinkage the numbers contradict.
+
+Depends on: Batch 3 (same service; sequential order prevents conflicts).
+
+Files:
+
+1. `libs/frontend/chat-state/src/lib/tab-manager.service.ts`
+   - `applyCompactionComplete` (lines 1730-1753): payload gains optional `postCompactionContextTokens?: number | null`. When the value is a positive finite number AND the tab's current `liveModelStats` has a model, seed `liveModelStats` with `{ model, contextUsed: postCompactionContextTokens, contextWindow, contextPercent }` instead of `null`. Missing, zero, negative, or NaN → `null` (unchanged). Cumulative cost/token fields stay untouched.
+2. `libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts`
+   - In `handleCompactionComplete`, pass `postCompactionContextTokens: result.postTokens ?? null` to `applyCompactionComplete` for each fan-out tab.
+3. `libs/frontend/chat-state/src/lib/tab-manager.service.spec.ts`
+   - New cases: (a) postTokens 21930 + known model → seeded stats with that value; (b) postTokens absent → `liveModelStats` null; (c) postTokens 0 → null (unknown is not zero); (d) cumulative tokens/cost unchanged by the seed; (e) a later live usage frame still overwrites the seed.
+4. `libs/frontend/chat-ui/src/lib/molecules/notifications/compaction-marker.component.ts`
+   - `tokenLine` (lines 97-105): keep "shrank" only when `preTokens > postTokens`. When `postTokens >= preTokens`, render `` `${format(pre)} → ${format(post)} tokens` `` with no verb. Either value null → no line (unchanged).
+5. `libs/frontend/chat-ui/src/lib/molecules/notifications/compaction-marker.component.spec.ts`
+   - New cases: (a) pre 150000 / post 21000 → "shrank"; (b) pre 144 / post 21930 → neutral, no "shrank"; (c) equal values → neutral; (d) one value null → no token line.
+
+Constraints:
+
+- Do not touch `aggregateUsageStats`, `LiveUsageTracker`, `SessionStatsAggregator`, or `preloadedStats` preservation.
+- No other refactors in the marker component.
+
+Test gate:
+
+```bash
+npx nx run-many -t test -p @ptah-extension/chat @ptah-extension/chat-state @ptah-extension/chat-ui
+npx nx affected -t typecheck
+```
+
+Review gate: code-logic-reviewer + code-style-reviewer. Focus points: seed only when positive and finite, no synthetic zero overwrites real context, cumulative totals unchanged.
+
+---
+
+## Batch 5 — Backend: artifact parity between live transform and replay
+
+Goal. The same transcript artifacts produce the same user-visible messages on live transform and on replay. Fix only divergences the parity spec proves.
+
+Depends on: Batch 1 (same lib; sequential order prevents conflicts).
+
+Files:
+
+1. New spec `libs/backend/agent-sdk/src/lib/message-transform/artifact-parity.spec.ts` (or the replay spec folder if the repo prefers; follow existing spec placement).
+   - Fixture corpus, each through BOTH `SdkMessageTransformer.transform` (live path) and the replay path (`session-replay.service.ts`): `isSynthetic: true` user line; `isMeta: true` user line; `sourceToolUseID` user line; tool-result-only user line; `<task-notification>` text; interrupt-sentinel text; `<skill-format>`, `<command-message>`, `<command-name>`, skill base-directory, invoked-skills, plan-file, frontmatter content patterns; local command output line; one genuine user text; one genuine assistant text; the `No response requested.` probe line.
+   - Assert: the user-visible message set is identical between the two paths.
+2. Run the spec. Record which fixtures diverge. Expected (from code reading, not yet proven by test): replay lets the `isSkillOrMetaContent` patterns through.
+3. Fix ONLY the proven divergences. Expected minimal fix: `libs/backend/agent-sdk/src/lib/helpers/history/session-replay.service.ts` user-message gate (lines 122-144) gains the `isSkillOrMetaContent` check, imported from `message-transform-helpers.ts` (same lib). If the spec proves the live path misses task-notification or interrupt-sentinel user text, add those checks to the live gate in `sdk-message-transformer.ts` (lines 159-191).
+4. Update the spec to cover the fixed behavior. Add regression cases to the replay spec if the repo separates them.
+
+Constraints:
+
+- No timestamp sorting. No blanket drop of genuine user or assistant messages.
+- Compaction summary semantics stay unchanged: boundary drop rule, marker summary persistence, `compact_boundary` handling.
+- The `No response requested.` provenance stays a hypothesis. Fix it only if the parity spec proves a rule that covers it without dropping genuine content. Otherwise record the finding in the review notes and leave it.
+
+Test gate:
+
+```bash
+npx nx run-many -t test -p @ptah-extension/agent-sdk @ptah-extension/rpc-handlers
+npx nx affected -t typecheck
+```
+
+Review gate: code-logic-reviewer + code-style-reviewer. Focus points: filter direction (replay gains live's checks, not the reverse, unless the spec proves otherwise), no genuine content dropped, fixture coverage matches the corpus above.
+
+---
+
+## Completion gate (after Batch 5)
+
+1. Full suite over all touched projects:
+
+```bash
+npx nx run-many -t test -p @ptah-extension/shared @ptah-extension/agent-sdk @ptah-extension/rpc-handlers @ptah-extension/chat @ptah-extension/chat-state @ptah-extension/chat-ui
+npx nx affected -t typecheck
+```
+
+Verify the header shows 7 projects.
+
+2. Map each acceptance item from `context.md` (1-6) to the batch and spec that covers it. Record the mapping in the task folder.
+3. Confirm no `[compaction-diag]` warns were removed outside the allowed exception.
+4. Confirm no commit and no push exist on the branch beyond the starting commit `30d37f61c`.

--- a/.ptah/specs/TASK_2026_414/context.md
+++ b/.ptah/specs/TASK_2026_414/context.md
@@ -1,0 +1,37 @@
+# Compaction UI consistency
+
+User requested a dedicated worktree and Ollama Cloud CLI implementation, followed by orchestrator review and verification. No commits or pushes authorized.
+
+- Strategy: BUGFIX, Partial. Read-only architecture/batch plan first, user approval, then sequential Ollama Cloud implementation and independent review/tests.
+- Worktree: D:/projects/ptah-extension/.claude-worktrees/compaction-ui-consistency
+- Branch: fix/compaction-ui-consistency
+- Canonical task folder: D:/projects/ptah-extension/.ptah/specs/TASK_2026_414
+- CLI delegation: enabled, explicitly requested. Ollama Cloud ptahCliId pc-85830910-3d81-4248-84c1-4fa52752dd19. No substitute provider without user consent.
+
+## Verified evidence
+
+Electron log C:/Users/abdal/AppData/Roaming/Ptah/logs/Ptah Electron-2026-09-10.log lines 10354-10385: after manual compaction, canvas session 8a0a185b-4af2-4327-aa06-9f82605290a4 replay read old boundary534 while separate message reader read new boundary999; response mixed194 events with4 messages. Git session d1808e88-9211-4ba4-822b-406569c21d5b returned609 events/16 messages without new boundary. Later reloads lines10423-10436 found boundaries999/358 with9 events/4 messages. Both compactions completed and summaries persisted.
+
+Boundary metadata preTokens144/68 matches last assistant output usage; input/cache usage was zero. postTokens21930/17369, duration217372/212092ms. Do not invent kilotoken conversion. Provider accounting is distinct from refresh failure.
+
+## Scope and acceptance
+
+1. Boundary-aware reload: do not replace valid visible history with pre-compaction or mixed snapshots. Build messages/replay from consistent data; verify expected new boundary with bounded readiness handling, preserve newer live turns and tab isolation. Avoid arbitrary sleeps as sole fix.
+2. Preserve trustworthy current-context metrics, use postTokens appropriately; synthetic zero usage must not overwrite real context. Unknown is not zero. Do not corrupt cumulative cost/tokens.
+3. Handle SDK local-command/synthetic artifacts consistently between live and replay, preserve compaction summary semantics. Do not sort all transcript timestamps or blanket-drop genuine assistant/user messages. Specific screenshot 'No response requested.' provenance remains unverified.
+4. Recovery timers scoped per session/conversation and cleaned up appropriately. Two concurrent compactions cannot cancel each other.
+5. Neutral marker wording if values do not demonstrate shrinkage; avoid unnecessary unrelated refactors.
+6. Targeted regression tests for stale then ready JSONL, consistent snapshot, concurrent sessions, zero synthetic usage, artifact replay and existing load deduplication.
+
+## Investigation starting points
+
+- libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts (completion/reload, singleton timer)
+- libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts (reload, context hydration)
+- libs/frontend/chat-state/src/lib/tab-manager.service.ts (compaction context reset)
+- libs/backend/agent-sdk/src/lib/session-history-reader.service.ts (multiple reads/context snapshot)
+- libs/backend/agent-sdk/src/lib/helpers/history/jsonl-reader.service.ts (projection drops metadata)
+- libs/backend/agent-sdk/src/lib/helpers/history/session-replay.service.ts (artifact handling)
+- libs/backend/agent-sdk/src/lib/message-transform/message-transform-helpers.ts (live injected content filter)
+- libs/frontend/chat-ui/src/lib/molecules/notifications/compaction-marker.component.ts
+
+Read actual code and scoped CLAUDE.md before designing. All product edits and test execution must target the dedicated worktree, not the root checkout. Ptah index defaults to root: use explicit absolute paths and verify cwd for commands. Do not restart the app or modify real session logs. No task carriers in other folders and no nested task creation.

--- a/.ptah/specs/TASK_2026_414/implementation-plan.md
+++ b/.ptah/specs/TASK_2026_414/implementation-plan.md
@@ -1,0 +1,148 @@
+# TASK_2026_414 — Compaction UI consistency: implementation plan
+
+- Worktree: `D:/projects/ptah-extension/.claude-worktrees/compaction-ui-consistency` (branch `fix/compaction-ui-consistency`)
+- All product edits and test runs target the worktree, never the root checkout.
+- Executor for every batch: Ollama Cloud CLI, ptahCliId `pc-85830910-3d81-4248-84c1-4fa52752dd19`. No substitute provider without user consent.
+- No commits or pushes. No live session/log mutations. Do not restart the app.
+
+All line numbers below were verified against the worktree on 2026-09-10.
+
+## 1. Proven causes (verified in code + logs)
+
+### P1 — Mixed snapshot: `chat:resume` performs two independent transcript reads
+
+`ChatSessionService.resumeSession` reads the transcript twice, sequentially:
+
+- `chat-session.service.ts:798` — `readSessionHistory` (events + stats; drops pre-boundary inside `session-replay.service.ts`).
+- `chat-session.service.ts:805` — `readHistoryAsMessages` (messages; drops pre-boundary inside `readHistoryMessages`, `session-history-reader.service.ts:379-393`).
+
+`JsonlReaderService.readJsonlMessages` memoizes on `(path, size, mtimeMs)` (`jsonl-reader.service.ts`, TASK_2026_353 token rule). During the post-compaction reload the SDK appended the new `compact_boundary` + summary lines between the two reads, so `size/mtimeMs` moved and the second read re-parsed a NEWER file. Result (verified log, session `8a0a185b`): events from the pre-compaction parse (old boundary, 194 events) mixed with messages from the post-compaction parse (new boundary, 4 messages). Session `d1808e88` returned 609 events / 16 messages with no new boundary at all. Later reloads found the new boundaries (9 events / 4 messages) — the boundary does land on disk shortly after; the first read raced it.
+
+### P2 — Singleton compaction safety timer
+
+`compaction-lifecycle.service.ts:57` holds ONE `compactionTimeoutId`. `handleCompactionStart` (lines 120-123) clears any existing timer before arming its own (lines 136-151). Two concurrent compactions (two live sessions/tiles) therefore cancel each other's 10-minute safety net: session B's start disarms session A's timer, and whichever completes first (line 268-271) disarms the rest. `clearCompactionState` (lines 527-530) also clears the single timer on every call.
+
+### P3 — Marker always claims shrinkage
+
+`compaction-marker.component.ts:97-105`: `tokenLine` is always `` `shrank ${pre} → ${post} tokens` ``. Observed boundary metadata: preTokens 144/68, postTokens 21930/17369 — post > pre, so the chip asserts a shrinkage the numbers contradict.
+
+### P4 — Post-compaction context display is blanked by construction
+
+Mechanics, all verified:
+
+- `aggregateUsageStats` (`session-history-reader.service.ts:744-755, 832-834`) slices stats to the post-boundary segment and returns `null` when that segment holds no usage. Immediately after a compaction, with no assistant turn since the boundary, `stats` is `null` and `stats.contextSnapshot` cannot exist.
+- `applyCompactionComplete` (`tab-manager.service.ts:1750`) sets `liveModelStats: null`.
+- In `switchSession` (`session-loader.service.ts:686-696`), `stats == null` plus `targetTabId` set (always true for compaction reloads) hits neither branch, so nothing restores the context display until the next live turn.
+
+The compaction itself produced a trustworthy post-compaction context size — `compact_metadata.post_tokens` (21930/17369), already plumbed end-to-end: SDK → `system-message.transformer.ts:91` → `CompactionCompleteEvent.postTokens` → `accumulator-core.service.ts:569` → `streaming-handler.service.ts:340` → `chat.store.ts:366` → `handleCompactionComplete` → currently only into the marker record.
+
+## 2. Hypotheses (explicitly NOT treated as proven)
+
+- H1 — preTokens 144/68 equaling the last assistant output usage with input/cache zero is provider-side `compact_metadata` accounting (the SDK computes it from usage frames the provider reports). This is distinct from the refresh failure (context.md). We do not attempt to fix provider accounting; the marker wording fix (P3) is the user-visible mitigation.
+- H2 — Live vs replay artifact filter divergence lets injected/synthetic content through replay. The CODE divergence is proven (see §5); which artifact a user actually saw (the `No response requested.` screenshot) is UNVERIFIED. Batch 5 probes it; no fix lands without a proven rule.
+- H3 — The first post-compaction read can legitimately observe a transcript that does not yet contain the expected new boundary (SDK flush timing). Supported by P1's log evidence ("later reloads found the boundary"); the bounded-readiness design (§4.1) assumes it.
+
+## 3. Verified contracts (current state)
+
+- `CompactionCompleteEvent` (`libs/shared/src/lib/types/execution/stream.ts:264-274`): `trigger`, optional `preTokens`/`postTokens`/`durationMs`.
+- `ChatResumeParams` (`libs/shared/src/lib/types/rpc/rpc-chat.types.ts:210-230`): no compaction-related field today; zod-validated by `ChatResumeParamsSchema` in `libs/backend/rpc-handlers/src/lib/handlers/chat-rpc.schema.ts` (spec: `chat-rpc.schema.spec.ts:115-150`, including a known-keys assertion).
+- `ChatResumeResult` (`rpc-chat.types.ts:233-310`): `messages` (deprecated), `events`, `stats.contextSnapshot`, `resumableSubagents`, `cliSessions`, `activated`, `activationError`.
+- `readSessionHistory` (`session-history-reader.service.ts:135-214`): returns `{ events, stats }`; internally holds `mainMessages` (the full parsed array), `agentSessions`; seeds `LiveUsageTracker` (`seedLiveUsageBaseline`, lines 248-268, stops at last `compact_boundary`).
+- `readHistoryAsMessages` / `readHistoryMessages` (lines 280-430): boundary scan + `extractTextContent` + `<task-notification>` drop. No other production caller besides `chat-session.service.ts:805` (verified by grep; `readHistoryForCuration` shares the private core but is a separate public method used by the memory curator).
+- `transformCompactBoundary` (`system-message.transformer.ts:32-96`): clears streaming state, resolves sessionId (caller → payload → activeIds[0]), prunes subagents, `clearSessionTokenSnapshot` (line 81), emits `compaction_complete` with `timestamp: Date.now()` and metadata passthrough. Skips emission when no sessionId resolves (lines 66-78).
+- Frontend reload chain: `chat.store.ts:361-368` → `CompactionLifecycleService.handleCompactionComplete` (`compaction-lifecycle.service.ts:261-427`): marker stamp (351), `applyCompactionComplete` per fan-out tab (381), then `switchSession(sessionId, { reason: 'compaction', targetTabId })` per target (410-423) with a pending-settle counter.
+- `switchSession` (`session-loader.service.ts:552-745`): dedup via `_inFlightSessions` keyed `${sessionId}:${targetTabId}` (557-568); `requireTargetTab` throws when the tab no longer owns the session (747-756); prefers `events` replay path (697) over legacy `messages` (714).
+- `CompactionMarkerRecord` + `setCompactionMarkerTokens` (`conversation-registry.service.ts:263-285`): per-conversation, field-wise merge with persisted prior, `completedAt` max-merge.
+- Timer sweep callers: `chat-lifecycle.service.ts:277` (`clearCompactionState()`, no tab) and `session-stats-aggregator.service.ts:85` (`clearCompactionState(t.id)`).
+
+## 4. Design
+
+### 4.1 Consistent boundary-verified reload (acceptance 1)
+
+Two independent fixes, layered:
+
+**(a) Single snapshot (kills the mixed snapshot by construction).**
+`readSessionHistory` gains the messages projection: extract the boundary-scan + filter core of `readHistoryMessages` into a private `projectSimpleMessages(rawMessages, extractContent)` and call it inside `readSessionHistory` with `eventFactory.extractTextContent`. Return shape grows additively:
+
+```ts
+{ events, stats, messages: SimpleHistoryMessage[] }   // messages from the SAME mainMessages parse
+```
+
+`resumeSession` (`chat-session.service.ts:805`) drops its `readHistoryAsMessages` call and uses `result.messages`. Events and messages now drop pre-boundary by the SAME rule over the SAME array — a mid-read file change can no longer split them. The stale doc comment at `jsonl-reader.service.ts:348-349` ("chat:resume calls readSessionHistory() and then readHistoryAsMessages() — two full parses") is updated in the same change.
+
+`readHistoryAsMessages` stays: it is documented public API of `@ptah-extension/agent-sdk` with its own specs, and `readHistoryForCuration` shares its core. It gets a doc note that `chat:resume` must not call it (single-snapshot rule). Deleting public API mid-bugfix is out of scope.
+
+**(b) Bounded boundary readiness (kills the stale snapshot).**
+The backend already knows, in-process, when it transformed a `compact_boundary` — the same process that serves `chat:resume`. No frontend timestamp plumbing, no clock skew.
+
+- New injectable `CompactionReadinessRegistry` (`agent-sdk`, helpers): bounded insertion-ordered map (64 entries, LRU-evicted — same bound pattern as `RESUME_BASELINE_LIMIT`), `record(sessionId, { boundaryRecordedAt, boundaryLineTimestamp? })` and `latest(sessionId)`. Retention rule: entries older than `COMPACTION_READINESS_WINDOW_MS` (15 min) answer `null` — recency is the validity token, not a TTL sweep (the LRU is only the leak guard; matches the repo's read-cache rules).
+- Producer: `transformCompactBoundary` records AFTER the resolvedSessionId guard (skip exactly when emission is skipped). `TransformerHelpers` (`transformer-helpers.ts:10`) gains a `readonly compactionReadiness` member; DI token `SDK_COMPACTION_READINESS_REGISTRY: Symbol.for('SdkCompactionReadinessRegistry')` in `di/tokens.ts` + `register.ts`.
+- Consumer: `readSessionHistory` gains an options param `{ awaitCompactionBoundary?: boolean }`. When set AND the registry holds a recent entry for the session, the reader verifies the parse's last `compact_boundary` line timestamp is at/after `entry.boundaryLineTimestamp - COMPACTION_READINESS_SLACK_MS` (60 s). If not: bounded retry — `MAX_COMPACTION_READINESS_ATTEMPTS = 5`, `COMPACTION_READINESS_RETRY_DELAY_MS = 150` (worst case ≈ 750 ms), re-calling `readJsonlMessages` (memoized: an unchanged `(size, mtimeMs)` token costs nothing; a changed token re-parses). No arbitrary sleep is the sole mechanism — the loop is token-gated and bounded.
+- Only `ChatSessionService.resumeSession` passes `awaitCompactionBoundary: true` (opt-in; the stats-only caller at `session-rpc.handlers.ts:834` is untouched). The registry's recency window is the real gate: normal resumes of sessions without a recent compaction take the exact same path as today.
+- Readiness result travels out as `ChatResumeResult.staleSnapshot?: boolean` (additive, `rpc-chat.types.ts`): `true` only when the hint was checked and the boundary never appeared within the budget; absent otherwise. No `ChatResumeParams` change, no `chat-rpc.schema.ts` change.
+- Check `libs/shared/src/lib/types/wire-parsers.equivalence.spec.ts` for any shape-pinning of `ChatResumeResult` and update if it enumerates result fields.
+
+**Frontend stale guard** (`session-loader.service.ts`, after the `chat:resume` return, before the apply block at line 697): when `opts?.reason === 'compaction'` and `resumeResult.data?.staleSnapshot === true` — do NOT apply events/messages/stats (the payload is a pre-compaction parse; applying it is exactly the defect), restore the tab (`markTabIdle`, status `loaded`, keep `preloadedStats` installed by `applyCompactionComplete`), warn once, return normally so the pending-settle counter still clears compaction state. The tab shows the compacted marker and refills correctly on the next session switch, which re-resumes and now finds the boundary. Non-compaction resumes keep today's behavior unchanged.
+
+**Unchanged guards, to be test-pinned (acceptance 1 "preserve newer live turns and tab isolation", acceptance 6 "existing load deduplication"):** `_inFlightSessions` dedup key `${sessionId}:${targetTabId}`, `requireTargetTab` ownership throw, `clearPendingUpdates` before targeted replay (`session-loader.service.ts:631-633`), turn-state revision floors (untouched — no writer in this task).
+
+### 4.2 Reliable post-compaction context stats (acceptance 2)
+
+- `TabManagerService.applyCompactionComplete` (`tab-manager.service.ts:1730-1753`) payload gains `postCompactionContextTokens?: number | null`. When it is a positive finite number AND the tab's current `liveModelStats` has a model, the write seeds `liveModelStats` with `{ model, contextUsed: postCompactionContextTokens, contextWindow, contextPercent }` instead of `null`. Zero, negative, NaN, or missing → `null` (unchanged) — **unknown is not zero, and zero is not evidence**.
+- `handleCompactionComplete` passes `result.postTokens` through (it already computes nothing new — the value rides the existing chain, §1 P4).
+- Cumulative cost/tokens are untouched: `preloadedStats` preservation and `SessionStatsAggregator` grace-window logic stay exactly as-is. `aggregateUsageStats` slicing is unchanged. No change to `LiveUsageTracker` semantics (TASK_2026_374 rules stand; `clearSessionTokenSnapshot` at boundary, lines `system-message.transformer.ts:81`, stays).
+- H1 (provider preTokens accounting) is explicitly not addressed beyond the marker wording.
+
+### 4.3 SDK artifact semantics, live vs replay (acceptance 3)
+
+Verified divergence — live user-message gate (`sdk-message-transformer.ts:159-191`): `isSynthetic === true`; skill-tool-active unless tool_result; `isSkillOrMetaContent` patterns (`message-transform-helpers.ts:28-77`: `sourceToolUseID`, `<skill-format>`, `<command-message>`, `<command-name>`, skill base-directory, invoked-skills, plan-file, frontmatter). Replay user gate (`session-replay.service.ts:122-144`): `isMeta === true`; `sourceToolUseID`; tool_result-only; `<task-notification>`; interrupt sentinel.
+
+Batch 5 lands a parity spec FIRST (fixture corpus: every pattern above, a genuine user text, a local-command-output line, and the `No response requested.` probe), running the same fixtures through `SdkMessageTransformer.transform` and `replayToStreamEvents`, asserting the same user-visible message set. Then only the divergences the spec proves are fixed — expected minimal change: replay gains the `isSkillOrMetaContent` content patterns for user lines (same lib, import from `message-transform-helpers`). Constraints: no timestamp sorting, no blanket drop of genuine user/assistant messages, compaction summary semantics (boundary drop + registry-persisted marker summary) unchanged.
+
+### 4.4 Per-session compaction timers (acceptance 4)
+
+Replace the singleton with `private readonly compactionTimers = new Map<SessionId, { timeoutId; tabIds; convIds }>()`:
+
+- `handleCompactionStart(sessionId)`: clear + re-arm ONLY the entry for that session; callback closes over that session's `tabIds`/`convIds` and re-verifies each tab still binds the session before `applyCompactionTimeoutReset` (a tab may have closed or re-bound during the 10 minutes).
+- `handleCompactionComplete(result.compactionSessionId)`: clear only that session's entry.
+- `clearCompactionState(tabId?)`: with tabId → clear entries whose `convIds` include the tab's conversation; without → clear ALL entries (full-sweep semantics preserved for `chat-lifecycle.service.ts:277`).
+- Timeout fire: delete own entry (`this.compactionTimers.delete(sessionId)` inside the callback — the current code already nulls its own handle, line 147).
+
+### 4.5 Neutral marker wording (acceptance 5)
+
+`tokenLine` (`compaction-marker.component.ts:97-105`): keep "shrank" only when `preTokens > postTokens` (a demonstrated reduction); when `postTokens >= preTokens` render `` `${format(pre)} → ${format(post)} tokens` `` with no verb. Either value null → no line (unchanged). No other refactors in the component.
+
+## 5. Explicitly out of scope
+
+- Provider-side `compact_metadata` accounting (H1).
+- The `No response requested.` screenshot provenance (H2) — probe only.
+- Deleting `readHistoryAsMessages` public API.
+- The `[compaction-diag]` `console.warn` blocks (`compaction-lifecycle.service.ts:325-345, 393-398`; `session-loader.service.ts:613-626`) — marked TEMPORARY, but removing them is an unrelated refactor (scope item 5); leave them unless a batch touches those exact lines for its own change.
+- Any change to `ChatResumeParams` / `chat-rpc.schema.ts`.
+- Turn-state, dedup, revision-floor, or `LiveUsageTracker` semantics.
+
+## 6. Race and concurrency guards (summary)
+
+| Race                                      | Guard                                                                                        |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Transcript appended between two reads     | Single snapshot — one parse feeds events + messages (§4.1a)                                  |
+| Boundary not yet flushed at reload        | Bounded token-gated retry + `staleSnapshot` flag + frontend no-apply guard (§4.1b)           |
+| Unchanged-file retry cost                 | `readJsonlMessages` memo on `(size, mtimeMs)` — retries are free until the file moves        |
+| Two concurrent compactions                | Per-session timer map, per-session clear (§4.4)                                              |
+| Tab closed/re-bound during a 10-min timer | Callback re-verifies session ownership before reset (§4.4)                                   |
+| Duplicate concurrent reloads              | `_inFlightSessions` keyed `${sessionId}:${targetTabId}` (existing, test-pinned)              |
+| Reload target drift                       | `requireTargetTab` ownership throw (existing, test-pinned)                                   |
+| Readiness registry growth                 | 64-entry LRU + 15-min recency window                                                         |
+| Stale guard misfiring on normal resumes   | Opt-in flag + registry recency gate; `staleSnapshot` consumed only on `reason: 'compaction'` |
+
+## 7. Test commands (verified project names)
+
+```bash
+# Never `nx test projA projB projC` — first project only. Always run-many, then check the header count:
+npx nx run-many -t test -p @ptah-extension/shared @ptah-extension/agent-sdk @ptah-extension/rpc-handlers
+npx nx run-many -t test -p @ptah-extension/chat @ptah-extension/chat-state @ptah-extension/chat-ui
+npx nx run-many -t test -p @ptah-extension/chat-streaming   # only if a batch touches it (none planned)
+npx nx affected -t typecheck                                # after each batch
+```
+
+Run from the worktree root. Verify the `Running target test for N projects` header shows the N requested. No `project.json` edits are planned, so no `npx nx reset` is required; if one becomes necessary, never run it while another executor works in the worktree.

--- a/.ptah/specs/TASK_2026_414/task.md
+++ b/.ptah/specs/TASK_2026_414/task.md
@@ -1,0 +1,21 @@
+---
+id: TASK_2026_414
+status: in_progress
+type: BUGFIX
+title: Fix compaction history refresh and context UI consistency
+depends_on: []
+created: '2026-09-10T16:12:36.726Z'
+updated: '2026-09-10T16:12:53.819Z'
+description: >-
+  Make post-compaction history reload boundary-aware, preserve trustworthy
+  context statistics, handle SDK artifacts, and isolate concurrent recovery
+  timers.
+executor: ollama cloud
+estimate: M
+---
+
+<!-- Ptah carrier: machine-owned metadata. Ptah rewrites the frontmatter above. Do NOT write prose here — prose belongs in ./context.md. -->
+
+Make post-compaction history reload boundary-aware, preserve trustworthy context statistics, handle SDK artifacts, and isolate concurrent recovery timers.
+
+Full context, plan and discussion live in [./context.md](./context.md).

--- a/.ptah/specs/TASK_2026_415/context.md
+++ b/.ptah/specs/TASK_2026_415/context.md
@@ -1,0 +1,19 @@
+# Boot readiness timeout / startup freeze
+
+User reports initial-load UI freezing for a couple of minutes. Screenshot contains repeated (count10) [ClaudeRpcService] RPC timeout for method: boot:getReadiness. User explicitly prioritizes this as critical irrespective of relation to compaction and requests a CLI agent investigate.
+
+Strategy BUGFIX: investigate logs and implementation, establish cause, plan minimal fix, orchestrator review before implementation. CLI delegation explicitly enabled: Ollama Cloud pc-85830910-3d81-4248-84c1-4fa52752dd19. No commits/pushes. No production data changes or restarting user's running app.
+
+Dedicated worktree D:/projects/ptah-extension/.claude-worktrees/boot-readiness-timeout, branch fix/boot-readiness-timeout. Product reads and eventual edits must use that worktree, not root. Canonical report folder D:/projects/ptah-extension/.ptah/specs/TASK_2026_415. Independent related task414 handles compaction; avoid scope overlap and never run process-wide nx reset while other agents execute.
+
+## Evidence and leads
+
+- Screenshot repeated boot:getReadiness timeout, not yet proof of root cause. Distinguish missing handler/transport readiness vs handler blocking vs event-loop starvation vs frontend rendering stalls.
+- Application log C:/Users/abdal/AppData/Roaming/Ptah/logs/Ptah Electron-2026-09-10.log. Read locally and narrowly. Never include secrets/prompts in report. Log earlier startup around23:05 UTC on Sept9 and later startup before15:44 UTC Sept10; identify correct current process by log boot markers rather than guessing.
+- Memory leads (must verify current code): TASK_2026_380 investigated initial-load performance. Five boot RPCs previously blocked main thread: autocomplete:agents, git:info, config:models-list, session:list, auth:getAuthStatus. boot:getReadiness uses BOOT_READINESS port and ElectronBootReadinessProvider; NullBootReadinessProvider for other hosts. Pull recovery is required because pushes before Angular bootstrap can be lost.
+- Existing measure-boot-rpcs.mjs reportedly measures cold boot on isolated copied profile. Inspect before considering execution; do not copy/access production DB unnecessarily or start another live profile. Prefer unit/integration reproducible slow-boot fixtures.
+- Screenshot compaction diagnostics correctly resolve originating session/tab, and context stats suppression is deliberate guard. Separate background_agent missing agentId fallback warning is lower-priority and not evidence of startup cause.
+
+## Acceptance for eventual fix
+
+Readiness RPC should be available promptly and represent true state, never fake ready. Bound polling/inflight requests and clean teardown. Address demonstrated blocking work rather than increase timeout or suppress diagnostics. Preserve all three hosts and hexagonal boundaries. Tests should exercise slow startup, request/response delivery, recovery/teardown and identified actual failure. Report installed-bundle vs source mismatch if present. No arbitrary broad startup redesign.

--- a/.ptah/specs/TASK_2026_415/implementation-plan.md
+++ b/.ptah/specs/TASK_2026_415/implementation-plan.md
@@ -1,0 +1,268 @@
+# TASK_2026_415 — Implementation plan: fix repeated `boot:getReadiness` timeouts and initial-load freeze
+
+Read `research-report.md` first. This plan follows findings 1–3.
+No change increases a timeout, suppresses a diagnostic, or fakes readiness.
+
+---
+
+## Fix 1 (primary): per-key persistence in `ElectronStateStorage`
+
+**File**: `libs/backend/platform-electron/src/implementations/electron-state-storage.ts`
+(the only production file that changes for Fix 1).
+
+### The defect
+
+The adapter keeps every key in one object. Every `update` writes the whole
+store: `JSON.stringify(this.data, null, 2)` at line 70 serializes the whole
+255.67 MB on the main thread, for one key. Every `loadSync` parses the whole
+file. See research report §4.
+
+### The change
+
+Split the store into one JSON file per key:
+
+1. **Layout.** Replace the single `workspace-state.json` with a directory
+   `workspace-state/` next to it. Each key becomes one file inside it:
+   - File name = `encodeURIComponent(key) + '.json'`. This is safe on
+     Windows: `encodeURIComponent` escapes `:` (illegal in Windows file names)
+     and `/`, `\`, `?`, `*`, and other reserved characters.
+   - File body = `JSON.stringify(value)` — the value only, not the map.
+2. **Construction.** Do not read any key file at construction. Build the key
+   list from the directory listing (`readdirSync`, one call, names only). Parse
+   a key's file only on the first `get` of that key, then cache the value in
+   memory. This removes the whole-store `JSON.parse` from `loadSync`.
+   - `update(key, value)` still puts the value in memory immediately. The
+     first `get` after a restart pays one small parse, not a 255 MB parse.
+3. **Write path.** `persist(key)` writes only that key's file: serialize the
+   one value, `writeFile` to a temp file, `rename` over the target. Same
+   atomicity guarantee the adapter has today, at one-key cost.
+   - Keep the `writePromise` chain per instance so writes still serialize.
+   - A write of key B must not touch key A's file. The regression spec below
+     asserts this.
+4. **Sync variants.** Keep `updateSync`/`persistSync` as sync writes of the one
+   key file. They keep their current callers and their semantics. Their cost
+   drops from whole-store to one key.
+5. **`keys()`** returns the decoded names from the directory listing. Remove
+   the in-memory whole-map dependency.
+6. **Migration.** At construction, if `workspace-state.json` exists and the
+   split directory does not:
+   - Parse the legacy file once (this is the last whole-store parse).
+   - Write one file per key into the split directory, with the temp+rename
+     atomic write.
+   - After all key files are in place, rename the legacy file to
+     `workspace-state.json.migrated` (do not delete it; it is the rollback).
+   - If migration fails partway, the next start retries it: the directory
+     exists without the marker, so re-run from the legacy file. The write is
+     idempotent per key.
+   - Migration cost is one deliberate multi-second block at the first start
+     after the update. State this in the release note. Every later start is
+     cheap.
+7. **Port contract unchanged.** `IStateStorage` (`platform-core`) keeps its
+   method set. No consumer changes. No token changes.
+
+### What this does not fix
+
+`ptah.sessionMetadata` is one key of 127.10 MB. Each flush of that key now
+serializes only its own value, not all 190 keys. That is a large improvement,
+but the single value is still large. Moving session metadata to
+`persistence-sqlite` is a separate data-model task. Record it, do not do it here.
+
+### Host impact
+
+- **Electron**: fixed. This adapter is Electron-only.
+- **VS Code host**: untouched. It uses the real `vscode.ExtensionContext`
+  storage, not `ElectronStateStorage` (see `register-storage-shims.ts` header).
+- **CLI host**: untouched. It uses `CliStateStorage`
+  (`libs/backend/platform-cli`).
+- The hexagonal rule holds: the change is inside one adapter, behind
+  `IStateStorage`. `vscode-core` (`WorkspaceAwareStateStorage`,
+  `registerStateStorageAdapters`) has no knowledge of the on-disk format. The
+  factory type comment in `workspace-aware-state-storage.ts:23-28` mentions the
+  Electron file name; update that comment only.
+
+---
+
+## Fix 2: single-flight the readiness watchdog pull
+
+**File**: `libs/frontend/core/src/lib/services/boot-status.service.ts`
+
+**The defect**: `startWatchdog` (lines 196-201) runs
+`setInterval(() => { void this.pullReadiness(); }, 2000)` with no in-flight
+flag. A pull can take the full 5 s timeout while the main process is starved, so
+ticks stack: up to 3 concurrent pulls, ~78 queued RPC calls over the observed
+2 min 36 s window (research report §6). This breaks the acceptance "bound
+polling/inflight".
+
+**The change**:
+
+1. Add one private field: `private pullInFlight = false;`
+2. In `pullReadiness` (line 162): at the start, `if (this.pullInFlight) return;`
+   then set `this.pullInFlight = true;`. In a `finally` block, set it back to
+   `false`. The existing `try/catch` already covers all exit paths; wrap the
+   reset in `finally` so a throw cannot strand the guard.
+3. Change nothing else. Same timeout (5000 ms). Same interval (2000 ms). Same
+   monotonic adoption rule. Same ready default for the VS Code host. A skipped
+   tick is safe: the next tick in 2 s asks the same question, and the push path
+   stays authoritative.
+
+**Result**: at most one `boot:getReadiness` call in flight at any time. The
+watchdog keeps its recovery role (a lost push cannot strand the boot screen).
+
+---
+
+## Fix 3 (gated): async target-side reads in the harness reconcile pass
+
+**Gate**: do this only after a CPU profile confirms the attribution (Step 0
+below). The source walk is already async (TASK_2026_323); these are the
+remaining synchronous reads on the target side.
+
+**Files and changes**:
+
+1. `libs/backend/harness-sync/src/lib/targets/workspace-target.ts:411` —
+   the copy-plan `content: readFileSync(sourceFile, 'utf-8')`. Make the plan
+   step async and read with `fs/promises`. The plan builder is already async up
+   the call chain (it awaits source hashes).
+2. `workspace-target.ts:919` — same change in apply:
+   `content: readFileSync(write.source, 'utf-8')` → `await readFile(...)` from
+   `fs/promises`.
+3. `hashTransformedDirSync` (same file) — replace its use with the existing
+   async fold. `targets/copy-engine.ts` already holds an async
+   `hashTransformedDir` over the same file map (`digestFileMap` in
+   `content-hash.ts`). Both folds must stay byte-identical: the digest is a
+   compared value, not a diagnostic. Add a spec that hashes one fixture
+   directory with both folds and asserts equal digests, then delete the sync
+   fold only after that spec is green.
+4. `libs/backend/harness-sync/src/lib/targets/claude-target.ts:493,551,566,610,614`
+   — `lstatSync`/`readdirSync`/`readFileSync` → the matching `fs/promises`
+   calls.
+5. `harness-manifest.builder.ts:389,529` — leave alone. These are documented
+   deliberate one-level exceptions (see harness-sync CLAUDE.md).
+
+**Digest stability**: the async source walk (TASK_2026_323) kept a byte-for-byte
+stable digest. Follow the same pattern: same fold order, same chunk boundaries
+(`HASH_BATCH_SIZE`), same `setImmediate` yields, same commit-point cancellation
+via `pass-abort.ts`.
+
+---
+
+## Step 0 (evidence, non-blocking): capture a CPU profile
+
+Fixes 1 and 2 stand on source arithmetic and stand alone. Fix 3 needs profile
+confirmation before it is done. Per `libs/backend/vscode-core/CLAUDE.md`
+("Diagnosing a hang"), the lag run proves a block; the profile names the owner.
+
+1. On the next slow boot (no restart needed to arm it — the next natural start
+   counts), run from the renderer devtools:
+   `window.ptahDiag.captureCpuProfile(10000)` during the lag run.
+   Alternative: set `PTAH_PROFILE_ON_LAG_MS=3000` before start, which captures
+   automatically on the first lag over 3 s.
+2. Read the profile for `JSON.stringify` frames (Fix 1 owner) versus
+   `readFileSync`/hash frames (Fix 3 owner).
+3. If the profile shows neither, do not proceed to Fix 3. Record the actual
+   owner and stop.
+
+**Fixture harness (no live profile)**: adapt `measure-boot-rpcs.mjs` from
+`.ptah/specs/TASK_2026_380/` into an isolated slow-boot fixture: a temp
+`workspace-state.json` seeded with a large `ptah.agentOutput:*` key set, a
+small key updated in a loop, and an event-loop lag probe. This reproduces the
+write amplification in a unit test without the production profile. Inspect the
+380 harness first; do not run anything against the live profile.
+
+---
+
+## Regression tests
+
+All specs sit beside their target file, per repo convention.
+
+### Fix 1 — `electron-state-storage.spec.ts` (extend the existing spec)
+
+1. **Write amplification**: seed a storage with a large key A (several MB of
+   filler) and a small key B. Update B. Assert: B's key file changed, A's key
+   file did not (compare `mtime` or bytes). Under the old adapter this fails:
+   the whole store is one file.
+2. **Lazy load**: construct the storage with two keys on disk. Assert the
+   construction did not read key file bodies (spy on `readFile`/`readFileSync`:
+   only the directory listing ran). Assert `get` of one key parses only that
+   key's file.
+3. **Migration round-trip**: write a legacy `workspace-state.json` with two
+   keys. Construct the storage. Assert: both keys readable with the same
+   values; the split directory holds one file per key; the legacy file was
+   renamed to `.migrated`. Construct again: assert no re-migration (the
+   presence check works) and the same values.
+4. **Atomicity**: update a key while its file exists. Assert no partial file
+   at any observable point: after `update` resolves, the file parses as JSON.
+   (The temp+rename pattern gives this; the spec pins it.)
+5. **Windows name safety**: write a key containing `:` and `/`
+   (`ptah.agentOutput:123/a`). Assert the key file name encodes both, and
+   `keys()` returns the original key unchanged.
+
+### Fix 2 — `boot-status.service.spec.ts` (extend the existing spec)
+
+1. **Single-flight**: put the RPC into a state where a pull stays unsettled
+   (a `boot:getReadiness` promise the test controls). Fire the watchdog tick
+   twice. Assert the RPC call count is 1, not 2. Resolve the pull. Advance
+   time. Assert the next tick fires a new pull.
+2. **Guard resets on failure**: make the pull reject. Assert the next tick
+   still issues a new pull (the `finally` reset works; the service cannot
+   wedge after one failure).
+3. **Existing behavior unchanged**: the current spec already covers the pull,
+   the push, the monotonic rule, and the ready default. Do not change those
+   tests. They must stay green without edits.
+
+### Fix 3 — harness-sync digest-stability and call-count specs
+
+1. **Digest equality**: hash one fixture directory with the sync fold and the
+   async fold. Assert identical digests. (Write this spec BEFORE deleting the
+   sync fold; it is the gate.)
+2. **No sync fs in the apply path**: follow the marker-spec pattern the repo
+   already uses (`skill-md-migration` marker spec): after the change, grep the
+   compiled apply-path modules for `readFileSync` and assert zero matches,
+   with the manifest builder's documented exception listed explicitly.
+
+---
+
+## Commands
+
+Project names come from each lib's `project.json` (verified):
+
+```bash
+npx nx run-many -t test -p @ptah-extension/platform-electron @ptah-extension/core @ptah-extension/harness-sync @ptah-extension/vscode-core
+```
+
+- Read the `Running target test for 4 projects` header. The number must equal
+  the number of projects asked for. A misspelled name is dropped silently.
+- Never `npx nx test projA projB` — Nx runs the first project only and the
+  rest become Jest path filters (root CLAUDE.md).
+- No `project.json` is edited by this plan, so no `nx reset` is needed. If a
+  batch later edits one, reset before the first command of that batch, never
+  while another executor runs in the same worktree.
+- Type check after the edits:
+  `npx nx affected -t typecheck` or the scoped
+  `npx nx run-many -t typecheck -p @ptah-extension/platform-electron @ptah-extension/core`.
+
+---
+
+## Acceptance mapping
+
+| Requirement (task)                                    | How this plan meets it                                                                                                                                             |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Readiness RPC available promptly, answer truthful     | Fix 1 and Fix 3 remove the loop blocks that starve the handler. The handler itself is unchanged and stays truthful.                                                |
+| Bound polling/inflight                                | Fix 2: one pull in flight at most.                                                                                                                                 |
+| Clean teardown                                        | Fix 2 keeps the existing `DestroyRef` cleanup (`boot-status.service.ts:138`). The in-flight flag needs no teardown: a pending pull resolves into an inert service. |
+| Fix demonstrates blocking work                        | Fix 1 by arithmetic (255.67 MB stringify per key write, research report §4); Fix 3 by CPU profile (Step 0).                                                        |
+| Preserve all three hosts                              | Fix 1 is inside the Electron adapter only. VS Code and CLI adapters untouched. Port contract unchanged.                                                            |
+| Preserve hexagonal boundaries                         | No backend lib imports an adapter. No new port. No token change.                                                                                                   |
+| Report installed-bundle vs source mismatch if present | Research report §9: not checked, stated as unverified.                                                                                                             |
+| No broad startup redesign                             | Three targeted fixes; no phase reordering, no new subsystem.                                                                                                       |
+
+---
+
+## Out of scope (recorded, not planned here)
+
+1. Move `ptah.sessionMetadata` (127.10 MB) from JSON state to
+   `persistence-sqlite`. This is the data-model follow-up after Fix 1.
+2. Pruning the 186 `ptah.agentOutput:*` keys (83.8 MB) — a retention policy
+   question, not a boot fix.
+3. `harness-manifest.builder.ts` `readdirSync` one-level listings — documented
+   deliberate exception.
+4. VS Code webview boot behavior — already correct; the `ready` default stays.

--- a/.ptah/specs/TASK_2026_415/research-report.md
+++ b/.ptah/specs/TASK_2026_415/research-report.md
@@ -1,0 +1,255 @@
+# TASK_2026_415 — Research report: repeated `boot:getReadiness` RPC timeouts and initial-load UI freeze
+
+Status: read-only research. No product code changed. No commits, no pushes, no
+agent spawns, no production DB/log mutation, no live-app restart.
+Checkout examined: `D:/projects/ptah-extension/.claude-worktrees/boot-readiness-timeout`.
+Log examined: `C:/Users/abdal/AppData/Roaming/Ptah/logs/Ptah Electron-2026-09-10.log`.
+
+---
+
+## 1. Verdict in one paragraph
+
+The `boot:getReadiness` handler is registered early and is cheap. The timeouts
+are caused by main-process event-loop starvation during post-window boot work.
+One blocking path is demonstrated by arithmetic from measured file sizes: the
+Electron workspace-state adapter re-serializes the whole 255.67 MB state file on
+every key write, on the main thread. The renderer's 5-second readiness pull then
+times out repeatedly while the loop is blocked. A second blocking path
+(synchronous target-side file reads in the harness reconcile pass) is confirmed
+present in source but its share of the freeze is correlational until a CPU
+profile is captured.
+
+---
+
+## 2. What the timeout is NOT (excluded mechanisms)
+
+| Hypothesis                     | Verdict               | Evidence                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Handler not registered         | Excluded              | Log: RPC surface registered at `15:40:58.850`, `boot:getReadiness` included. The starved window starts at `15:41:12` — after registration.                                                                                                                                                                                      |
+| Handler slow or waiting on I/O | Excluded              | `boot:getReadiness` reads `PLATFORM_TOKENS.BOOT_READINESS` → `ElectronBootReadinessProvider` → `coordinator.snapshot()`. In-memory read. Never throws. Fails OPEN to ready/settled. Registered in `apps/ptah-electron/src/activation/bootstrap.ts` as `useValue` (last registration wins over the vscode-core null adapter).    |
+| Transport not ready            | Excluded              | The RPC surface was up before the window. Other RPC calls reached the main process during it (`[RPC] slow handler` lines exist for other methods). The calls were queued behind a blocked loop, not lost.                                                                                                                       |
+| Renderer blocking              | Excluded as the cause | The renderer issued the pulls; each pull carries a 5 s timeout (`libs/frontend/core/src/lib/services/boot-status.service.ts:57`). The pull times out because the main process cannot turn the loop within 5 s. One renderer-side defect candidate exists (overlapping pulls, §6), but it is a symptom amplifier, not the cause. |
+
+Remaining mechanism: **backend event-loop starvation**. Confirmed by the
+`[event-loop] lag` run in the same window (§3). Per `libs/backend/vscode-core/CLAUDE.md`
+("Diagnosing a hang"): lag with no matching slow-handler line for the call
+means the block is background work on the main thread.
+
+---
+
+## 3. The starved window (boot 2, 2026-09-10 log)
+
+| Time           | Event                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------- |
+| `15:40:58.850` | RPC surface registered (incl. `boot:getReadiness`).                                   |
+| `15:41:12.046` | `[SessionImporter] Scanning` — starved window starts.                                 |
+| `15:42:50`     | Lag `maxMs 9244.2` — worst sample.                                                    |
+| `15:43:46`     | Lag falls to `687.9` — the run ends.                                                  |
+| `15:43:48.218` | `Import complete: {"imported":0,"fromIndex":0}` — window closes after ~2 min 36 s.    |
+| `15:43:52.720` | `[UserLayerMirror] mirrorAll complete {"skipped":45,…}`.                              |
+| `15:43:52.833` | `[UserLayerMirror] reconcile complete {"noop":25,"fastForwarded":0,"diverged":20,…}`. |
+| `15:43:52.873` | `skill_registry catalog synced {"upserted":45,"linked":1}`.                           |
+
+Key readings:
+
+- The lag run climbs `829.9 → 1193.3 → 3307.2 → … → 9244.2` and falls to
+  `687.9` exactly as the user-layer pass and the catalog sync complete.
+- `p99Ms == maxMs` on the worst samples. The monitor samples every 2 s, so
+  `p99 == max` means the whole 2 s window was blocked.
+- SessionImporter imported **0** and pruned **0**. It was a victim of the
+  congested loop, not a cause: its own work in this boot was an index-file read
+  (file absent → early exit), a 50-file skip-if-exists scan, and an async prune
+  walk with zero deletions.
+
+Boot 1 (earlier boot in the same log): imports ended `23:08:41.750` with
+`imported: 13`, each import spaced 2–4 s; `[RPC] slow handler harness:health
+57880.2ms`; `indexing:getStatus` 24 s. `harness:health` with a cache miss runs
+`reconciler.verify()` — a full `plan()` pass with per-target walks
+(`libs/backend/rpc-handlers/src/lib/harness/health/harness-health-rpc.service.ts:99-136`)
+— which explains the 57.9 s duration and confirms a full plan pass was in
+flight during that boot.
+
+---
+
+## 4. Demonstrated blocking write path: `ElectronStateStorage`
+
+Measured on disk (read-only):
+
+| File                   | Size                              | Notes                                                                                                                                |
+| ---------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `workspace-state.json` | **255.67 MB** (267,412,430 bytes) | 190 keys. `ptah.sessionMetadata` alone = 127.10 MB (685 sessions, largest record 27.33 MB). 186 `ptah.agentOutput:*` keys = 83.8 MB. |
+| `global-state.json`    | 13,963 bytes                      | Cheap. Not a factor.                                                                                                                 |
+| `ptah.sqlite`          | 1.13 GB                           | Synchronous better-sqlite3. See §5.                                                                                                  |
+
+Source: `libs/backend/platform-electron/src/implementations/electron-state-storage.ts`.
+
+- `update(key, value)` (`:28-39`) mutates the in-memory map, then chains
+  `persist()`.
+- `persist()` (`:64-74`) calls `JSON.stringify(this.data, null, 2)` at `:70` —
+  **the entire 190-key, 255.67 MB object**, pretty-printed, before every write.
+  `fsPromises.writeFile` is async, but `JSON.stringify` is synchronous CPU work
+  on the main thread. One write of any key — including a small flag — pays a
+  multi-second stringify of the whole store.
+- `updateSync` (`:41-49`) → `persistSync()` (`:76-82`) is worse:
+  `fs.writeFileSync` of the full serialization, synchronous end to end.
+- `loadSync()` (`:55-62`) runs at construction: `readFileSync` + `JSON.parse`
+  of the whole file. Every `WorkspaceAwareStateStorage.addWorkspace`
+  (`libs/backend/vscode-core/src/services/workspace-aware-state-storage.ts:46-51`)
+  constructs a storage and pays the full parse.
+- `registerStateStorageAdapters`
+  (`libs/backend/vscode-core/src/di/register-storage-shims.ts:113-134`) binds
+  `TOKENS.STORAGE_SERVICE` over this storage, so ordinary workspace-key writes
+  from anywhere in the backend land on this path.
+
+Boot 1 evidence: the 13 session imports were spaced 2–4 s each. Each import
+writes `ptah.sessionMetadata` (127 MB value). Under the current adapter, every
+such flush re-serializes all 255.67 MB. The observed spacing matches the
+expected stringify cost. Boot 2 imported nothing, so in boot 2 the freeze
+shifted to the user-layer reconcile pass and the SQLite catalog sync (§5).
+
+The renderer pull (5 s timeout) cannot win against a loop holding 3–9 s blocks.
+Repeated `boot:getReadiness` timeouts are the direct symptom.
+
+---
+
+## 5. Confirmed synchronous main-thread work remaining on the boot path
+
+### 5.1 Harness reconcile, TARGET side (harness-sync)
+
+TASK_2026_323 made the SOURCE hash walk async
+(`libs/backend/harness-sync/src/lib/hash/content-hash.ts` — `fs/promises`,
+`HASH_BATCH_SIZE = 16`, `setImmediate` yields, `ContentHashOptions.signal`;
+`abort/pass-abort.ts` owns `yieldToEventLoop` and the per-target commit point).
+The user-layer mirror itself is also fully async — no `*Sync` fs call exists in
+`libs/backend/agent-generation/src/lib/services/user-layer/` (grep, non-spec
+files).
+
+The TARGET side did not get the same treatment:
+
+- `libs/backend/harness-sync/src/lib/targets/workspace-target.ts:411` —
+  `content: readFileSync(sourceFile, 'utf-8')` in the copy plan.
+- `workspace-target.ts:919` — `content: readFileSync(write.source, 'utf-8')` in
+  apply.
+- `hashTransformedDirSync` (same file, beside `copyDirectoryTransformed`) — a
+  synchronous directory hash used in the adopt comparison. An async fold
+  (`digestFileMap` in `content-hash.ts`) already exists and the async
+  transformed-dir hash lives in `targets/copy-engine.ts`.
+- `libs/backend/harness-sync/src/lib/targets/claude-target.ts:493,551,566,610,614`
+  — `lstatSync`/`readdirSync`/`readFileSync`.
+- `harness-manifest.builder.ts:389,529` — `readdirSync` one-level listings,
+  documented as a deliberate exception.
+
+Every `mode: 'full'` trigger (activation, folder change, plugin toggle,
+content download) re-hashes targets. The boot-2 detached user-layer pass
+(`reconcile complete` at `15:43:52.833`, `diverged: 20` over ~45 skills ×
+targets) ran through the whole starved window and is the strongest candidate
+for the 3–9.2 s lag bursts.
+
+### 5.2 SQLite catalog sync (skill-synthesis)
+
+`SkillRegistryCatalogService.sync`
+(`libs/backend/skill-synthesis/src/lib/skill-registry-catalog.service.ts:45-89`)
+awaits an async clone list, then performs 45 `registry.upsert` calls.
+`SkillRegistryStore.upsert` (`skill-registry.store.ts:61-63`) is a
+synchronous better-sqlite3 `prepare`/`run` against the 1.13 GB DB. 45 small
+upserts are bounded and cheap individually; they completed at `15:43:52.873`,
+the moment the lag run ended. This is a co-terminator of the user-layer pass,
+not an independent cause.
+
+### 5.3 `quick_check` — already gone
+
+TASK_2026_380's root cause 1 no longer applies:
+`libs/backend/persistence-sqlite/src/lib/sqlite-connection.service.ts` contains
+no `runBootChecks`/`quick_check` on the boot path (grep verified). The
+2026-09-10 freeze is the REMAINING work, not a regression of 380.
+
+---
+
+## 6. Renderer pull contract — verified, with one defect candidate
+
+`libs/frontend/core/src/lib/services/boot-status.service.ts` verified:
+
+- Pull once on construction, then every `DEFAULT_READINESS_RETRY_AFTER_MS`
+  (2000 ms) while `warming` (`:196-201`). Timeout 5000 ms (`:57`).
+- The pull is **mandatory**, not a nicety: the host emits
+  `boot:readinessChanged` at `did-finish-load`, which fires before Angular
+  installs its `message` listener, so the first transition is routinely lost
+  (`:9-14`). This verifies the memory lead "pull recovery is required because
+  pushes before Angular bootstrap can be lost" — it is stated in the source.
+- Monotonic guard: a late pull cannot rewind a newer push (`:175`).
+- The `ready` default is load-bearing for the VS Code host (`:25-31`). No
+  change proposed there — never fake ready, never block the VS Code webview.
+
+**Defect candidate (acceptance: "bound polling/inflight").** The watchdog is
+`setInterval(() => { void this.pullReadiness(); }, 2000)`. It does not await
+and keeps no in-flight flag. While the main process is starved, a pull takes
+the full 5 s timeout, so ticks stack: up to 3 concurrent pulls, ~78 queued RPC
+calls across the 2 min 36 s window. Each call is individually bounded, but the
+cumulative inflight set is not. A single-flight guard (skip the tick while a
+pull is unsettled) fixes this without changing any timeout or faking state.
+
+---
+
+## 7. Verified memory leads
+
+| Lead                                                                                       | Verdict                                                                                                                                                                                                                |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TASK_2026_380 five boot RPCs / `measure-boot-rpcs.mjs`                                     | Exists: `D:/projects/ptah-extension/.ptah/specs/TASK_2026_380/measure-boot-rpcs.{cold,warm,logcapture}.log`. Reusable harness for an isolated slow-boot fixture (inspect/adapt — do not run against the live profile). |
+| 380 root cause 1 (`quick_check`)                                                           | Fixed and landed in this checkout. Not the current freeze.                                                                                                                                                             |
+| 380 root cause 2 (readiness contract unwired)                                              | Since wired: `BootStatusService`, `boot:getReadiness`, `boot:readinessChanged` push all exist and are exercised by `boot-status.service.spec.ts` and `webview-e2e-harness/.../boot-progress.e2e.spec.ts`.              |
+| Boot scan delay keys (`bootScanDelayMs`, `bootScanIdleBackoffMs`, 7-day migration ceiling) | Present (`skill-synthesis` CLAUDE.md, TASK_2026_380).                                                                                                                                                                  |
+| "Pull recovery required"                                                                   | Verified in source, §6.                                                                                                                                                                                                |
+| `NullBootReadinessProvider` overridden                                                     | Verified: `bootstrap.ts` registers `ElectronBootReadinessProvider` last; last registration wins.                                                                                                                       |
+
+---
+
+## 8. Disproven hypotheses
+
+- Handler not registered / transport not ready / handler waiting — §2.
+- `sessions-index.json` parse cost — the file does not exist on this machine.
+- Global state file size — 13,963 bytes.
+- Importer prune deletions — zero deletions logged in both boots.
+- Symbol indexer auto-start — indexing starts from a manual button
+  (`workspace-indexing.component.ts:99`), not at boot.
+- `quick_check` on boot — removed (§5.3).
+- SessionImporter as the boot-2 cause — imported 0, pruned 0; it was a victim.
+
+---
+
+## 9. Attribution limits and unverified items
+
+- **No CPU profile was captured.** Capturing one requires a slow boot while the
+  app runs (`window.ptahDiag.captureCpuProfile(10000)` or
+  `PTAH_PROFILE_ON_LAG_MS`), and the live app must not be restarted under this
+  task's constraints. Per repo doctrine the profile is the definitive
+  attribution tool for background-work lag. The plan therefore contains a
+  profile step, and Fix 1 stands on arithmetic that does not depend on it.
+- §4 is demonstrated by construction (a 255.67 MB `JSON.stringify` on the main
+  thread per key write is synchronous by language semantics). §5.1 is confirmed
+  present in source; its share of the 2026-09-10 window is a correlation
+  (strong: the lag run ends exactly at the pass's completion) until a profile
+  exists.
+- **Installed-bundle vs source mismatch: not checked.** The installed app
+  bundle was not read (install path not confirmed under read-only constraints).
+  The source checkout is the worktree at branch `fix/boot-readiness-timeout`,
+  HEAD `30d37f61c`. If the installed app is older than this source, the
+  observed behavior maps to the installed bundle, not exactly to these line
+  numbers.
+- Renderer paint cost (Angular bootstrap) was not profiled; the boot screen
+  exists and the evidence shows the renderer waited on RPC, not on its own work.
+
+---
+
+## 10. Findings, ranked
+
+1. **`ElectronStateStorage` whole-store re-serialization on every key write**
+   (and whole-store sync parse at load). Demonstrated blocking write path.
+   Fix is minimal and adapter-local — see `implementation-plan.md` Fix 1.
+2. **Synchronous target-side I/O in the harness reconcile full pass**
+   (`workspace-target.ts:411/:919`, `hashTransformedDirSync`,
+   `claude-target.ts` sync reads). Confirmed present; the likely owner of the
+   boot-2 lag bursts. Fix 3, gated on a profile.
+3. **Readiness watchdog can stack overlapping pulls** while the main process is
+   starved. Renderer-side amplifier. Fix 2 (single-flight guard).
+4. Follow-up (out of scope): `ptah.sessionMetadata` at 127 MB in JSON state is
+   a data-model problem; that data belongs in SQLite. Recorded, not planned.

--- a/.ptah/specs/TASK_2026_415/task.md
+++ b/.ptah/specs/TASK_2026_415/task.md
@@ -1,0 +1,23 @@
+---
+id: TASK_2026_415
+status: in_progress
+type: BUGFIX
+title: Investigate boot readiness RPC timeout and startup freeze
+depends_on: []
+created: '2026-09-10T16:16:02.872Z'
+updated: '2026-09-10T16:16:19.699Z'
+description: >-
+  Trace repeated boot:getReadiness timeouts and reported initial-load UI freeze,
+  identify the cause and define a regression-tested fix independent of
+  compaction.
+executor: ollama cloud
+estimate: M
+relates_to:
+  - TASK_2026_414
+---
+
+<!-- Ptah carrier: machine-owned metadata. Ptah rewrites the frontmatter above. Do NOT write prose here — prose belongs in ./context.md. -->
+
+Trace repeated boot:getReadiness timeouts and reported initial-load UI freeze, identify the cause and define a regression-tested fix independent of compaction.
+
+Full context, plan and discussion live in [./context.md](./context.md).

--- a/libs/backend/agent-sdk/src/lib/helpers/stream-transformer.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/stream-transformer.spec.ts
@@ -193,6 +193,36 @@ function messageStart(
   } as unknown as SDKMessage;
 }
 
+// Final message_delta of an API turn. Fields left undefined here are ABSENT
+// from the emitted usage object (not zero) — absence is the case the
+// retain-last-known rule must distinguish from an explicit 0.
+function messageDelta(usage: {
+  input_tokens?: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+}): SDKMessage {
+  return {
+    type: 'stream_event',
+    event: {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn', stop_sequence: null },
+      usage: {
+        ...(usage.input_tokens !== undefined
+          ? { input_tokens: usage.input_tokens }
+          : {}),
+        output_tokens: usage.output_tokens,
+        ...(usage.cache_read_input_tokens !== undefined
+          ? { cache_read_input_tokens: usage.cache_read_input_tokens }
+          : {}),
+        ...(usage.cache_creation_input_tokens !== undefined
+          ? { cache_creation_input_tokens: usage.cache_creation_input_tokens }
+          : {}),
+      },
+    },
+  } as unknown as SDKMessage;
+}
+
 function systemInit(mcpServers: unknown, sessionId = 'sess-1'): SDKMessage {
   return {
     type: 'system',
@@ -213,7 +243,12 @@ function compactBoundary(): SDKMessage {
 
 function resultMessage(
   model: string,
-  usage: { inputTokens: number; outputTokens: number },
+  usage: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadInputTokens?: number;
+    cacheCreationInputTokens?: number;
+  },
 ): SDKMessage {
   return {
     type: 'result',
@@ -227,15 +262,15 @@ function resultMessage(
     usage: {
       input_tokens: usage.inputTokens,
       output_tokens: usage.outputTokens,
-      cache_read_input_tokens: 0,
-      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: usage.cacheReadInputTokens ?? 0,
+      cache_creation_input_tokens: usage.cacheCreationInputTokens ?? 0,
     },
     modelUsage: {
       [model]: {
         inputTokens: usage.inputTokens,
         outputTokens: usage.outputTokens,
-        cacheReadInputTokens: 0,
-        cacheCreationInputTokens: 0,
+        cacheReadInputTokens: usage.cacheReadInputTokens ?? 0,
+        cacheCreationInputTokens: usage.cacheCreationInputTokens ?? 0,
         contextWindow: 200000,
         costUSD: 0,
       },
@@ -403,6 +438,358 @@ describe('StreamTransformer — lastTurnContextTokens (TASK_2026_109_FOLLOWUP)',
     // Only the second message_start's tokens count: 100 + 50 = 150.
     // If the map leaked / accumulated, we'd see 1500 (1000+500) or 1650.
     expect(captured[0][0].lastTurnContextTokens).toBe(150);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TASK_2026_408 phase 2 — usage-to-stats integration regressions.
+//
+// These pin the producer side of the context gauge: whatever usage a
+// provider's message_start carries must reach `onResultStats` untouched,
+// and the turn's context fill (lastTurnContextTokens) must stay distinct
+// from the turn's cumulative token total. The frontend's
+// `deriveLiveModelStats` (pinned in its own spec) renders exactly this
+// payload; the gauge cannot be more honest than what leaves this seam.
+// ---------------------------------------------------------------------------
+
+describe('StreamTransformer — usage-to-stats flow (TASK_2026_408)', () => {
+  interface StatsCapture {
+    cost: number | null;
+    // Matches the payload's `MessageTokenUsage`: cache fields are optional
+    // upstream, so the capture type must accept their absence too.
+    tokens: {
+      input: number;
+      output: number;
+      cacheRead?: number;
+      cacheCreation?: number;
+    };
+    modelUsage?: ResultModelUsage[];
+  }
+
+  function captureStats(): {
+    captured: StatsCapture[];
+    onResultStats: (stats: StatsCapture) => void;
+  } {
+    const captured: StatsCapture[] = [];
+    return {
+      captured,
+      onResultStats: (stats) => {
+        captured.push({
+          cost: stats.cost,
+          tokens: stats.tokens,
+          modelUsage: stats.modelUsage,
+        });
+      },
+    };
+  }
+
+  it('carries input 30 / cacheRead 12 / output 9 through to the stats payload', async () => {
+    const { transformer } = makeHarness();
+    const { captured, onResultStats } = captureStats();
+
+    const messages: SDKMessage[] = [
+      // Direct-Anthropic shape: message_start already carries the real
+      // prompt size. (Proxied providers send synthetic zeros here and the
+      // real numbers in the final message_delta — covered by the Gap 1
+      // describe below.)
+      messageStart(MODEL, {
+        input_tokens: 30,
+        cache_read_input_tokens: 12,
+      }),
+      resultMessage(MODEL, {
+        inputTokens: 30,
+        outputTokens: 9,
+        cacheReadInputTokens: 12,
+      }),
+    ];
+
+    await drain(
+      transformer.transform({
+        sdkQuery: asAsyncIterable(messages),
+        sessionId: 'sess-1' as SessionId,
+        initialModel: MODEL,
+        onResultStats,
+      }),
+    );
+
+    expect(captured).toHaveLength(1);
+    // Cumulative turn totals: 30 + 9 + 12 = 51.
+    expect(captured[0].tokens).toEqual({
+      input: 30,
+      output: 9,
+      cacheRead: 12,
+      cacheCreation: 0,
+    });
+    const row = captured[0].modelUsage?.[0];
+    expect(row).toBeDefined();
+    expect(row?.cacheReadInputTokens).toBe(12);
+    // Context fill of THIS turn (30 uncached + 12 cached) must stay distinct
+    // from the cumulative total (51): mixing them up is what produces
+    // ">100% full" headers after a few turns.
+    expect(row?.lastTurnContextTokens).toBe(42);
+  });
+
+  it('treats an explicit-zero message_start as a real reading (0, not undefined)', async () => {
+    const { transformer } = makeHarness();
+    const { captured, onResultStats } = captureStats();
+
+    await drain(
+      transformer.transform({
+        sdkQuery: asAsyncIterable([
+          // input_tokens: 0 is an answer ("this prompt was fully billed as
+          // cache"), not an absence. `deriveLiveModelStats` renders 0 as a
+          // valid gauge reading; only undefined falls back to cumulative.
+          messageStart(MODEL, { input_tokens: 0, cache_read_input_tokens: 0 }),
+          resultMessage(MODEL, { inputTokens: 0, outputTokens: 5 }),
+        ]),
+        sessionId: 'sess-1' as SessionId,
+        initialModel: MODEL,
+        onResultStats,
+      }),
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].modelUsage?.[0].lastTurnContextTokens).toBe(0);
+  });
+
+  it('emits lastTurnContextTokens undefined when no message_start reported usage for the model', async () => {
+    const { transformer } = makeHarness();
+    const { captured, onResultStats } = captureStats();
+
+    await drain(
+      transformer.transform({
+        sdkQuery: asAsyncIterable([
+          // No message_start at all — the frontend must fall back to the
+          // cumulative tokens (and suppress the fill post-compaction).
+          resultMessage(MODEL, { inputTokens: 100, outputTokens: 20 }),
+        ]),
+        sessionId: 'sess-1' as SessionId,
+        initialModel: MODEL,
+        onResultStats,
+      }),
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(
+      captured[0].modelUsage?.[0].lastTurnContextTokens,
+    ).toBeUndefined();
+  });
+
+  it('derives identical token stats for direct Anthropic and proxied providers (usage is provider-neutral)', async () => {
+    // Same stream shape under two auth environments. Only cost sourcing is
+    // allowed to differ; token and context accounting must not.
+    const run = async (authEnv: AuthEnv): Promise<StatsCapture> => {
+      const { transformer } = makeHarness(authEnv);
+      const { captured, onResultStats } = captureStats();
+      await drain(
+        transformer.transform({
+          sdkQuery: asAsyncIterable([
+            messageStart(MODEL, {
+              input_tokens: 30,
+              cache_read_input_tokens: 12,
+            }),
+            resultMessage(MODEL, {
+              inputTokens: 30,
+              outputTokens: 9,
+              cacheReadInputTokens: 12,
+            }),
+          ]),
+          sessionId: 'sess-1' as SessionId,
+          initialModel: MODEL,
+          onResultStats,
+        }),
+      );
+      expect(captured).toHaveLength(1);
+      return captured[0];
+    };
+
+    const direct = await run(
+      makeAuthEnv({ ANTHROPIC_BASE_URL: 'https://api.anthropic.com' }),
+    );
+    const proxied = await run(
+      makeAuthEnv({ ANTHROPIC_BASE_URL: 'https://openrouter.ai/api/v1' }),
+    );
+
+    expect(proxied.tokens).toEqual(direct.tokens);
+    expect(proxied.modelUsage?.[0].inputTokens).toBe(
+      direct.modelUsage?.[0].inputTokens,
+    );
+    expect(proxied.modelUsage?.[0].cacheReadInputTokens).toBe(
+      direct.modelUsage?.[0].cacheReadInputTokens,
+    );
+    expect(proxied.modelUsage?.[0].lastTurnContextTokens).toBe(
+      direct.modelUsage?.[0].lastTurnContextTokens,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TASK_2026_408 Gap 1 — message_delta usage in the context tracker.
+//
+// Proxied providers (Codex/OpenRouter via the responses translation proxy)
+// emit message_start with SYNTHETIC ZERO usage and the real input/cache
+// numbers only in the FINAL message_delta. Before the fix the tracker read
+// message_start alone, so the gauge stayed pinned at 0% for every proxied
+// session. Direct Anthropic semantics must survive the fix: its deltas are
+// output-only, and such a delta must NOT reset input/cache.
+// ---------------------------------------------------------------------------
+
+describe('StreamTransformer — message_delta context tracking (TASK_2026_408 Gap 1)', () => {
+  function capture(): {
+    captured: ResultModelUsage[][];
+    onResultStats: (stats: { modelUsage?: ResultModelUsage[] }) => void;
+  } {
+    const captured: ResultModelUsage[][] = [];
+    return {
+      captured,
+      onResultStats: (stats) => {
+        if (stats.modelUsage) captured.push(stats.modelUsage);
+      },
+    };
+  }
+
+  async function run(messages: SDKMessage[]): Promise<ResultModelUsage[][]> {
+    const cap = capture();
+    const { transformer } = makeHarness();
+    await drain(
+      transformer.transform({
+        sdkQuery: asAsyncIterable(messages),
+        sessionId: 'sess-1' as SessionId,
+        initialModel: MODEL,
+        onResultStats: cap.onResultStats,
+      }),
+    );
+    return cap.captured;
+  }
+
+  it('ACTUAL proxy sequence: synthetic-zero message_start, real usage in the final message_delta → 42', async () => {
+    const captured = await run([
+      // What the responses translation proxy actually emits: message_start
+      // usage is {input_tokens: 0, output_tokens: 0} (synthetic), and the
+      // real numbers arrive only in the delta. Injecting correct usage
+      // directly into message_start (the phase-2 tests above) does NOT
+      // reproduce this bug.
+      messageStart(MODEL, { input_tokens: 0 }),
+      messageDelta({
+        input_tokens: 30,
+        output_tokens: 9,
+        cache_read_input_tokens: 12,
+      }),
+      resultMessage(MODEL, { inputTokens: 30, outputTokens: 9, cacheReadInputTokens: 12 }),
+    ]);
+
+    expect(captured).toHaveLength(1);
+    // 30 input + 12 cache_read — the turn's real context fill. Cumulative
+    // output (9) is NOT part of the context, per the tracker's contract.
+    expect(captured[0][0].lastTurnContextTokens).toBe(42);
+  });
+
+  it('true translateResponsesUsage split: delta input 18 + cache_read 12 → 30 (inclusive input, cache separated)', async () => {
+    const captured = await run([
+      // translateResponsesUsage maps OpenAI's INCLUSIVE input 30 with 12
+      // cached to Anthropic shape: input_tokens 18 + cache_read 12. The
+      // context fill is the sum, 30 — the same total the inclusive input
+      // described.
+      messageStart(MODEL, { input_tokens: 0 }),
+      messageDelta({
+        input_tokens: 18,
+        output_tokens: 9,
+        cache_read_input_tokens: 12,
+      }),
+      resultMessage(MODEL, { inputTokens: 18, outputTokens: 9, cacheReadInputTokens: 12 }),
+    ]);
+
+    expect(captured[0][0].lastTurnContextTokens).toBe(30);
+  });
+
+  it('direct Anthropic output-only delta does NOT reset the message_start context', async () => {
+    const captured = await run([
+      messageStart(MODEL, {
+        input_tokens: 5000,
+        cache_read_input_tokens: 1000,
+      }),
+      // Direct Anthropic message_delta usage carries only the running
+      // output count. Absent input/cache fields must retain the start's
+      // 5000 + 1000 — zeroing them here is the regression this guards.
+      messageDelta({ output_tokens: 9 }),
+      resultMessage(MODEL, { inputTokens: 5000, outputTokens: 9, cacheReadInputTokens: 1000 }),
+    ]);
+
+    expect(captured[0][0].lastTurnContextTokens).toBe(6000);
+  });
+
+  it('an explicit zero in the delta REPLACES the start context (a real reading, not absence)', async () => {
+    const captured = await run([
+      messageStart(MODEL, {
+        input_tokens: 5000,
+        cache_read_input_tokens: 1000,
+      }),
+      // Explicit 0 fields are readings ("the prompt was fully cache-billed
+      // / shrunk"), not absences — `??` semantics: only null/undefined skip.
+      messageDelta({
+        input_tokens: 0,
+        output_tokens: 9,
+        cache_read_input_tokens: 0,
+      }),
+      resultMessage(MODEL, { inputTokens: 0, outputTokens: 9 }),
+    ]);
+
+    expect(captured[0][0].lastTurnContextTokens).toBe(0);
+  });
+
+  it('repeated cumulative deltas REPLACE, they do not add', async () => {
+    const captured = await run([
+      messageStart(MODEL, { input_tokens: 0 }),
+      messageDelta({
+        input_tokens: 30,
+        output_tokens: 5,
+        cache_read_input_tokens: 12,
+      }),
+      // Same turn, a later cumulative frame. If the tracker ADDED, this
+      // would read 42 + 44 = 86; replacing reads 44.
+      messageDelta({
+        input_tokens: 31,
+        output_tokens: 9,
+        cache_read_input_tokens: 13,
+      }),
+      resultMessage(MODEL, { inputTokens: 31, outputTokens: 9, cacheReadInputTokens: 13 }),
+    ]);
+
+    expect(captured[0][0].lastTurnContextTokens).toBe(44);
+  });
+
+  it('multi-turn: a later message_start REPLACES delta-carried values (no leak across turns)', async () => {
+    const captured = await run([
+      messageStart(MODEL, { input_tokens: 0 }),
+      messageDelta({
+        input_tokens: 30,
+        output_tokens: 9,
+        cache_read_input_tokens: 12,
+      }),
+      // Turn 2: a fresh API request. Its message_start carries turn 2's
+      // real prompt and must fully replace turn 1's delta numbers.
+      messageStart(MODEL, {
+        input_tokens: 200,
+        cache_read_input_tokens: 50,
+      }),
+      resultMessage(MODEL, { inputTokens: 200, outputTokens: 5, cacheReadInputTokens: 50 }),
+    ]);
+
+    expect(captured[0][0].lastTurnContextTokens).toBe(250);
+  });
+
+  it('a message_delta with no preceding message_start is ignored (no model to attribute it to)', async () => {
+    const captured = await run([
+      messageDelta({
+        input_tokens: 30,
+        output_tokens: 9,
+        cache_read_input_tokens: 12,
+      }),
+      resultMessage(MODEL, { inputTokens: 30, outputTokens: 9 }),
+    ]);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0][0].lastTurnContextTokens).toBeUndefined();
   });
 });
 

--- a/libs/backend/agent-sdk/src/lib/helpers/stream-transformer.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/stream-transformer.ts
@@ -31,6 +31,7 @@ import {
   isSystemInit,
   isStreamEvent,
   isMessageStart,
+  isMessageDelta,
   isCompactBoundary,
   isLocalCommandOutput,
   isTaskStarted,
@@ -71,10 +72,15 @@ export interface ResultModelUsage {
   /** Cache read input tokens for this model (cumulative across all turns) */
   cacheReadInputTokens: number;
   /**
-   * Current context fill from the last API turn (input + cache_read tokens).
-   * Unlike the cumulative inputTokens/cacheReadInputTokens, this represents
-   * the actual prompt size sent on the most recent turn — i.e., the real
-   * context window fill level. Undefined if no message_start was captured.
+   * Current context fill from the last API turn (input + cache_read +
+   * cache_creation tokens). Unlike the cumulative
+   * inputTokens/cacheReadInputTokens, this represents the actual prompt size
+   * sent on the most recent turn — i.e., the real context window fill level.
+   * Written from `message_start` usage and replaced by the final
+   * `message_delta` usage when the delta carries input/cache numbers (proxied
+   * providers send only synthetic zeros in `message_start` and the real
+   * numbers in the delta). Excludes cumulative output. Undefined if no usage
+   * was captured for the model.
    */
   lastTurnContextTokens?: number;
 }
@@ -284,7 +290,19 @@ export class StreamTransformer {
         let sdkMessageCount = 0;
         let yieldedEventCount = 0;
         let effectiveSessionId = sessionId;
-        const lastTurnContextByModel = new Map<string, number>();
+        // Per-component last-turn context, keyed by model. message_start
+        // REPLACES all three components; the final message_delta REPLACES only
+        // the components it carries (`??` skips null/undefined only, so an
+        // explicit 0 is a real reading and an absent field keeps the last
+        // known value). Components are stored separately so an output-only
+        // delta — the direct Anthropic shape — cannot zero input/cache.
+        const lastTurnContextByModel = new Map<
+          string,
+          { input: number; cacheRead: number; cacheCreation: number }
+        >();
+        // message_delta carries no model, so the tracker remembers the model
+        // of the message_start it belongs to.
+        let currentStreamModel: string | null = null;
         let loggedEagerMcpTools = false;
 
         // Arm the no-activity watchdog before consuming the stream. It fires
@@ -304,13 +322,45 @@ export class StreamTransformer {
               if (isMessageStart(event)) {
                 const model = event.message.model;
                 const turnUsage = event.message.usage;
+                currentStreamModel = model ?? null;
                 if (model && turnUsage) {
-                  lastTurnContextByModel.set(
-                    model,
-                    (turnUsage.input_tokens ?? 0) +
-                      (turnUsage.cache_read_input_tokens ?? 0) +
-                      (turnUsage.cache_creation_input_tokens ?? 0),
-                  );
+                  lastTurnContextByModel.set(model, {
+                    input: turnUsage.input_tokens ?? 0,
+                    cacheRead: turnUsage.cache_read_input_tokens ?? 0,
+                    cacheCreation: turnUsage.cache_creation_input_tokens ?? 0,
+                  });
+                }
+              } else if (isMessageDelta(event)) {
+                // Proxied providers (Codex/OpenRouter via the responses
+                // translation proxy) emit message_start with synthetic zero
+                // usage and the real input/cache numbers ONLY in the final
+                // message_delta. Read them here so the context gauge tracks
+                // the real prompt size. `MessageDeltaEvent.usage` is typed
+                // output-only because direct Anthropic deltas normally are,
+                // so read the optional input/cache fields through the same
+                // widened structural cast as
+                // stream-event.transformer's onMessageDelta.
+                const model = currentStreamModel;
+                const previous = model
+                  ? lastTurnContextByModel.get(model)
+                  : undefined;
+                const usage = (
+                  event as {
+                    usage?: {
+                      input_tokens?: number;
+                      cache_read_input_tokens?: number;
+                      cache_creation_input_tokens?: number;
+                    };
+                  }
+                ).usage;
+                if (model && previous && usage) {
+                  lastTurnContextByModel.set(model, {
+                    input: usage.input_tokens ?? previous.input,
+                    cacheRead: usage.cache_read_input_tokens ?? previous.cacheRead,
+                    cacheCreation:
+                      usage.cache_creation_input_tokens ??
+                      previous.cacheCreation,
+                  });
                 }
               }
             }
@@ -401,6 +451,7 @@ export class StreamTransformer {
                     }
                     const knownContextWindow =
                       getModelContextWindow(resolvedModel);
+                    const trackedContext = lastTurnContextByModel.get(model);
                     modelUsageList.push({
                       model: resolvedModel,
                       inputTokens: usage.inputTokens,
@@ -411,8 +462,11 @@ export class StreamTransformer {
                           : knownContextWindow,
                       costUSD,
                       cacheReadInputTokens: usage.cacheReadInputTokens ?? 0,
-                      lastTurnContextTokens:
-                        lastTurnContextByModel.get(model) ?? undefined,
+                      lastTurnContextTokens: trackedContext
+                        ? trackedContext.input +
+                          trackedContext.cacheRead +
+                          trackedContext.cacheCreation
+                        : undefined,
                     });
                   }
                   if (modelUsageList.length > 1) {

--- a/libs/backend/auth-providers/src/lib/translation/responses-stream-collector.spec.ts
+++ b/libs/backend/auth-providers/src/lib/translation/responses-stream-collector.spec.ts
@@ -21,6 +21,39 @@ function harness() {
 }
 
 describe('collectResponsesStream', () => {
+  it('contains malformed terminal usage and cleans up the stream', async () => {
+    const h = harness();
+    const assertion = expect(h.result).rejects.toThrow('Invalid Responses event stream');
+    h.upstream.end(frame('response.completed', { ...snapshot,
+      usage: { input_tokens: 'private-upstream-value', output_tokens: 9 } }));
+    await assertion;
+    expect(h.upstream.destroyed).toBe(true);
+    expect(h.downstream.listenerCount('close')).toBe(0);
+  });
+  it.each([
+    [undefined, 42, undefined],
+    [{}, 42, undefined],
+    [{ cached_tokens: 0 }, 42, 0],
+    [{ cached_tokens: 12 }, 30, 12],
+    [{ cached_tokens: 99 }, 0, 42],
+  ])('preserves bounded input/cache accounting %j', async (details, input, cache) => {
+    const h = harness();
+    h.upstream.end(frame('response.completed', { ...snapshot, usage: {
+      input_tokens: 42, output_tokens: 9, input_tokens_details: details,
+      output_tokens_details: { reasoning_tokens: 7 },
+    } }));
+    expect((await h.result)['usage']).toEqual({ input_tokens: input, output_tokens: 9,
+      ...(cache !== undefined ? { cache_read_input_tokens: cache } : {}) });
+  });
+
+  it('forwards usage on valid max-output incomplete responses', async () => {
+    const h = harness();
+    h.upstream.end(frame('response.incomplete', { ...snapshot, status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      usage: { input_tokens: 42, output_tokens: 9, input_tokens_details: { cached_tokens: 12 } } }));
+    expect(await h.result).toMatchObject({ stop_reason: 'max_tokens',
+      usage: { input_tokens: 30, cache_read_input_tokens: 12, output_tokens: 9 } });
+  });
   it.each(['\r', '\r\n', '\n'])('accepts complete byte-split delimiter %j at EOF', async (delimiter) => {
     const h = harness();
     for (const char of frame('response.completed').replace(/\r\n/g, delimiter)) h.upstream.write(char);

--- a/libs/backend/auth-providers/src/lib/translation/responses-stream-collector.ts
+++ b/libs/backend/auth-providers/src/lib/translation/responses-stream-collector.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { z } from 'zod';
-import { MAX_BODY_SIZE } from './translation-proxy-helpers';
+import { MAX_BODY_SIZE, translateResponsesUsage } from './translation-proxy-helpers';
 
 export class ResponsesStreamError extends Error {
   constructor(public readonly code: 'payload_too_large' | 'upstream_incomplete') {
@@ -188,13 +188,7 @@ export function collectResponsesStream(
           id: `msg_${requestId}`, type: 'message', role: 'assistant', model, content,
           stop_reason: responseStopReason(response, content),
           stop_sequence: null,
-          usage: {
-            input_tokens: Math.max(0, (response.usage?.input_tokens ?? 0) -
-              (response.usage?.input_tokens_details?.cached_tokens ?? 0)),
-            output_tokens: response.usage?.output_tokens ?? 0,
-            ...(response.usage?.input_tokens_details?.cached_tokens !== undefined
-              ? { cache_read_input_tokens: response.usage.input_tokens_details.cached_tokens } : {}),
-          },
+          usage: translateResponsesUsage(response.usage),
         });
       } catch (error: unknown) {
         fail(error instanceof ResponsesStreamError ? error : new Error('Incomplete or invalid Responses stream'));

--- a/libs/backend/auth-providers/src/lib/translation/responses-stream-translator.spec.ts
+++ b/libs/backend/auth-providers/src/lib/translation/responses-stream-translator.spec.ts
@@ -25,6 +25,8 @@
  *   `libs/backend/agent-sdk/src/lib/openai-translation/responses-stream-translator.ts`
  */
 
+import { translateResponsesUsage } from './translation-proxy-helpers';
+import { MessageStream } from '@anthropic-ai/sdk/lib/MessageStream';
 import { ResponsesStreamTranslator } from './responses-stream-translator';
 
 // ---------------------------------------------------------------------------
@@ -60,6 +62,114 @@ function parseAll(sseArray: readonly string[]): ParsedEvent[] {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe('ResponsesStreamTranslator — final usage', () => {
+  it.each([undefined, null, {}])('defaults missing usage %j without inventing cache', (usage) => {
+    expect(translateResponsesUsage(usage)).toEqual({ input_tokens: 0, output_tokens: 0 });
+  });
+  it.each([
+    { input_tokens: -1 }, { output_tokens: -1 },
+    { input_tokens_details: { cached_tokens: -1 } },
+    { input_tokens: '42' }, { input_tokens: Infinity },
+  ])('rejects malformed usage %j at the boundary', (usage) => {
+    expect(() => translateResponsesUsage(usage)).toThrow();
+  });
+  it.each([-1, 'private-upstream-value', null])('terminates malformed completed usage %j safely', async (input) => {
+    const t = new ResponsesStreamTranslator('m', 'invalid');
+    const initial = t.getInitialEvents();
+    const output = t.processChunk(responsesSse('response.completed', {
+      response: { usage: { input_tokens: input, output_tokens: 9 } },
+    }));
+    expect(parseAll(output)).toEqual([{ event: 'error', data: {
+      type: 'error', error: { type: 'api_error', message: 'Invalid upstream Responses usage' },
+    } }]);
+    expect(t.processChunk('data: [DONE]\n\n' +
+      responsesSse('response.completed', { response: { usage: { input_tokens: 42 } } }) +
+      responsesSse('response.output_text.delta', { delta: 'must not appear' }) +
+      responsesSse('response.output_item.added', { output_index: 0,
+        item: { type: 'function_call', call_id: 'call', name: 'read_file' } }) +
+      responsesSse('response.function_call_arguments.delta', { output_index: 0, delta: '{}' }) +
+      responsesSse('response.output_item.done', { output_index: 0,
+        item: { type: 'function_call', call_id: 'call', name: 'read_file', arguments: '{}' } }),
+    )).toEqual([]);
+    const wire = [initial, ...output].map((event) =>
+      JSON.stringify(parseAnthropicSse(event).data)).join('\n') + '\n';
+    const readable = new ReadableStream<Uint8Array>({ start(controller) {
+      controller.enqueue(new TextEncoder().encode(wire));
+      controller.close();
+    } });
+    // This SDK entry point ingests decoded events (not the HTTP SSE error
+    // parser). It must reject an errored stream, never return a final message.
+    await expect(MessageStream.fromReadableStream(readable).finalMessage())
+      .rejects.toThrow('stream ended without producing a Message');
+  });
+
+  it('installed Anthropic SDK accumulator consumes final input/cache updates', async () => {
+    const t = new ResponsesStreamTranslator('m', 'sdk-usage');
+    const events = [t.getInitialEvents(), ...t.processChunk(
+      responsesSse('response.output_text.delta', { delta: 'hello' }) +
+      responsesSse('response.completed', { response: { usage: {
+        input_tokens: 42, input_tokens_details: { cached_tokens: 12 }, output_tokens: 9,
+      } } }),
+    )];
+    // SDK fromReadableStream expects newline-delimited JSON events, not SSE.
+    // Use its real accumulator; no model, transport mock, or credentials involved.
+    const wire = events.map((event) => JSON.stringify(parseAnthropicSse(event).data)).join('\n') + '\n';
+    const readable = new ReadableStream<Uint8Array>({ start(controller) {
+      controller.enqueue(new TextEncoder().encode(wire));
+      controller.close();
+    } });
+    const message = await MessageStream.fromReadableStream(readable).finalMessage();
+    expect(message.usage).toMatchObject({ input_tokens: 30, cache_read_input_tokens: 12, output_tokens: 9 });
+    expect(message.content).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+  it.each([
+    [undefined, 42, undefined],
+    [{}, 42, undefined],
+    [{ cached_tokens: 0 }, 42, 0],
+    [{ cached_tokens: 12 }, 30, 12],
+    [{ cached_tokens: 99 }, 0, 42],
+  ])('separates input/cache for details %j', (details, input, cache) => {
+    const t = new ResponsesStreamTranslator('m', 'usage');
+    const events = parseAll(t.processChunk(responsesSse('response.completed', {
+      response: { usage: { input_tokens: 42, output_tokens: 9,
+        input_tokens_details: details, output_tokens_details: { reasoning_tokens: 7 } } },
+    })));
+    expect(events.find((event) => event.event === 'message_delta')?.data['usage']).toEqual({
+      input_tokens: input, output_tokens: 9,
+      ...(cache !== undefined ? { cache_read_input_tokens: cache } : {}),
+    });
+    expect(t.processChunk(responsesSse('response.completed', {
+      response: { usage: { input_tokens: 999, output_tokens: 999 } },
+    }))).toEqual([]);
+  });
+
+  it('keeps usage scoped to each tool turn', () => {
+    for (const cached of [12, 30]) {
+      const t = new ResponsesStreamTranslator('m', `turn-${cached}`);
+      t.processChunk(responsesSse('response.output_item.added', {
+        output_index: 0, item: { type: 'function_call', call_id: 'call', name: 'read_file' },
+      }));
+      const events = parseAll(t.processChunk(responsesSse('response.completed', {
+        response: { usage: { input_tokens: 42, output_tokens: 9,
+          input_tokens_details: { cached_tokens: cached } } },
+      })));
+      expect(events.find((event) => event.event === 'message_delta')?.data).toMatchObject({
+        delta: { stop_reason: 'tool_use' },
+        usage: { input_tokens: 42 - cached, cache_read_input_tokens: cached, output_tokens: 9 },
+      });
+    }
+  });
+
+  it.each(['response.failed', 'error', 'response.incomplete'])(
+    'does not publish successful usage from unsupported terminal %s', (type) => {
+      const t = new ResponsesStreamTranslator('m', 'terminal');
+      expect(t.processChunk(responsesSse(type, {
+        response: { usage: { input_tokens: 42, output_tokens: 9 } },
+      }))).toEqual([]);
+    },
+  );
+});
 
 describe('ResponsesStreamTranslator — initial framing', () => {
   it('getInitialEvents() emits a message_start with the model, request id and zero usage', () => {

--- a/libs/backend/auth-providers/src/lib/translation/responses-stream-translator.ts
+++ b/libs/backend/auth-providers/src/lib/translation/responses-stream-translator.ts
@@ -22,6 +22,8 @@
  * Follows the same patterns as OpenAIResponseTranslator in response-translator.ts.
  */
 
+import { translateResponsesUsage } from './translation-proxy-helpers';
+
 /**
  * Format a single Anthropic SSE event string.
  * Format: `event: <type>\ndata: <json>\n\n`
@@ -70,6 +72,7 @@ interface ResponsesCompletedData {
     input_tokens?: number;
     output_tokens?: number;
     total_tokens?: number;
+    input_tokens_details?: { cached_tokens?: number } | null;
   };
 }
 
@@ -120,11 +123,8 @@ export class ResponsesStreamTranslator {
   /** Whether any tool calls (function_call items) were emitted during this stream */
   private hadToolCalls = false;
 
-  /** Accumulated input token count */
-  private inputTokens = 0;
-
-  /** Accumulated output token count */
-  private outputTokens = 0;
+  /** Final cumulative usage; upstream reports input/cache only at completion. */
+  private usage = translateResponsesUsage(undefined);
 
   /** Buffer for incomplete SSE lines across chunks */
   private lineBuffer = '';
@@ -220,6 +220,7 @@ export class ResponsesStreamTranslator {
     eventType: string,
     event: ResponsesStreamEvent,
   ): string[] {
+    if (this.finalized) return [];
     switch (eventType) {
       case 'response.output_text.delta':
         return this.handleTextDelta(event);
@@ -451,9 +452,19 @@ export class ResponsesStreamTranslator {
 
     const response = event.response;
 
-    if (response?.usage) {
-      this.inputTokens = response.usage.input_tokens ?? this.inputTokens;
-      this.outputTokens = response.usage.output_tokens ?? this.outputTokens;
+    try {
+      this.usage = translateResponsesUsage(response?.usage);
+    } catch (error: unknown) {
+      // Completion runs inside an HTTP data listener: validation errors must not
+      // escape as uncaught exceptions or allow a later sentinel to claim success.
+      void error;
+      this.finalized = true;
+      this.activeToolCalls.clear();
+      this.inTextBlock = false;
+      return [sseEvent('error', {
+        type: 'error',
+        error: { type: 'api_error', message: 'Invalid upstream Responses usage' },
+      })];
     }
 
     return this.emitFinalEvents();
@@ -493,7 +504,7 @@ export class ResponsesStreamTranslator {
       sseEvent('message_delta', {
         type: 'message_delta',
         delta: { stop_reason: stopReason, stop_sequence: null },
-        usage: { output_tokens: this.outputTokens },
+        usage: this.usage,
       }),
     );
     events.push(sseEvent('message_stop', { type: 'message_stop' }));

--- a/libs/backend/auth-providers/src/lib/translation/translation-proxy-base.spec.ts
+++ b/libs/backend/auth-providers/src/lib/translation/translation-proxy-base.spec.ts
@@ -51,6 +51,10 @@ class FakeTranslationProxy extends TranslationProxyBase {
    * subclasses' shape (id known only at construction) is exercised here too.
    */
   public providerId = 'fake-provider';
+  public useResponsesApi = false;
+  protected override shouldUseResponsesApi(): boolean {
+    return this.useResponsesApi;
+  }
   public readonly getApiEndpointMock = jest.fn(
     async () => 'http://127.0.0.1:1', // intentionally-unreachable port for forwarding tests
   );
@@ -315,6 +319,72 @@ const MESSAGES_BODY = JSON.stringify({
   max_tokens: 16,
   stream: false,
   messages: [{ role: 'user', content: 'hi' }],
+});
+
+describe('TranslationProxyBase — Responses JSON usage', () => {
+  it.each([false, true])('contains malformed usage over HTTP (stream=%s)', async (stream) => {
+    const upstream = await startUpstream((_req, res) => {
+      const response = { status: 'completed', output: [],
+        usage: { input_tokens: 'private-upstream-value', output_tokens: 9 } };
+      res.writeHead(200, { 'Content-Type': stream ? 'text/event-stream' : 'application/json' });
+      res.end(stream
+        ? `data: ${JSON.stringify({ type: 'response.completed', response })}\n\ndata: [DONE]\n\n`
+        : JSON.stringify(response));
+    });
+    const h = await startProxy();
+    h.proxy.useResponsesApi = true;
+    h.proxy.getApiEndpointMock.mockResolvedValue(upstream.origin);
+    try {
+      const result = await request(`${h.url}/v1/messages`, {
+        method: 'POST', body: JSON.stringify({ ...JSON.parse(MESSAGES_BODY), stream }),
+      });
+      expect(result.body).not.toContain('private-upstream-value');
+      if (stream) {
+        expect(result.status).toBe(200);
+        expect(result.body).toContain('Invalid upstream Responses usage');
+        expect(result.body).not.toContain('message_stop');
+        expect(result.body).not.toContain('message_delta');
+      } else {
+        expect(result.status).toBe(500);
+        expect(JSON.parse(result.body)).toEqual({ type: 'error', error: {
+          type: 'api_error', message: 'Failed to translate Fake response',
+        } });
+      }
+    } finally {
+      await h.stop();
+      await upstream.close();
+    }
+  });
+  it.each([
+    [undefined, 42, undefined],
+    [{}, 42, undefined],
+    [{ cached_tokens: 0 }, 42, 0],
+    [{ cached_tokens: 12 }, 30, 12],
+    [{ cached_tokens: 99 }, 0, 42],
+  ])('forwards input/cache without double counting %j', async (details, input, cache) => {
+    const upstream = await startUpstream((req, res) => {
+      expect(req.url).toBe('/responses');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'completed', output: [
+        { type: 'function_call', call_id: 'call', name: 'read_file', arguments: '{"path":"a"}' },
+      ], usage: { input_tokens: 42, output_tokens: 9, input_tokens_details: details,
+        output_tokens_details: { reasoning_tokens: 7 } } }));
+    });
+    const h = await startProxy();
+    h.proxy.useResponsesApi = true;
+    h.proxy.getApiEndpointMock.mockResolvedValue(upstream.origin);
+    try {
+      const response = await request(`${h.url}/v1/messages`, { method: 'POST', body: MESSAGES_BODY });
+      expect(response.status).toBe(200);
+      expect(JSON.parse(response.body)).toMatchObject({ stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', input: { path: 'a' } }] });
+      expect(JSON.parse(response.body).usage).toEqual({ input_tokens: input, output_tokens: 9,
+        ...(cache !== undefined ? { cache_read_input_tokens: cache } : {}) });
+    } finally {
+      await h.stop();
+      await upstream.close();
+    }
+  });
 });
 
 describe('TranslationProxyBase — 429 records a provider cooldown', () => {

--- a/libs/backend/auth-providers/src/lib/translation/translation-proxy-base.ts
+++ b/libs/backend/auth-providers/src/lib/translation/translation-proxy-base.ts
@@ -45,6 +45,7 @@ import {
   sendErrorResponse,
   buildUpstreamUrl,
   safeJsonParse,
+  translateResponsesUsage,
 } from './translation-proxy-helpers';
 import { providerQuotaStore } from '../auth/provider-quota.store';
 
@@ -822,10 +823,7 @@ export abstract class TranslationProxyBase implements ITranslationProxy {
             model,
             stop_reason: stopReason,
             stop_sequence: null,
-            usage: {
-              input_tokens: responsesResponse.usage?.input_tokens ?? 0,
-              output_tokens: responsesResponse.usage?.output_tokens ?? 0,
-            },
+            usage: translateResponsesUsage(responsesResponse.usage),
           };
 
           sendJson(res, 200, anthropicResponse);

--- a/libs/backend/auth-providers/src/lib/translation/translation-proxy-helpers.ts
+++ b/libs/backend/auth-providers/src/lib/translation/translation-proxy-helpers.ts
@@ -9,6 +9,34 @@
  */
 
 import * as http from 'http';
+import { z } from 'zod';
+
+const responsesUsageSchema = z.object({
+  input_tokens: z.number().nonnegative().optional(),
+  output_tokens: z.number().nonnegative().optional(),
+  input_tokens_details: z.object({
+    cached_tokens: z.number().nonnegative().optional(),
+  }).nullish(),
+}).nullish();
+
+/** Responses input includes cache hits; Anthropic input excludes them.
+ * Output already includes reasoning tokens, so never add reasoning details.
+ */
+export function translateResponsesUsage(value: unknown): {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+} {
+  const usage = responsesUsageSchema.parse(value);
+  const input = usage?.input_tokens ?? 0;
+  const cached = usage?.input_tokens_details?.cached_tokens;
+  const cacheRead = Math.min(input, cached ?? 0);
+  return {
+    input_tokens: input - cacheRead,
+    output_tokens: usage?.output_tokens ?? 0,
+    ...(cached !== undefined ? { cache_read_input_tokens: cacheRead } : {}),
+  };
+}
 
 /** Maximum request body size (50 MB) */
 export const MAX_BODY_SIZE = 50 * 1024 * 1024;

--- a/libs/frontend/chat/src/lib/services/chat-store/session-live-stats.util.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/session-live-stats.util.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Pure-function spec for `deriveLiveModelStats` — the ONE derivation behind the
+ * context gauge, shared by tab and non-tab surfaces.
+ *
+ * TASK_2026_408 phase 2. The load-bearing rules pinned here:
+ *   1. `lastTurnContextTokens: 0` is an HONEST reading, not an absence. Only
+ *      null/undefined falls back to the cumulative sum. This is the total
+ *      prompt size, including cached input; a fully cached nonempty prompt
+ *      must still have nonzero context occupancy.
+ *   2. The last turn's context fill and the session's cumulative token total
+ *      are DIFFERENT numbers; the gauge must show the former when present.
+ *   3. The cumulative fallback is not a context fill once the session has
+ *      compacted or the sum has passed the window — it is suppressed (live:
+ *      null), never rendered as a >100% fill.
+ */
+
+import {
+  deriveLiveModelStats,
+  type TurnModelUsage,
+} from './session-live-stats.util';
+
+const WINDOW = 200_000;
+
+function usage(overrides: Partial<TurnModelUsage> = {}): TurnModelUsage {
+  return {
+    model: 'claude-sonnet-4',
+    inputTokens: 30,
+    outputTokens: 9,
+    contextWindow: WINDOW,
+    costUSD: 0,
+    cacheReadInputTokens: 12,
+    ...overrides,
+  };
+}
+
+describe('deriveLiveModelStats (session-live-stats.util)', () => {
+  it('returns null for an empty modelUsage list', () => {
+    expect(
+      deriveLiveModelStats([], { stickyModel: null, hasCompacted: false }),
+    ).toBeNull();
+  });
+
+  it('treats lastTurnContextTokens 0 as a real reading — 0% fill, not a fallback', () => {
+    const derived = deriveLiveModelStats(
+      [usage({ lastTurnContextTokens: 0 })],
+      { stickyModel: null, hasCompacted: false },
+    );
+
+    expect(derived).not.toBeNull();
+    expect(derived?.suppressed).toBe(false);
+    expect(derived?.live?.contextUsed).toBe(0);
+    expect(derived?.live?.contextPercent).toBe(0);
+  });
+
+  it('falls back to cumulative input + cacheRead + output only when lastTurnContextTokens is absent', () => {
+    const derived = deriveLiveModelStats(
+      [usage({ lastTurnContextTokens: undefined })],
+      { stickyModel: null, hasCompacted: false },
+    );
+
+    expect(derived?.suppressed).toBe(false);
+    // 30 input + 12 cacheRead + 9 output — the cumulative turn total.
+    expect(derived?.live?.contextUsed).toBe(51);
+  });
+
+  it('prefers the last turn context over the cumulative total when both exist', () => {
+    const derived = deriveLiveModelStats(
+      // Cumulative would read 51; the turn's real prompt was 4200.
+      [usage({ lastTurnContextTokens: 4200 })],
+      { stickyModel: null, hasCompacted: false },
+    );
+
+    expect(derived?.live?.contextUsed).toBe(4200);
+    // 4200 / 200000 = 2.1%.
+    expect(derived?.live?.contextPercent).toBe(2.1);
+  });
+
+  it('suppresses the fill when compacted and only the cumulative fallback exists', () => {
+    const derived = deriveLiveModelStats(
+      [usage({ lastTurnContextTokens: undefined })],
+      { stickyModel: null, hasCompacted: true },
+    );
+
+    expect(derived?.suppressed).toBe(true);
+    // null means "leave the displayed number alone" — never a wrong fill.
+    expect(derived?.live).toBeNull();
+  });
+
+  it('does NOT suppress after compaction when the turn reported its own context fill', () => {
+    const derived = deriveLiveModelStats(
+      [usage({ lastTurnContextTokens: 1200 })],
+      { stickyModel: null, hasCompacted: true },
+    );
+
+    expect(derived?.suppressed).toBe(false);
+    expect(derived?.live?.contextUsed).toBe(1200);
+  });
+
+  it('suppresses when the cumulative fallback exceeds the context window', () => {
+    const derived = deriveLiveModelStats(
+      [
+        usage({
+          inputTokens: 190_000,
+          outputTokens: 20_000,
+          cacheReadInputTokens: 0,
+          lastTurnContextTokens: undefined,
+        }),
+      ],
+      { stickyModel: null, hasCompacted: false },
+    );
+
+    expect(derived?.suppressed).toBe(true);
+    expect(derived?.live).toBeNull();
+  });
+
+  it('keeps a sticky model that appears in the turn as the primary model', () => {
+    const derived = deriveLiveModelStats(
+      [
+        usage({ model: 'other-model', costUSD: 0.9, lastTurnContextTokens: 10 }),
+        usage({ model: 'claude-sonnet-4', costUSD: 0.01, lastTurnContextTokens: 1000 }),
+      ],
+      { stickyModel: 'claude-sonnet-4', hasCompacted: false },
+    );
+
+    expect(derived?.primaryModel.model).toBe('claude-sonnet-4');
+    expect(derived?.live?.contextUsed).toBe(1000);
+  });
+
+  it('ignores a sticky model that did not contribute to this turn', () => {
+    const derived = deriveLiveModelStats(
+      [usage({ model: 'claude-sonnet-4', costUSD: 0.05, lastTurnContextTokens: 500 })],
+      { stickyModel: 'claude-opus-4', hasCompacted: false },
+    );
+
+    expect(derived?.primaryModel.model).toBe('claude-sonnet-4');
+  });
+
+  it('renders 0 contextPercent when the context window is unknown (0)', () => {
+    const derived = deriveLiveModelStats(
+      [usage({ contextWindow: 0, lastTurnContextTokens: 42 })],
+      { stickyModel: null, hasCompacted: false },
+    );
+
+    expect(derived?.live?.contextUsed).toBe(42);
+    expect(derived?.live?.contextPercent).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Separate cached and uncached Responses input consistently across streaming, JSON, and collected SSE; avoid double-counting reasoning output.
- Consume final message_delta input/cache updates in the existing provider-neutral context tracker, so synthetic message_start zeros do not keep the context gauge at zero. Preserve direct Anthropic output-only delta behavior.
- Contain malformed usage as a sanitized stream error and prevent later events from reporting success.
- Add public Anthropic SDK accumulator, backend stats, and existing UI derivation regressions. No frontend production redesign.
- Includes the separately requested preservation commit 75e0da092 containing existing task investigation records; task-ID suffix rules remain intact. Product fix: 4f806f210.

## Test plan
- [x] Local rerun: frontend usage utility + stats aggregator — 38 tests passed.
- [x] Local rerun: stream transformer — 36 tests passed.
- [x] Local rerun: translation — 166 tests and 2 snapshots passed.
- [x] Agent SDK and auth-providers spec TypeScript checks passed.
- [x] git diff --check passed.
- [ ] Full frontend spec TypeScript check fails (exit 2); earlier agent reported 179 diagnostics. Baseline attribution has not been independently established. Focused frontend Jest tests pass.
- [ ] Live native Claude CLI/provider session and post-reload visual validation not performed. Public SDK accumulation and mocked host-event seams do not prove native auto-compaction behavior.

## Scope / remaining work
This repairs accounting and the existing context-stat producer; it does not demonstrate subscription-quota savings or expose provider quota remaining. Broader chat-completions/OpenRouter accounting, compaction lifecycle work, historical-session repair, and reasoning/cache optimization remain outside this patch. TASK_2026_408 stays in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Background agents now open live execution views more reliably.
  - Agent worktrees are created consistently across Windows, macOS, and Linux, including paths with special characters.
  - Worktree and hook errors now surface accurately instead of appearing successful.
  - Optional agent settings remain optional when using Codex-backed tools.
  - Improved handling of malformed Responses API usage data and incomplete responses.

- **Usage & Statistics**
  - Context-token, cache, cost, and per-turn usage reporting is now more accurate across providers and compaction events.
  - Added safeguards to prevent incorrect or duplicated usage totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->