### PR TITLE
fix: preserve worktree context when resuming sessions

### DIFF
--- a/.ptah/specs/TASK_2026_419_95af/task.md
+++ b/.ptah/specs/TASK_2026_419_95af/task.md
@@ -1,0 +1,26 @@
+---
+id: TASK_2026_419_95af
+status: in_review
+type: BUGFIX
+title: Preserve worktree context when resuming sessions
+depends_on: []
+created: '2026-09-11T01:05:21.280Z'
+updated: '2026-09-11T02:02:46.815Z'
+description: >-
+  Persist and restore the session working directory and resumable subagent
+  registry so a session started in a git worktree does not resume against the
+  main checkout with lost agent continuity.
+executor: backend-developer
+estimate: M
+labels:
+  - performance
+relates_to:
+  - TASK_2026_410
+  - TASK_2026_411
+---
+
+<!-- Ptah carrier: machine-owned metadata. Ptah rewrites the frontmatter above. Do NOT write prose here — prose belongs in ./context.md. -->
+
+Persist and restore the session working directory and resumable subagent registry so a session started in a git worktree does not resume against the main checkout with lost agent continuity.
+
+Full context, plan and discussion live in [./context.md](./context.md).

--- a/libs/backend/agent-sdk/src/lib/session-metadata-store.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/session-metadata-store.spec.ts
@@ -39,6 +39,7 @@ import type {
   CliOutputSegment,
   CliSessionReference,
   FlatStreamEventUnion,
+  SubagentRecord,
 } from '@ptah-extension/shared';
 import type { Logger } from '@ptah-extension/vscode-core';
 import { SdkError } from './errors';
@@ -274,6 +275,67 @@ describe('SessionMetadataStore', () => {
       expect(after?.cliSessions?.map((c) => c.cliSessionId)).toEqual([
         'keep-me',
       ]);
+    });
+
+    it('preserves resume state when a later save omits it', async () => {
+      await store.create('sess-1', WORKSPACE, 'parent');
+      const interrupted: SubagentRecord = {
+        toolCallId: 'tool-1',
+        agentType: 'backend',
+        status: 'interrupted',
+        startedAt: Date.now(),
+        interruptedAt: Date.now(),
+        parentSessionId: 'sess-1',
+        agentId: 'agent-1',
+      };
+      await store.saveResumeState('sess-1', {
+        workingDirectory: `${WORKSPACE}/.claude/worktrees/fix`,
+        resumableSdkSubagents: [interrupted],
+      });
+
+      const current = (await store.get('sess-1')) as NonNullable<
+        Awaited<ReturnType<typeof store.get>>
+      >;
+      await store.save({
+        ...current,
+        workingDirectory: undefined,
+        resumableSdkSubagents: undefined,
+        name: 'renamed',
+      });
+
+      const after = await store.get('sess-1');
+      expect(after?.workingDirectory).toBe(
+        `${WORKSPACE}/.claude/worktrees/fix`,
+      );
+      expect(after?.resumableSdkSubagents).toEqual([interrupted]);
+    });
+  });
+
+  describe('saveResumeState', () => {
+    it('stores only interrupted foreground SDK records for the canonical session', async () => {
+      await store.create('sess-1', WORKSPACE, 'parent');
+      const base: SubagentRecord = {
+        toolCallId: 'kept',
+        agentType: 'backend',
+        status: 'interrupted',
+        startedAt: Date.now(),
+        interruptedAt: Date.now(),
+        parentSessionId: 'sess-1',
+        agentId: 'agent-kept',
+      };
+
+      await store.saveResumeState('sess-1', {
+        resumableSdkSubagents: [
+          base,
+          { ...base, toolCallId: 'running', status: 'running' },
+          { ...base, toolCallId: 'background', isBackground: true },
+          { ...base, toolCallId: 'cli', isCliAgent: true },
+          { ...base, toolCallId: 'other', parentSessionId: 'sess-2' },
+        ],
+      });
+
+      const after = await store.get('sess-1');
+      expect(after?.resumableSdkSubagents).toEqual([base]);
     });
   });
 

--- a/libs/backend/agent-sdk/src/lib/session-metadata-store.ts
+++ b/libs/backend/agent-sdk/src/lib/session-metadata-store.ts
@@ -42,6 +42,7 @@ import type {
   FlatStreamEventUnion,
   SessionMetadataChangedNotification,
   SessionMetadataChangeKind,
+  SubagentRecord,
 } from '@ptah-extension/shared';
 import { blankToUndefined } from '@ptah-extension/shared';
 
@@ -90,6 +91,18 @@ export interface SessionMetadata {
 
   /** CLI agent sessions linked to this parent session. Enables resume. */
   readonly cliSessions?: readonly CliSessionReference[];
+
+  /**
+   * Exact process working directory used by the SDK session. This can differ
+   * from workspaceId when the session runs in a git worktree.
+   */
+  readonly workingDirectory?: string;
+
+  /**
+   * Interrupted SDK subagents that can be resumed after host restart.
+   * Rival CLI/background/running/completed records never belong here.
+   */
+  readonly resumableSdkSubagents?: readonly SubagentRecord[];
 
   /** When true, this session is a child/subagent session (e.g., Ptah CLI agent spawned
    *  by a parent orchestrator). Child sessions are hidden from the sidebar session list. */
@@ -316,6 +329,13 @@ export class SessionMetadataStore {
         ...(existing.cliSessions && !metadata.cliSessions
           ? { cliSessions: existing.cliSessions }
           : {}),
+        ...(existing.workingDirectory && !metadata.workingDirectory
+          ? { workingDirectory: existing.workingDirectory }
+          : {}),
+        ...(existing.resumableSdkSubagents &&
+        metadata.resumableSdkSubagents === undefined
+          ? { resumableSdkSubagents: existing.resumableSdkSubagents }
+          : {}),
       });
     } else {
       all.push(await this.leanCliSessions(metadata));
@@ -489,6 +509,51 @@ export class SessionMetadataStore {
   async get(sessionId: string): Promise<SessionMetadata | null> {
     const all = await this.getAll();
     return all.find((m) => m.sessionId === sessionId) || null;
+  }
+
+  /**
+   * Persist the process-resume state owned by chat orchestration.
+   *
+   * The filter is deliberately repeated at the storage boundary: callers may
+   * pass a registry snapshot, but only interrupted foreground SDK subagents
+   * belonging to this canonical session are durable.
+   */
+  async saveResumeState(
+    sessionId: string,
+    state: {
+      workingDirectory?: string;
+      resumableSdkSubagents: readonly SubagentRecord[];
+    },
+  ): Promise<void> {
+    await this.enqueueWrite(async () => {
+      const metadata = await this.get(sessionId);
+      if (!metadata) {
+        this.logger.warn(
+          `[SessionMetadataStore] Cannot save resume state for missing session ${sessionId}`,
+        );
+        return;
+      }
+
+      const resumableSdkSubagents = state.resumableSdkSubagents
+        .filter(
+          (record) =>
+            record.status === 'interrupted' &&
+            record.parentSessionId === sessionId &&
+            !record.isBackground &&
+            !record.isCliAgent &&
+            blankToUndefined(record.toolCallId) !== undefined &&
+            blankToUndefined(record.agentId) !== undefined,
+        )
+        .map((record) => ({ ...record }));
+
+      await this._saveInternal({
+        ...metadata,
+        ...(blankToUndefined(state.workingDirectory)
+          ? { workingDirectory: state.workingDirectory }
+          : {}),
+        resumableSdkSubagents,
+      });
+    });
   }
 
   /**
@@ -871,6 +936,7 @@ export class SessionMetadataStore {
       sessionId,
       name,
       workspaceId,
+      workingDirectory: workspaceId,
       createdAt: now,
       lastActiveAt: now,
       totalCost: 0,
@@ -902,6 +968,7 @@ export class SessionMetadataStore {
       sessionId,
       name,
       workspaceId,
+      workingDirectory: workspaceId,
       createdAt: now,
       lastActiveAt: now,
       totalCost: 0,

--- a/libs/backend/rpc-handlers/src/lib/chat/session/chat-continue-slash-before-resume.spec.ts
+++ b/libs/backend/rpc-handlers/src/lib/chat/session/chat-continue-slash-before-resume.spec.ts
@@ -148,7 +148,11 @@ function makeHarness(opts: SessionState, autopilot = false): Harness {
     { broadcastMessage: noop } as never,
     {
       get: noop,
-      getWithDefault: jest.fn().mockImplementation((key: string) => key === 'autopilot.permissionLevel' ? 'yolo' : autopilot),
+      getWithDefault: jest
+        .fn()
+        .mockImplementation((key: string) =>
+          key === 'autopilot.permissionLevel' ? 'yolo' : autopilot,
+        ),
     } as unknown as ConfigManager,
     sdkAdapter,
     { captureException: jest.fn() } as unknown as SentryService,
@@ -163,14 +167,20 @@ function makeHarness(opts: SessionState, autopilot = false): Harness {
       readHistoryAsMessages: jest.fn().mockResolvedValue([]),
     } as never,
     {
+      restoreResumableBySession: jest.fn().mockReturnValue(0),
       registerFromHistoryEvents: jest.fn().mockReturnValue(0),
       getResumableBySession: jest.fn().mockReturnValue([]),
     } as unknown as SubagentRegistryService,
     {
       intercept: jest.fn().mockReturnValue({ action: 'passthrough' }),
     } as never,
-    { getCliSessionsForRestore: jest.fn().mockResolvedValue([]) } as never,
+    {
+      get: jest.fn().mockResolvedValue(null),
+      getCliSessionsForRestore: jest.fn().mockResolvedValue([]),
+      saveResumeState: jest.fn().mockResolvedValue(undefined),
+    } as never,
     provider as unknown as IWorkspaceProvider,
+    { exists: jest.fn().mockResolvedValue(true) } as never,
     {
       type: 'cli',
       extensionPath: '/tmp/ptah-app',
@@ -213,6 +223,7 @@ function makeHarness(opts: SessionState, autopilot = false): Harness {
     // The constructor subscribes to the fan-out, so `register` must exist; a
     // real registry is cheap and keeps the stub honest.
     new SessionMcpStatusRegistry(),
+    { register: jest.fn().mockReturnValue(() => undefined) } as never,
     { register: jest.fn().mockReturnValue(() => undefined) } as never,
   );
 
@@ -461,12 +472,22 @@ describe('chat:continue — dead record (registered, not streaming)', () => {
   });
 });
 
-
 it('reports failed interruption as not delivered rather than sending to retired session', async () => {
-  const { service, interruptCurrentTurn, sendMessageToSession } = makeHarness(LIVE, true);
+  const { service, interruptCurrentTurn, sendMessageToSession } = makeHarness(
+    LIVE,
+    true,
+  );
   interruptCurrentTurn.mockResolvedValue(false);
-  const result = await service.continueSession({ sessionId: SESSION_ID, tabId: TAB_ID, prompt: 'stop', workspacePath: OPEN_FOLDER } as ChatContinueParams);
+  const result = await service.continueSession({
+    sessionId: SESSION_ID,
+    tabId: TAB_ID,
+    prompt: 'stop',
+    workspacePath: OPEN_FOLDER,
+  } as ChatContinueParams);
   expect(interruptCurrentTurn).toHaveBeenCalledTimes(1);
   expect(sendMessageToSession).not.toHaveBeenCalled();
-  expect(result).toEqual({ success: false, error: expect.stringContaining('Your follow-up was not sent') });
+  expect(result).toEqual({
+    success: false,
+    error: expect.stringContaining('Your follow-up was not sent'),
+  });
 });

--- a/libs/backend/rpc-handlers/src/lib/chat/session/chat-session-auth.spec.ts
+++ b/libs/backend/rpc-handlers/src/lib/chat/session/chat-session-auth.spec.ts
@@ -99,6 +99,7 @@ function makeService(
     } as never,
     stub as never,
     workspaceProvider,
+    { exists: jest.fn().mockResolvedValue(true) } as never,
     {
       type: 'cli',
       extensionPath: '/tmp/ptah-app',
@@ -130,6 +131,7 @@ function makeService(
     // The constructor subscribes to the fan-out, so `register` must exist; a
     // real registry is cheap and keeps the stub honest.
     new SessionMcpStatusRegistry(),
+    { register: jest.fn().mockReturnValue(() => undefined) } as never,
     { register: jest.fn().mockReturnValue(() => undefined) } as never,
   );
 }

--- a/libs/backend/rpc-handlers/src/lib/chat/session/chat-session-mcp-status.spec.ts
+++ b/libs/backend/rpc-handlers/src/lib/chat/session/chat-session-mcp-status.spec.ts
@@ -116,6 +116,7 @@ function makeHarness(opts: { broadcastRejects?: boolean } = {}): Harness {
     createMockWorkspaceProvider({
       folders: ['/c/projects/my-repo'],
     }) as unknown as IWorkspaceProvider,
+    { exists: jest.fn().mockResolvedValue(true) } as never,
     {
       type: 'cli',
       extensionPath: '/tmp/ptah-app',
@@ -144,6 +145,7 @@ function makeHarness(opts: { broadcastRejects?: boolean } = {}): Harness {
     { resolveSessionFields: jest.fn().mockResolvedValue({}) } as never,
     registry,
     fanOut as never,
+    { register: jest.fn().mockReturnValue(() => undefined) } as never,
   );
 
   return {

--- a/libs/backend/rpc-handlers/src/lib/chat/session/chat-session-resume-activate.spec.ts
+++ b/libs/backend/rpc-handlers/src/lib/chat/session/chat-session-resume-activate.spec.ts
@@ -78,6 +78,16 @@ function makeService(params: {
   resumeSession?: jest.Mock;
   isStreaming?: jest.Mock;
   mcpServerRunning?: boolean;
+  metadata?: Record<string, unknown> | null;
+  fileExists?: jest.Mock;
+  readSessionHistory?: jest.Mock;
+  readHistoryAsMessages?: jest.Mock;
+  restoreResumableBySession?: jest.Mock;
+  registerFromHistoryEvents?: jest.Mock;
+  getResumableBySession?: jest.Mock;
+  saveResumeState?: jest.Mock;
+  sessionEndRegister?: jest.Mock;
+  restoreAgents?: jest.Mock;
 }): ChatSessionService {
   const noop = jest.fn();
   const stub = { then: undefined } as unknown;
@@ -93,18 +103,25 @@ function makeService(params: {
   } as unknown as IAgentAdapter;
 
   const historyReader = {
-    readSessionHistory: jest
-      .fn()
-      .mockResolvedValue({ events: [], stats: null }),
-    readHistoryAsMessages: jest.fn().mockResolvedValue([]),
+    readSessionHistory:
+      params.readSessionHistory ??
+      jest.fn().mockResolvedValue({ events: [], stats: null }),
+    readHistoryAsMessages:
+      params.readHistoryAsMessages ?? jest.fn().mockResolvedValue([]),
   };
   const subagentRegistry = {
-    registerFromHistoryEvents: jest.fn().mockReturnValue(0),
-    getResumableBySession: jest.fn().mockReturnValue([]),
+    restoreResumableBySession:
+      params.restoreResumableBySession ?? jest.fn().mockReturnValue(0),
+    registerFromHistoryEvents:
+      params.registerFromHistoryEvents ?? jest.fn().mockReturnValue(0),
+    getResumableBySession:
+      params.getResumableBySession ?? jest.fn().mockReturnValue([]),
   } as unknown as SubagentRegistryService;
   const sessionMetadataStore = {
-    get: jest.fn().mockResolvedValue(null),
+    get: jest.fn().mockResolvedValue(params.metadata ?? null),
     getCliSessionsForRestore: jest.fn().mockResolvedValue([]),
+    saveResumeState:
+      params.saveResumeState ?? jest.fn().mockResolvedValue(undefined),
   };
   const sdkContext = {
     isMcpServerRunning: jest
@@ -144,6 +161,9 @@ function makeService(params: {
     sessionMetadataStore as never,
     provider as unknown as IWorkspaceProvider,
     {
+      exists: params.fileExists ?? jest.fn().mockResolvedValue(true),
+    } as never,
+    {
       type: 'cli',
       extensionPath: '/tmp/ptah-app',
       globalStoragePath: '/tmp/ptah-storage',
@@ -175,6 +195,13 @@ function makeService(params: {
     // real registry is cheap and keeps the stub honest.
     new SessionMcpStatusRegistry(),
     { register: jest.fn().mockReturnValue(() => undefined) } as never,
+    {
+      register:
+        params.sessionEndRegister ?? jest.fn().mockReturnValue(() => undefined),
+    } as never,
+    params.restoreAgents
+      ? ({ restoreAgents: params.restoreAgents } as never)
+      : null,
   );
 }
 
@@ -280,5 +307,160 @@ describe('ChatSessionService — resumeSession activate:true (TS-04)', () => {
     expect(result.activated).toBe(false);
     expect(result.activationError).toBeUndefined();
     expect(result.activationErrorCode).toBeUndefined();
+  });
+
+  it('restores a persisted worktree cwd before history, registry fallback, and activation', async () => {
+    const worktree = `${OPEN_FOLDER}/.claude/worktrees/fix`;
+    const calls: string[] = [];
+    const readSessionHistory = jest.fn(async (_id, cwd) => {
+      calls.push(`history:${cwd}`);
+      return { events: [{ id: 'history' }], stats: null };
+    });
+    const readHistoryAsMessages = jest.fn(async (_id, cwd) => {
+      calls.push(`messages:${cwd}`);
+      return [];
+    });
+    const restoreResumableBySession = jest.fn(() => {
+      calls.push('restore');
+      return 1;
+    });
+    const registerFromHistoryEvents = jest.fn(() => {
+      calls.push('fallback');
+      return 0;
+    });
+    const resumeSession = jest.fn(async (_id, options) => {
+      calls.push(`activate:${options.projectPath}`);
+      return (async function* () {
+        /* no events */
+      })();
+    });
+    const persisted = {
+      toolCallId: 'tool-1',
+      agentType: 'backend',
+      status: 'interrupted',
+      startedAt: Date.now(),
+      interruptedAt: Date.now(),
+      parentSessionId: SESSION_ID,
+      agentId: 'agent-1',
+    };
+    const svc = makeService({
+      metadata: {
+        workingDirectory: worktree,
+        resumableSdkSubagents: [persisted],
+      },
+      fileExists: jest.fn().mockResolvedValue(true),
+      readSessionHistory,
+      readHistoryAsMessages,
+      restoreResumableBySession,
+      registerFromHistoryEvents,
+      resumeSession,
+      getResumableBySession: jest.fn().mockReturnValue([persisted]),
+      isSessionActive: jest.fn().mockReturnValue(false),
+    });
+
+    const result = await svc.resumeSession({
+      sessionId: SESSION_ID,
+      tabId: TAB_ID,
+      workspacePath: OPEN_FOLDER,
+      activate: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(restoreResumableBySession).toHaveBeenCalledWith(SESSION_ID, [
+      persisted,
+    ]);
+    expect(calls).toEqual([
+      `history:${worktree}`,
+      `messages:${worktree}`,
+      'restore',
+      'fallback',
+      `activate:${worktree}`,
+    ]);
+  });
+
+  it('persists cwd and interrupted SDK records from the session-end lifecycle', async () => {
+    const worktree = `${OPEN_FOLDER}/.claude/worktrees/fix`;
+    const persisted = {
+      toolCallId: 'tool-1',
+      agentType: 'backend',
+      status: 'interrupted',
+      startedAt: Date.now(),
+      interruptedAt: Date.now(),
+      parentSessionId: SESSION_ID,
+      agentId: 'agent-1',
+    };
+    const getResumableBySession = jest.fn().mockReturnValue([persisted]);
+    const saveResumeState = jest.fn().mockResolvedValue(undefined);
+    let sessionEndCallback:
+      | ((payload: { sessionId: string; workspaceRoot: string }) => unknown)
+      | undefined;
+    const sessionEndRegister = jest.fn((callback) => {
+      sessionEndCallback = callback;
+      return () => undefined;
+    });
+
+    makeService({
+      getResumableBySession,
+      saveResumeState,
+      sessionEndRegister,
+    });
+
+    expect(sessionEndCallback).toBeDefined();
+    await sessionEndCallback?.({
+      sessionId: SESSION_ID,
+      workspaceRoot: worktree,
+    });
+
+    expect(getResumableBySession).toHaveBeenCalledWith(SESSION_ID);
+    expect(saveResumeState).toHaveBeenCalledWith(SESSION_ID, {
+      workingDirectory: worktree,
+      resumableSdkSubagents: [persisted],
+    });
+  });
+
+  it.each([
+    ['missing', jest.fn().mockResolvedValue(false)],
+    ['unreadable', jest.fn().mockRejectedValue(new Error('stat failed'))],
+  ])('falls back when persisted cwd is %s', async (_label, fileExists) => {
+    const readSessionHistory = jest
+      .fn()
+      .mockResolvedValue({ events: [], stats: null });
+    const svc = makeService({
+      metadata: {
+        workingDirectory: `${OPEN_FOLDER}/.claude/worktrees/deleted`,
+      },
+      fileExists,
+      readSessionHistory,
+    });
+
+    const result = await svc.resumeSession({
+      sessionId: SESSION_ID,
+      tabId: TAB_ID,
+      workspacePath: OPEN_FOLDER,
+    });
+
+    expect(result.success).toBe(true);
+    expect(readSessionHistory).toHaveBeenCalledWith(SESSION_ID, OPEN_FOLDER);
+  });
+
+  it('keeps legacy metadata behavior when continuity fields are absent', async () => {
+    const readSessionHistory = jest
+      .fn()
+      .mockResolvedValue({ events: [], stats: null });
+    const restoreResumableBySession = jest.fn().mockReturnValue(0);
+    const svc = makeService({
+      metadata: { workspaceId: OPEN_FOLDER },
+      readSessionHistory,
+      restoreResumableBySession,
+    });
+
+    await svc.resumeSession({
+      sessionId: SESSION_ID,
+      tabId: TAB_ID,
+      workspacePath: OPEN_FOLDER,
+    });
+
+    expect(readSessionHistory).toHaveBeenCalledWith(SESSION_ID, OPEN_FOLDER);
+    expect(restoreResumableBySession).toHaveBeenCalledWith(SESSION_ID, []);
   });
 });

--- a/libs/backend/rpc-handlers/src/lib/chat/session/chat-session.service.ts
+++ b/libs/backend/rpc-handlers/src/lib/chat/session/chat-session.service.ts
@@ -50,11 +50,13 @@ import {
   SDK_TOKENS,
   SlashCommandInterceptor,
   AuthRequiredError,
+  type SessionEndCallbackRegistry,
   type SessionMcpStatusCallbackRegistry,
 } from '@ptah-extension/agent-sdk';
 import {
   PLATFORM_TOKENS,
   isUnsafeWorkspacePath,
+  type IFileSystemProvider,
   type IPlatformInfo,
   type IWorkspaceProvider,
 } from '@ptah-extension/platform-core';
@@ -141,6 +143,8 @@ export class ChatSessionService {
     private readonly sessionMetadataStore: SessionMetadataStore,
     @inject(PLATFORM_TOKENS.WORKSPACE_PROVIDER)
     private readonly workspaceProvider: IWorkspaceProvider,
+    @inject(PLATFORM_TOKENS.FILE_SYSTEM_PROVIDER)
+    private readonly fileSystemProvider: IFileSystemProvider,
     @inject(PLATFORM_TOKENS.PLATFORM_INFO)
     private readonly platformInfo: IPlatformInfo,
     @inject(CHAT_TOKENS.SDK_CONTEXT)
@@ -173,6 +177,8 @@ export class ChatSessionService {
     private readonly mcpStatusRegistry: SessionMcpStatusRegistry,
     @inject(SDK_TOKENS.SDK_SESSION_MCP_STATUS_CALLBACK_REGISTRY)
     private readonly mcpStatusEvents: SessionMcpStatusCallbackRegistry,
+    @inject(SDK_TOKENS.SDK_SESSION_END_CALLBACK_REGISTRY)
+    private readonly sessionEndEvents: SessionEndCallbackRegistry,
     /**
      * Optional so a host that never registers the manager resumes exactly as
      * before. Used for one thing: putting the CLI session references this
@@ -183,6 +189,7 @@ export class ChatSessionService {
     private readonly agentProcessManager: AgentProcessManager | null = null,
   ) {
     this.subscribeToMcpStatus();
+    this.subscribeToSessionEnd();
   }
 
   /**
@@ -213,6 +220,18 @@ export class ChatSessionService {
           : this.mcpStatusRegistry.recordNotice(event.sessionId, event.notice);
       if (!record) return;
       this.publishMcpStatus(event.sessionId, record);
+    });
+  }
+
+  /** Persist resume continuity whenever any SDK lifecycle path ends a session. */
+  private subscribeToSessionEnd(): void {
+    this.sessionEndEvents.register(({ sessionId, workspaceRoot }) => {
+      const resumableSdkSubagents =
+        this.subagentRegistry.getResumableBySession(sessionId);
+      return this.sessionMetadataStore.saveResumeState(sessionId, {
+        workingDirectory: workspaceRoot,
+        resumableSdkSubagents,
+      });
     });
   }
 
@@ -719,11 +738,13 @@ export class ChatSessionService {
             'RPC: chat:continue - stop intent detected, interrupting current turn',
             { sessionId, permissionLevel, prompt: prompt.substring(0, 80) },
           );
-          const interrupted = await this.sdkAdapter.interruptCurrentTurn(sessionId);
+          const interrupted =
+            await this.sdkAdapter.interruptCurrentTurn(sessionId);
           if (!interrupted) {
             return {
               success: false,
-              error: 'The current turn could not be interrupted safely. Your follow-up was not sent. Retry to resume the session.',
+              error:
+                'The current turn could not be interrupted safely. Your follow-up was not sent. Retry to resume the session.',
             };
           }
         }
@@ -750,6 +771,54 @@ export class ChatSessionService {
   }
 
   /**
+   * Resolve the SDK process cwd from durable session metadata before any JSONL
+   * lookup or activation. Invalid, unsafe, or deleted paths are ignored and the
+   * caller/current workspace fallback keeps legacy metadata resumable.
+   */
+  private async resolveResumeWorkingDirectory(
+    persistedPath: string | undefined,
+    fallbackPath: string,
+    sessionId: string,
+  ): Promise<string> {
+    if (!persistedPath) return fallbackPath;
+
+    if (!isAuthorizedWorkspace(persistedPath, this.workspaceProvider)) {
+      this.logger.warn(
+        '[RPC] chat:resume - persisted working directory is not authorized; using fallback',
+        { sessionId, persistedPath, fallbackPath },
+      );
+      return fallbackPath;
+    }
+
+    const safety = isUnsafeWorkspacePath(persistedPath, this.platformInfo);
+    if (!safety.ok) {
+      this.logger.warn(
+        '[RPC] chat:resume - persisted working directory is unsafe; using fallback',
+        { sessionId, persistedPath, fallbackPath, reason: safety.reason },
+      );
+      return fallbackPath;
+    }
+
+    try {
+      if (await this.fileSystemProvider.exists(persistedPath)) {
+        return persistedPath;
+      }
+    } catch (error: unknown) {
+      this.logger.warn(
+        '[RPC] chat:resume - persisted working directory could not be checked; using fallback',
+        error instanceof Error ? error : new Error(String(error)),
+      );
+      return fallbackPath;
+    }
+
+    this.logger.warn(
+      '[RPC] chat:resume - persisted working directory no longer exists; using fallback',
+      { sessionId, persistedPath, fallbackPath },
+    );
+    return fallbackPath;
+  }
+
+  /**
    * chat:resume - Load session history from JSONL files. Returns full
    * `events` (FlatStreamEventUnion[]) for tree reconstruction plus `messages`
    * (deprecated, backward compat), aggregated usage stats, resumable
@@ -758,9 +827,9 @@ export class ChatSessionService {
   async resumeSession(params: ChatResumeParams): Promise<ChatResumeResult> {
     try {
       const { sessionId } = params;
-      const resolvedWorkspacePath =
+      const fallbackWorkspacePath =
         params.workspacePath || this.workspaceProvider.getWorkspaceRoot();
-      if (!resolvedWorkspacePath) {
+      if (!fallbackWorkspacePath) {
         return {
           success: false,
           error:
@@ -777,15 +846,24 @@ export class ChatSessionService {
         };
       }
       const unsafeResume = this.rejectIfUnsafeWorkspace(
-        resolvedWorkspacePath,
+        fallbackWorkspacePath,
         'chat:resume',
       );
       if (unsafeResume) return unsafeResume;
+
+      const metadata = await this.sessionMetadataStore.get(sessionId);
+      const resolvedWorkspacePath = await this.resolveResumeWorkingDirectory(
+        metadata?.workingDirectory,
+        fallbackWorkspacePath,
+        sessionId,
+      );
       this.logger.info('RPC: chat:resume called', {
         sessionId,
         workspacePath: params.workspacePath || '(empty)',
         resolvedWorkspacePath,
-        usedFallback: !params.workspacePath,
+        usedFallback: resolvedWorkspacePath === fallbackWorkspacePath,
+        restoredWorkingDirectory:
+          resolvedWorkspacePath !== fallbackWorkspacePath,
         ptahCliId: params.ptahCliId,
       });
       if (params.ptahCliId) {
@@ -806,6 +884,21 @@ export class ChatSessionService {
         sessionId,
         resolvedWorkspacePath,
       );
+      const restoredFromMetadata =
+        this.subagentRegistry.restoreResumableBySession(
+          sessionId,
+          metadata?.resumableSdkSubagents ?? [],
+        );
+      if (restoredFromMetadata > 0) {
+        this.logger.info(
+          '[RPC] Restored interrupted SDK agents from session metadata',
+          { sessionId, restoredCount: restoredFromMetadata },
+        );
+      }
+
+      // Legacy/additive fallback. The history registrar skips toolCallIds that
+      // the durable snapshot restored above, so old sessions still work without
+      // duplicating current records.
       const registeredFromHistory =
         this.subagentRegistry.registerFromHistoryEvents(events, sessionId);
 
@@ -942,6 +1035,10 @@ export class ChatSessionService {
           })),
         });
       }
+
+      await this.sessionMetadataStore.saveResumeState(sessionId, {
+        resumableSdkSubagents: resumableSubagents,
+      });
 
       return {
         success: true,

--- a/libs/backend/vscode-core/src/services/subagent-registry-extended.service.spec.ts
+++ b/libs/backend/vscode-core/src/services/subagent-registry-extended.service.spec.ts
@@ -199,6 +199,35 @@ describe('SubagentRegistryService — extended methods', () => {
     });
   });
 
+  describe('restoreResumableBySession', () => {
+    it('restores only valid non-expired interrupted SDK records and deduplicates toolCallId', () => {
+      const now = Date.now();
+      const valid = {
+        toolCallId: 'tc-restored',
+        agentType: 'backend',
+        status: 'interrupted' as const,
+        startedAt: now,
+        interruptedAt: now,
+        parentSessionId: 'sess-a',
+        agentId: 'agent-restored',
+      };
+
+      const restored = service.restoreResumableBySession('sess-a', [
+        valid,
+        { ...valid, toolCallId: 'tc-running', status: 'running' },
+        { ...valid, toolCallId: 'tc-cli', isCliAgent: true },
+        { ...valid, toolCallId: 'tc-bg', isBackground: true },
+        { ...valid, toolCallId: 'tc-other', parentSessionId: 'sess-b' },
+        { ...valid, toolCallId: 'tc-expired', startedAt: 0 },
+      ]);
+      const duplicate = service.restoreResumableBySession('sess-a', [valid]);
+
+      expect(restored).toBe(1);
+      expect(duplicate).toBe(0);
+      expect(service.getResumableBySession('sess-a')).toEqual([valid]);
+    });
+  });
+
   describe('getRunningBySession', () => {
     it('returns running non-background agents for a session', () => {
       service.register(

--- a/libs/backend/vscode-core/src/services/subagent-registry.service.ts
+++ b/libs/backend/vscode-core/src/services/subagent-registry.service.ts
@@ -512,6 +512,46 @@ export class SubagentRegistryService {
   }
 
   /**
+   * Restore a durable snapshot of interrupted SDK subagents.
+   *
+   * Existing toolCallIds win so this is additive and history replay can safely
+   * run afterward without producing duplicates.
+   */
+  restoreResumableBySession(
+    parentSessionId: string,
+    records: readonly SubagentRecord[],
+  ): number {
+    if (blankToUndefined(parentSessionId) === undefined) return 0;
+
+    this.store.lazyCleanup();
+    let restored = 0;
+    for (const record of records) {
+      if (
+        record.status !== 'interrupted' ||
+        record.parentSessionId !== parentSessionId ||
+        record.isBackground ||
+        record.isCliAgent ||
+        blankToUndefined(record.toolCallId) === undefined ||
+        blankToUndefined(record.agentId) === undefined ||
+        this.store.isExpired(record) ||
+        this.store.has(record.toolCallId)
+      ) {
+        continue;
+      }
+      this.store.set(record.toolCallId, { ...record });
+      restored++;
+    }
+
+    if (restored > 0) {
+      this.logger.info(
+        '[SubagentRegistryService.restoreResumableBySession] Restored interrupted SDK subagents',
+        { parentSessionId, restored },
+      );
+    }
+    return restored;
+  }
+
+  /**
    * Get all running (non-background) subagents for a session.
    *
    * Used by the frontend to show confirmation before interrupting.


### PR DESCRIPTION
## Summary

- persist the exact SDK working directory used by each session
- restore interrupted SDK subagents from durable session metadata after host restarts
- validate persisted paths and fall back safely when a worktree is missing or unauthorized
- retain transcript-based reconstruction for legacy sessions and leave rival CLI restoration unchanged

## Test plan

- `npx nx run-many -t test -p @ptah-extension/agent-sdk @ptah-extension/vscode-core @ptah-extension/rpc-handlers --runInBand`
- `npx nx run-many -t typecheck -p @ptah-extension/agent-sdk @ptah-extension/vscode-core @ptah-extension/rpc-handlers`
- `npx nx run-many -t lint -p @ptah-extension/agent-sdk @ptah-extension/vscode-core @ptah-extension/rpc-handlers`
- pre-commit affected lint, Electron bundle, and dependency validation
- pre-push DI invariant validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resuming a session from a Git worktree now restores its original working directory instead of defaulting to the main checkout.
  - Interrupted SDK subagents are preserved and restored when eligible, maintaining continuity across resumed sessions.
  - Sessions safely fall back to the workspace root when the saved working directory is missing, inaccessible, or no longer valid.
  - Session resume state is retained across subsequent metadata updates, preventing accidental loss of worktree and subagent information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->