### PR TITLE
fix: compaction history refresh and context UI consistency

### DIFF
--- a/.ptah/specs/TASK_2026_414/agent-output-root.md
+++ b/.ptah/specs/TASK_2026_414/agent-output-root.md
@@ -1,0 +1,10 @@
+# TASK_2026_414 reconciliation verdict
+
+Reviewed at `5f79f5ad8`, after PR490. The plan now preserves PR490 and removes provider-accounting overlap. It replaces timestamp/slack readiness with a bounded, explicit per-session expected boundary ordinal, returns a single immutable resume snapshot, and makes an unverified compaction reload safely non-applying on the frontend.
+
+Updated deliverables:
+
+- `implementation-plan.md`
+- `batches.md`
+
+No product code, logs, commits, pushes, tests, or live apps were changed or run.

--- a/.ptah/specs/TASK_2026_414/batches.md
+++ b/.ptah/specs/TASK_2026_414/batches.md
@@ -1,213 +1,127 @@
-# TASK_2026_414 — Implementation batches
+# TASK_2026_414 — Sequential Codex implementation batches
 
-Design and evidence: `implementation-plan.md` in this folder. Read it before you start any batch.
+Read `implementation-plan.md` first. Worktree: `D:/projects/ptah-extension/.claude-worktrees/compaction-ui-consistency` at reviewed HEAD `5f79f5ad8`. Executor: the user-requested Ollama Cloud CLI (`pc-85830910-3d81-4248-84c1-4fa52752dd19`), with no substitute provider. No commits, pushes, app restart, live-session/log edits, `git reset`, or bare `git stash`. Run one batch at a time; use the stated `run-many` command and confirm its project count.
 
-Rules for every batch:
-
-- Worktree: `D:/projects/ptah-extension/.claude-worktrees/compaction-ui-consistency` (branch `fix/compaction-ui-consistency`). Never touch the root checkout.
-- Executor: Ollama Cloud CLI, ptahCliId `pc-85830910-3d81-4248-84c1-4fa52752dd19`. No substitute provider without user consent.
-- No commits, no pushes, no `git reset`, no bare `git stash`. No app restart, no live session-log edits.
-- Batches run in order. One batch at a time. Each batch ends with the review/test gate in section 7.
-- Test with `npx nx run-many`, never `nx test a b c`. Verify the `Running target test for N projects` header shows the N you requested.
-- No `project.json` edits planned. If a batch must edit one, run `npx nx reset` first, and only when no other executor works in the worktree.
-- Leave the `[compaction-diag]` `console.warn` blocks alone unless your change touches those exact lines.
-
----
-
-## Batch 1 — Backend: single snapshot + compaction readiness + stale flag
-
-Goal. One transcript parse feeds events, messages, and stats. The reader verifies the expected compaction boundary with a bounded retry. `chat:resume` reports a stale parse instead of returning it as if valid.
+## Batch 1 — Backend: one immutable resume generation
 
 Files:
 
-1. `libs/shared/src/lib/types/rpc/rpc-chat.types.ts`
-   - Add optional `staleSnapshot?: boolean` to `ChatResumeResult` with a doc comment: true only when a recent compaction was known and the new boundary did not appear within the bounded retry budget.
-2. `libs/backend/agent-sdk/src/lib/helpers/compaction-readiness-registry.ts` (new)
-   - Bounded insertion-ordered map, 64 entries, LRU evict on insert past the bound.
-   - `record(sessionId, entry: { boundaryRecordedAt: number })`.
-   - `latest(sessionId)` returns the entry, or `null` when absent or older than `COMPACTION_READINESS_WINDOW_MS = 15 * 60_000`.
-   - `clear()` for tests.
-3. `libs/backend/agent-sdk/src/lib/message-transform/transformer-helpers.ts`
-   - Add `readonly compactionReadiness: CompactionReadinessRegistry` to `TransformerHelpers`.
-4. `libs/backend/agent-sdk/src/lib/message-transform/system-message.transformer.ts`
-   - In `transformCompactBoundary` (lines 32-96): after the sessionId-resolve guard (lines 66-78), call `helpers.compactionReadiness.record(sessionId, { boundaryRecordedAt: Date.now() })`. Skip the record exactly when emission is skipped.
-5. `libs/backend/agent-sdk/src/lib/di/tokens.ts` + `libs/backend/agent-sdk/src/lib/di/register.ts` (or the lib's registration file per the existing pattern)
-   - `SDK_COMPACTION_READINESS_REGISTRY: Symbol.for('SdkCompactionReadinessRegistry')`, singleton registration. Follow the `SDK_LIVE_USAGE_TRACKER` pattern.
-6. `libs/backend/agent-sdk/src/lib/session-history-reader.service.ts`
-   - Extract the boundary-scan + filter core of `readHistoryMessages` (lines 332-430) into a private `projectSimpleMessages(rawMessages, extractContent)`. `readHistoryMessages` calls it; behavior identical.
-   - `readSessionHistory` (lines 135-214): new optional param `options?: { awaitCompactionBoundary?: boolean }`.
-     - Add `messages` to the return value, computed from the SAME `mainMessages` array with `projectSimpleMessages`.
-     - When `awaitCompactionBoundary` is true and the registry holds a recent entry for the session: scan the parse for the last `compact_boundary` line timestamp. Accept when it is at or after `entry.boundaryRecordedAt - COMPACTION_READINESS_SLACK_MS` (60 s). When not accepted: retry up to `MAX_COMPACTION_READINESS_ATTEMPTS = 5`, delay `COMPACTION_READINESS_RETRY_DELAY_MS = 150` between attempts, re-calling `readJsonlMessages` each time (the `(size, mtimeMs)` memo makes unchanged attempts free). After the last failed attempt, proceed with what was read and set `staleSnapshot: true` on the return value.
-     - No registry entry, or entry outside the window: today's path, `staleSnapshot` absent.
-   - Update the two-parse doc comment at `libs/backend/agent-sdk/src/lib/helpers/history/jsonl-reader.service.ts:348-349` to the single-snapshot rule.
-7. `libs/backend/rpc-handlers/src/lib/chat/session/chat-session.service.ts`
-   - `resumeSession`: pass `{ awaitCompactionBoundary: true }` at line 798. Delete the `readHistoryAsMessages` call at line 805 and use `result.messages`. Thread `staleSnapshot` into the result.
-8. Specs:
-   - `libs/shared/src/lib/types/wire-parsers.equivalence.spec.ts` — check whether it pins `ChatResumeResult` fields; update it if it does.
-   - `libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts` — extend: (a) events and messages in the return come from one parse and share one boundary drop; (b) stale-then-ready JSONL: registry entry exists, first parse lacks the new boundary, retry loop observes the file change and returns ready; (c) budget exhausted → `staleSnapshot: true`; (d) no registry entry → flag absent; (e) boundary line written at completion time does not break the slack comparison (217 s compaction duration case).
-   - New `compaction-readiness-registry.spec.ts`: LRU bound, recency window, `latest` after `clear`.
-   - `libs/backend/agent-sdk/src/lib/message-transform/` transformer spec: `transformCompactBoundary` records only when a session id resolves.
-   - `libs/backend/rpc-handlers` existing resume spec (`chat-session-resume-activate.spec.ts`): update for the single-read call shape and `staleSnapshot` passthrough.
+- `libs/shared/src/lib/types/rpc/rpc-chat.types.ts`
+- `libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.ts` (new)
+- `libs/backend/agent-sdk/src/lib/di/tokens.ts`
+- `libs/backend/agent-sdk/src/lib/di/register.ts`
+- `libs/backend/agent-sdk/src/lib/message-transform/transformer-helpers.ts`
+- `libs/backend/agent-sdk/src/lib/sdk-message-transformer.ts`
+- `libs/backend/agent-sdk/src/lib/message-transform/system-message.transformer.ts`
+- `libs/backend/agent-sdk/src/lib/session-history-reader.service.ts`
+- `libs/backend/agent-sdk/src/lib/helpers/history/jsonl-reader.service.ts`
+- `libs/backend/rpc-handlers/src/lib/chat/session/chat-session.service.ts`
+- `libs/shared/src/lib/types/wire-parsers.equivalence.spec.ts` (only if its enumeration pins `ChatResumeResult`)
+- `libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts`
+- `libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.spec.ts` (new)
+- `libs/backend/agent-sdk/src/lib/sdk-message-transformer.spec.ts`
+- `libs/backend/rpc-handlers/src/lib/chat/session/chat-session-resume-activate.spec.ts`
 
-Constraints:
+Implement the single-parse result (`events`, text messages, stats) and make `chat:resume` consume it. Keep the legacy text and curation APIs. Add only the bounded generation registry described in the plan: reader captures a pending expectation before recording the current parsed boundary count; a resolved compact-boundary transform requests the next count; inject that singleton into `SdkMessageTransformer` and preserve it through `createIsolated()`; compaction resume retries by event-loop yield only while the count is short; no timestamps, TTL, delay constants, or slack. Consume expectation after response. Return additive `staleSnapshot?: true` when no baseline or no expected count is observed; leave ordinary and stats-only reads unchanged.
 
-- Do not change `ChatResumeParams`, `chat-rpc.schema.ts`, or the stats-only caller at `session-rpc.handlers.ts:834`.
-- Do not delete `readHistoryAsMessages`. Add a doc note: `chat:resume` must not call it.
-- Keep `readHistoryForCuration` behavior identical.
-- No arbitrary sleep outside the bounded retry loop.
+Tests must pin: one parse supplies events/messages with the same boundary; ready after a file-generation change; exhausted and baseline-absent results are stale; no expectation leaves the flag absent; transformer records only after session-id resolution; resume no longer calls the second reader and forwards the flag; shared-wire shape only if it enumerates this result. Update the JSONL cache comment to the one-read `chat:resume` rule.
 
-Test gate:
+Gate:
 
 ```bash
 npx nx run-many -t test -p @ptah-extension/shared @ptah-extension/agent-sdk @ptah-extension/rpc-handlers
 npx nx affected -t typecheck
 ```
 
-Review gate: code-logic-reviewer + code-style-reviewer on the diff. Focus points: memo interaction with the retry loop, registry window math, single-parse guarantee, additive contract only.
+Review: verify generation arithmetic, expectation consumption, cache behavior, and absence of clock-based acceptance.
 
----
-
-## Batch 2 — Frontend: stale-snapshot guard in the compaction reload
-
-Goal. A stale resume result never replaces the visible tab state. The tab stays on its compacted marker and reloads clean data on the next session switch.
-
-Depends on: Batch 1 (the `staleSnapshot` field).
+## Batch 2 — Frontend: stale compaction snapshot containment
 
 Files:
 
-1. `libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts`
-   - In `switchSession` after the `chat:resume` result and the second `requireTargetTab` (line 670-672), before the apply block (line 697): when `opts?.reason === 'compaction'` AND `resumeResult.data?.staleSnapshot === true`, do not apply events, messages, or stats. Restore the tab: status `loaded`, `markTabIdle`, keep the `preloadedStats` that `applyCompactionComplete` installed. Warn once. Return normally so the pending-settle counter still clears compaction state.
-   - Do not change the non-compaction resume path.
-2. `libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts`
-   - New cases: (a) compaction reload with `staleSnapshot: true` → no event/message/stats apply, tab restored, state not 'resuming'; (b) compaction reload with flag absent → normal apply; (c) normal resume with `staleSnapshot: true` (defensive) → normal apply (flag consumed only on compaction reason); (d) pin the existing dedup: two concurrent `switchSession` calls with the same `${sessionId}:${targetTabId}` share one in-flight load; (e) pin `requireTargetTab`: a tab that no longer owns the session throws.
+- `libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts`
+- `libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts`
 
-Constraints:
+For a targeted compaction reload with `staleSnapshot === true`, after ownership is re-validated and before any payload application, restore loaded/idle state and return normally. Preserve the marker and preloaded stats; do not apply events, messages, stats, CLI sessions, or resume-derived subagents. Normal resumes consume no special meaning from the flag. Do not add a retry, timer, or mutate existing dedup/ownership/pending-update behavior.
 
-- Do not add sleeps or re-try loops on the frontend. The bounded backend retry is the only retry.
-- Do not touch `_inFlightSessions` semantics, `requireTargetTab`, `clearPendingUpdates`, or turn-state floors.
+Tests: stale compaction response is not applied and is not left `resuming`; absent flag applies normally; stale normal resume applies normally; same target deduplicates; rebinding/closure causes ownership failure.
 
-Test gate:
+Gate:
 
 ```bash
 npx nx run-many -t test -p @ptah-extension/chat @ptah-extension/chat-state
 npx nx affected -t typecheck
 ```
 
-Review gate: code-logic-reviewer + code-style-reviewer. Focus points: pending-settle counter still clears, no stuck 'resuming' state, guard scoped to reason 'compaction'.
+Review: pending-settle still completes and no targeted tab can remain stuck.
 
----
-
-## Batch 3 — Frontend: per-session compaction timers
-
-Goal. Two concurrent compactions keep independent safety timers. Every exit path cleans its own timer.
-
-Depends on: Batch 2 (same file family; avoids merge conflicts in `compaction-lifecycle.service.ts`).
+## Batch 3 — Frontend: independent compaction safety timers
 
 Files:
 
-1. `libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts`
-   - Replace `compactionTimeoutId` (line 57) with `private readonly compactionTimers = new Map<string, { timeoutId: ReturnType<typeof setTimeout>; tabIds: string[]; convIds: string[] }>()`.
-   - `handleCompactionStart` (lines 110-152): clear and re-arm only the entry for that session id. The callback closes over that session's `tabIds` and `convIds`, re-verifies each tab still binds the session, then applies the timeout reset. The callback deletes its own map entry.
-   - `handleCompactionComplete` (lines 261-427): clear only the entry for `result.compactionSessionId` (lines 268-271 replacement).
-   - `clearCompactionState(tabId?)` (lines 526-547): with a tab id, clear entries whose `convIds` include that tab's conversation. Without a tab id, clear all entries. Keep both external callers working: `chat-lifecycle.service.ts:277` (sweep) and `session-stats-aggregator.service.ts:85` (tab-scoped).
-2. `libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts`
-   - New cases: (a) two sessions start compaction → two live timers, neither cancels the other; (b) session A completes → only A's timer cleared, B's still armed; (c) timeout fires for A → only A's tabs get the reset; (d) `clearCompactionState()` clears all; (e) `clearCompactionState(tabId)` clears only entries bound to that tab's conversation; (f) timeout callback skips a tab that closed or re-bound during the wait.
+- `libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts`
+- `libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts`
 
-Constraints:
+Replace the singleton timer with a per-session map. Preserve 600000 ms and existing completion fan-out. Start/restart clears only that session; complete clears only that session; per-tab clear removes entries for its current conversation; sweep clears all; callback deletes itself and skips tabs no longer bound to its captured session.
 
-- Keep `COMPACTION_SAFETY_TIMEOUT_MS = 600000` unchanged.
-- Do not change `handleCompactionComplete` fan-out logic, marker stamping, or the reload-target selection. Only the timer bookkeeping changes.
-- Do not remove the `[compaction-diag]` warns unless your edit rewrites those exact lines.
+Tests: two sessions arm independently; A completion leaves B armed; A timeout only resets A; tab clear is scoped; sweep clears all; close/rebind during wait is skipped; repeated A starts do not leak a handle.
 
-Test gate:
+Gate:
 
 ```bash
 npx nx run-many -t test -p @ptah-extension/chat @ptah-extension/chat-state
 npx nx affected -t typecheck
 ```
 
-Review gate: code-logic-reviewer + code-style-reviewer. Focus points: every exit path deletes its entry (complete, per-tab clear, sweep, timeout fire), no timer leak on repeated starts of the same session.
+Review: every terminal path removes the correct entry; do not touch fan-out or diagnostics.
 
----
-
-## Batch 4 — Frontend: post-compaction context seed + neutral marker wording
-
-Goal. After compaction, the context display shows the SDK-reported post-compaction size when it is known and stays blank when it is not. The marker never claims a shrinkage the numbers contradict.
-
-Depends on: Batch 3 (same service; sequential order prevents conflicts).
+## Batch 4 — Context seed and neutral compaction marker
 
 Files:
 
-1. `libs/frontend/chat-state/src/lib/tab-manager.service.ts`
-   - `applyCompactionComplete` (lines 1730-1753): payload gains optional `postCompactionContextTokens?: number | null`. When the value is a positive finite number AND the tab's current `liveModelStats` has a model, seed `liveModelStats` with `{ model, contextUsed: postCompactionContextTokens, contextWindow, contextPercent }` instead of `null`. Missing, zero, negative, or NaN → `null` (unchanged). Cumulative cost/token fields stay untouched.
-2. `libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts`
-   - In `handleCompactionComplete`, pass `postCompactionContextTokens: result.postTokens ?? null` to `applyCompactionComplete` for each fan-out tab.
-3. `libs/frontend/chat-state/src/lib/tab-manager.service.spec.ts`
-   - New cases: (a) postTokens 21930 + known model → seeded stats with that value; (b) postTokens absent → `liveModelStats` null; (c) postTokens 0 → null (unknown is not zero); (d) cumulative tokens/cost unchanged by the seed; (e) a later live usage frame still overwrites the seed.
-4. `libs/frontend/chat-ui/src/lib/molecules/notifications/compaction-marker.component.ts`
-   - `tokenLine` (lines 97-105): keep "shrank" only when `preTokens > postTokens`. When `postTokens >= preTokens`, render `` `${format(pre)} → ${format(post)} tokens` `` with no verb. Either value null → no line (unchanged).
-5. `libs/frontend/chat-ui/src/lib/molecules/notifications/compaction-marker.component.spec.ts`
-   - New cases: (a) pre 150000 / post 21000 → "shrank"; (b) pre 144 / post 21930 → neutral, no "shrank"; (c) equal values → neutral; (d) one value null → no token line.
+- `libs/frontend/chat-state/src/lib/tab-manager.service.ts`
+- `libs/frontend/chat-state/src/lib/tab-manager.service.spec.ts`
+- `libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts`
+- `libs/frontend/chat-ui/src/lib/molecules/notifications/compaction-marker.component.ts`
+- `libs/frontend/chat-ui/src/lib/molecules/notifications/compaction-marker.component.spec.ts`
 
-Constraints:
+Forward existing `postTokens` to `applyCompactionComplete`. Seed context only with positive finite tokens and a known existing model; preserve cumulative/preloaded data and allow later live usage to replace the seed. Make non-shrinking marker values neutral.
 
-- Do not touch `aggregateUsageStats`, `LiveUsageTracker`, `SessionStatsAggregator`, or `preloadedStats` preservation.
-- No other refactors in the marker component.
+Tests: valid seed; absent/zero/non-finite/no-model remains null; cumulative values survive; live frame replaces seed; decreasing/equal/increasing/null marker cases.
 
-Test gate:
+Gate:
 
 ```bash
 npx nx run-many -t test -p @ptah-extension/chat @ptah-extension/chat-state @ptah-extension/chat-ui
 npx nx affected -t typecheck
 ```
 
-Review gate: code-logic-reviewer + code-style-reviewer. Focus points: seed only when positive and finite, no synthetic zero overwrites real context, cumulative totals unchanged.
+Review: no synthetic zero and no PR490/provider-accounting overlap.
 
----
-
-## Batch 5 — Backend: artifact parity between live transform and replay
-
-Goal. The same transcript artifacts produce the same user-visible messages on live transform and on replay. Fix only divergences the parity spec proves.
-
-Depends on: Batch 1 (same lib; sequential order prevents conflicts).
+## Batch 5 — Artifact parity, test before filter change
 
 Files:
 
-1. New spec `libs/backend/agent-sdk/src/lib/message-transform/artifact-parity.spec.ts` (or the replay spec folder if the repo prefers; follow existing spec placement).
-   - Fixture corpus, each through BOTH `SdkMessageTransformer.transform` (live path) and the replay path (`session-replay.service.ts`): `isSynthetic: true` user line; `isMeta: true` user line; `sourceToolUseID` user line; tool-result-only user line; `<task-notification>` text; interrupt-sentinel text; `<skill-format>`, `<command-message>`, `<command-name>`, skill base-directory, invoked-skills, plan-file, frontmatter content patterns; local command output line; one genuine user text; one genuine assistant text; the `No response requested.` probe line.
-   - Assert: the user-visible message set is identical between the two paths.
-2. Run the spec. Record which fixtures diverge. Expected (from code reading, not yet proven by test): replay lets the `isSkillOrMetaContent` patterns through.
-3. Fix ONLY the proven divergences. Expected minimal fix: `libs/backend/agent-sdk/src/lib/helpers/history/session-replay.service.ts` user-message gate (lines 122-144) gains the `isSkillOrMetaContent` check, imported from `message-transform-helpers.ts` (same lib). If the spec proves the live path misses task-notification or interrupt-sentinel user text, add those checks to the live gate in `sdk-message-transformer.ts` (lines 159-191).
-4. Update the spec to cover the fixed behavior. Add regression cases to the replay spec if the repo separates them.
+- `libs/backend/agent-sdk/src/lib/message-transform/artifact-parity.spec.ts` (new, or the existing replay-spec location if that is the established fixture harness)
+- `libs/backend/agent-sdk/src/lib/helpers/history/session-replay.service.ts` only if the parity test proves a replay divergence
+- associated focused replay/live specs only if required
 
-Constraints:
+Build the normalized visible-text parity corpus specified in the plan. Record the proven divergence in the test description/review note. Apply only the minimal proven filter correction; do not modify `No response requested.` based on hypothesis alone.
 
-- No timestamp sorting. No blanket drop of genuine user or assistant messages.
-- Compaction summary semantics stay unchanged: boundary drop rule, marker summary persistence, `compact_boundary` handling.
-- The `No response requested.` provenance stays a hypothesis. Fix it only if the parity spec proves a rule that covers it without dropping genuine content. Otherwise record the finding in the review notes and leave it.
-
-Test gate:
+Gate:
 
 ```bash
 npx nx run-many -t test -p @ptah-extension/agent-sdk @ptah-extension/rpc-handlers
 npx nx affected -t typecheck
 ```
 
-Review gate: code-logic-reviewer + code-style-reviewer. Focus points: filter direction (replay gains live's checks, not the reverse, unless the spec proves otherwise), no genuine content dropped, fixture coverage matches the corpus above.
+Review: replay may gain a proven live filter; genuine content and compaction semantics remain intact.
 
----
-
-## Completion gate (after Batch 5)
-
-1. Full suite over all touched projects:
+## Completion gate
 
 ```bash
 npx nx run-many -t test -p @ptah-extension/shared @ptah-extension/agent-sdk @ptah-extension/rpc-handlers @ptah-extension/chat @ptah-extension/chat-state @ptah-extension/chat-ui
 npx nx affected -t typecheck
 ```
 
-Verify the header shows 7 projects.
-
-2. Map each acceptance item from `context.md` (1-6) to the batch and spec that covers it. Record the mapping in the task folder.
-3. Confirm no `[compaction-diag]` warns were removed outside the allowed exception.
-4. Confirm no commit and no push exist on the branch beyond the starting commit `30d37f61c`.
+Confirm six projects in the full `run-many` header, no diagnostic warning removal, and no product changes outside these batches.

--- a/.ptah/specs/TASK_2026_414/implementation-plan.md
+++ b/.ptah/specs/TASK_2026_414/implementation-plan.md
@@ -1,148 +1,84 @@
-# TASK_2026_414 — Compaction UI consistency: implementation plan
+# TASK_2026_414 — Compaction UI consistency: reconciled implementation plan
 
-- Worktree: `D:/projects/ptah-extension/.claude-worktrees/compaction-ui-consistency` (branch `fix/compaction-ui-consistency`)
-- All product edits and test runs target the worktree, never the root checkout.
-- Executor for every batch: Ollama Cloud CLI, ptahCliId `pc-85830910-3d81-4248-84c1-4fa52752dd19`. No substitute provider without user consent.
-- No commits or pushes. No live session/log mutations. Do not restart the app.
+Reviewed against `5f79f5ad8` (including PR490). Work only in this worktree; no commits, pushes, app restart, or session-log mutation.
 
-All line numbers below were verified against the worktree on 2026-09-10.
+## Verdict
 
-## 1. Proven causes (verified in code + logs)
+Keep the fix, but replace the old timestamp/readiness-window proposal. It would accept an old boundary within a 60-second slack, adds a permanent time-based registry, and turns flush timing into a clock-comparison problem. The current typed SDK compact-boundary contract does not expose the JSONL line `uuid`, so a true boundary identity cannot be carried from the stream to the file reader.
 
-### P1 — Mixed snapshot: `chat:resume` performs two independent transcript reads
+Use the smallest safe substitute: a process-local, per-session expected boundary **ordinal**. A successful history parse records the number of `compact_boundary` lines it observed. When the transformer emits a resolved completion, it records “next ordinal” from that baseline. The compaction-only resume accepts a snapshot only when its boundary count reaches that explicit expected ordinal. There is no timestamp, slack, expiry window, or frontend retry. If no baseline exists or the bounded retry cannot observe the expected ordinal, return the one immutable snapshot with `staleSnapshot: true`; the frontend deliberately leaves the compacted state intact rather than applying known-stale data.
 
-`ChatSessionService.resumeSession` reads the transcript twice, sequentially:
+This is one narrowly-scoped singleton because producer and reader otherwise have no shared state. It must be bounded by entry count and clear a pending expectation after the compaction resume settles; do not add a general readiness service, persistent state, or new RPC request field.
 
-- `chat-session.service.ts:798` — `readSessionHistory` (events + stats; drops pre-boundary inside `session-replay.service.ts`).
-- `chat-session.service.ts:805` — `readHistoryAsMessages` (messages; drops pre-boundary inside `readHistoryMessages`, `session-history-reader.service.ts:379-393`).
+## Verified causes and retained scope
 
-`JsonlReaderService.readJsonlMessages` memoizes on `(path, size, mtimeMs)` (`jsonl-reader.service.ts`, TASK_2026_353 token rule). During the post-compaction reload the SDK appended the new `compact_boundary` + summary lines between the two reads, so `size/mtimeMs` moved and the second read re-parsed a NEWER file. Result (verified log, session `8a0a185b`): events from the pre-compaction parse (old boundary, 194 events) mixed with messages from the post-compaction parse (new boundary, 4 messages). Session `d1808e88` returned 609 events / 16 messages with no new boundary at all. Later reloads found the new boundaries (9 events / 4 messages) — the boundary does land on disk shortly after; the first read raced it.
+1. `ChatSessionService.resumeSession` still makes two sequential reads (`readSessionHistory`, then `readHistoryAsMessages`), which can mix generations. Return text messages from the same parsed array as replay events and stats.
+2. `CompactionLifecycleService` still has one `compactionTimeoutId`; concurrent sessions cancel each other.
+3. The marker still says “shrank” even when `postTokens >= preTokens`.
+4. `applyCompactionComplete` clears `liveModelStats`; compaction `postTokens` is already carried to the lifecycle handler and can seed only the context display.
+5. Replay and live user-artifact filters differ, but the user-visible consequence must be proved by a parity test before changing a filter.
 
-### P2 — Singleton compaction safety timer
+PR490 is preserved. It fixes provider/Codex usage-context handling; it does not justify provider-accounting changes here. Do not alter `compact_metadata` accounting, `aggregateUsageStats`, `LiveUsageTracker`, `SessionStatsAggregator`, or cumulative cost/token totals.
 
-`compaction-lifecycle.service.ts:57` holds ONE `compactionTimeoutId`. `handleCompactionStart` (lines 120-123) clears any existing timer before arming its own (lines 136-151). Two concurrent compactions (two live sessions/tiles) therefore cancel each other's 10-minute safety net: session B's start disarms session A's timer, and whichever completes first (line 268-271) disarms the rest. `clearCompactionState` (lines 527-530) also clears the single timer on every call.
+## Design
 
-### P3 — Marker always claims shrinkage
+### Immutable, boundary-ready resume
 
-`compaction-marker.component.ts:97-105`: `tokenLine` is always `` `shrank ${pre} → ${post} tokens` ``. Observed boundary metadata: preTokens 144/68, postTokens 21930/17369 — post > pre, so the chip asserts a shrinkage the numbers contradict.
+`SessionHistoryReaderService.readSessionHistory` reads JSONL once per attempt. Its return grows additively to `{ events, messages, stats, staleSnapshot? }`; both projections consume the same `mainMessages` array and therefore the same last-boundary drop. `ChatSessionService.resumeSession` uses those returned messages and no longer calls `readHistoryAsMessages`.
 
-### P4 — Post-compaction context display is blanked by construction
+Keep `readHistoryAsMessages` and `readHistoryForCuration` public behavior unchanged. Extract only the text projection into a private helper, and document that `chat:resume` must use the single-snapshot result.
 
-Mechanics, all verified:
+Add `CompactionBoundaryGenerationRegistry` in `agent-sdk`:
 
-- `aggregateUsageStats` (`session-history-reader.service.ts:744-755, 832-834`) slices stats to the post-boundary segment and returns `null` when that segment holds no usage. Immediately after a compaction, with no assistant turn since the boundary, `stats` is `null` and `stats.contextSnapshot` cannot exist.
-- `applyCompactionComplete` (`tab-manager.service.ts:1750`) sets `liveModelStats: null`.
-- In `switchSession` (`session-loader.service.ts:686-696`), `stats == null` plus `targetTabId` set (always true for compaction reloads) hits neither branch, so nothing restores the context display until the next live turn.
+- per session, retain the latest observed boundary count and, only while pending, its expected next count;
+- reader records the count for every successful full history parse, but captures any pending expectation before updating that observation;
+- `transformCompactBoundary` records an expectation only after resolving a session id, using the latest count plus one; absent baseline becomes an explicit unverified expectation, never an assumed-ready one. Inject this singleton into `SdkMessageTransformer` and pass it through `createIsolated()` so all compact-boundary paths share the same expectation;
+- the compaction-only reader compares counts, not timestamps. It retries a small, fixed number of event-loop turns only while a pending expectation is unmet, re-reading via the existing `(size, mtimeMs)` cache token. No `Date.now`, delay duration, slack, recency TTL, or sleep;
+- the expectation is consumed on ready or exhausted response. The registry has a small insertion-order cap solely for process-memory safety; pending entries must never survive a completed response.
 
-The compaction itself produced a trustworthy post-compaction context size — `compact_metadata.post_tokens` (21930/17369), already plumbed end-to-end: SDK → `system-message.transformer.ts:91` → `CompactionCompleteEvent.postTokens` → `accumulator-core.service.ts:569` → `streaming-handler.service.ts:340` → `chat.store.ts:366` → `handleCompactionComplete` → currently only into the marker record.
+The stats-only `session:stats-batch` caller does not opt in. `ChatResumeParams` and its Zod schema remain unchanged. `ChatResumeResult.staleSnapshot?: true` is additive and means precisely: a compaction reload could not verify its expected boundary generation. A compaction result without a baseline is stale by design rather than risking a pre-boundary overwrite.
 
-## 2. Hypotheses (explicitly NOT treated as proven)
+In `SessionLoaderService`, consume that flag only for `reason: 'compaction'`, after the ownership re-check and before stats/event/message application. Mark the targeted tab loaded/idle, keep the compaction marker and preloaded totals installed by `applyCompactionComplete`, and return normally so the lifecycle pending-settle accounting clears. Do not schedule a frontend retry. Normal resumes, deduplication, target ownership, pending-update clearing, and turn-state floors stay unchanged.
 
-- H1 — preTokens 144/68 equaling the last assistant output usage with input/cache zero is provider-side `compact_metadata` accounting (the SDK computes it from usage frames the provider reports). This is distinct from the refresh failure (context.md). We do not attempt to fix provider accounting; the marker wording fix (P3) is the user-visible mitigation.
-- H2 — Live vs replay artifact filter divergence lets injected/synthetic content through replay. The CODE divergence is proven (see §5); which artifact a user actually saw (the `No response requested.` screenshot) is UNVERIFIED. Batch 5 probes it; no fix lands without a proven rule.
-- H3 — The first post-compaction read can legitimately observe a transcript that does not yet contain the expected new boundary (SDK flush timing). Supported by P1's log evidence ("later reloads found the boundary"); the bounded-readiness design (§4.1) assumes it.
+### Per-session recovery timers
 
-## 3. Verified contracts (current state)
+Replace the singleton handle with a map keyed by `SessionId`; each entry owns its timeout, fan-out tab ids, and conversation ids. Starting A only replaces A. Completion clears only its session. A tab-scoped clear removes only entries associated with that tab’s current conversation; a sweep removes all. Timeout deletes its own entry before applying resets and verifies that every captured tab is still bound to that session. Preserve the 600000 ms safety timeout and all current fan-out/reload selection.
 
-- `CompactionCompleteEvent` (`libs/shared/src/lib/types/execution/stream.ts:264-274`): `trigger`, optional `preTokens`/`postTokens`/`durationMs`.
-- `ChatResumeParams` (`libs/shared/src/lib/types/rpc/rpc-chat.types.ts:210-230`): no compaction-related field today; zod-validated by `ChatResumeParamsSchema` in `libs/backend/rpc-handlers/src/lib/handlers/chat-rpc.schema.ts` (spec: `chat-rpc.schema.spec.ts:115-150`, including a known-keys assertion).
-- `ChatResumeResult` (`rpc-chat.types.ts:233-310`): `messages` (deprecated), `events`, `stats.contextSnapshot`, `resumableSubagents`, `cliSessions`, `activated`, `activationError`.
-- `readSessionHistory` (`session-history-reader.service.ts:135-214`): returns `{ events, stats }`; internally holds `mainMessages` (the full parsed array), `agentSessions`; seeds `LiveUsageTracker` (`seedLiveUsageBaseline`, lines 248-268, stops at last `compact_boundary`).
-- `readHistoryAsMessages` / `readHistoryMessages` (lines 280-430): boundary scan + `extractTextContent` + `<task-notification>` drop. No other production caller besides `chat-session.service.ts:805` (verified by grep; `readHistoryForCuration` shares the private core but is a separate public method used by the memory curator).
-- `transformCompactBoundary` (`system-message.transformer.ts:32-96`): clears streaming state, resolves sessionId (caller → payload → activeIds[0]), prunes subagents, `clearSessionTokenSnapshot` (line 81), emits `compaction_complete` with `timestamp: Date.now()` and metadata passthrough. Skips emission when no sessionId resolves (lines 66-78).
-- Frontend reload chain: `chat.store.ts:361-368` → `CompactionLifecycleService.handleCompactionComplete` (`compaction-lifecycle.service.ts:261-427`): marker stamp (351), `applyCompactionComplete` per fan-out tab (381), then `switchSession(sessionId, { reason: 'compaction', targetTabId })` per target (410-423) with a pending-settle counter.
-- `switchSession` (`session-loader.service.ts:552-745`): dedup via `_inFlightSessions` keyed `${sessionId}:${targetTabId}` (557-568); `requireTargetTab` throws when the tab no longer owns the session (747-756); prefers `events` replay path (697) over legacy `messages` (714).
-- `CompactionMarkerRecord` + `setCompactionMarkerTokens` (`conversation-registry.service.ts:263-285`): per-conversation, field-wise merge with persisted prior, `completedAt` max-merge.
-- Timer sweep callers: `chat-lifecycle.service.ts:277` (`clearCompactionState()`, no tab) and `session-stats-aggregator.service.ts:85` (`clearCompactionState(t.id)`).
+### Context seed and marker copy
 
-## 4. Design
+`applyCompactionComplete` accepts `postCompactionContextTokens`. With a positive finite post value and an existing model, seed only `liveModelStats.contextUsed` (and recompute its percent from the existing model/window data). Missing, zero, negative, non-finite value, or no model remains `null`. Do not synthesize zero or write cumulative fields. `handleCompactionComplete` forwards `result.postTokens`.
 
-### 4.1 Consistent boundary-verified reload (acceptance 1)
+The marker says “shrank” only for `preTokens > postTokens`; equal or increasing values render a neutral `pre → post tokens` line; a null endpoint renders no line.
 
-Two independent fixes, layered:
+### Artifact parity, proof before change
 
-**(a) Single snapshot (kills the mixed snapshot by construction).**
-`readSessionHistory` gains the messages projection: extract the boundary-scan + filter core of `readHistoryMessages` into a private `projectSimpleMessages(rawMessages, extractContent)` and call it inside `readSessionHistory` with `eventFactory.extractTextContent`. Return shape grows additively:
+First add a focused parity test that compares normalized visible user/assistant text from live transformation and replay for each compatible fixture: synthetic/meta, `sourceToolUseID`, tool-result-only, task notification, interrupt sentinel, each `isSkillOrMetaContent` pattern, local-command output where both paths have a representation, genuine user/assistant text, and the `No response requested.` probe. The test must report a concrete divergence. Only then apply the smallest matching replay-side filter change (expected: replay imports `isSkillOrMetaContent`). Do not force parity for protocol-only messages that one path cannot represent, sort timestamps, or blanket-drop content. Leave the screenshot provenance untouched unless a proven rule safely covers it.
 
-```ts
-{ events, stats, messages: SimpleHistoryMessage[] }   // messages from the SAME mainMessages parse
-```
+## Explicitly out of scope
 
-`resumeSession` (`chat-session.service.ts:805`) drops its `readHistoryAsMessages` call and uses `result.messages`. Events and messages now drop pre-boundary by the SAME rule over the SAME array — a mid-read file change can no longer split them. The stale doc comment at `jsonl-reader.service.ts:348-349` ("chat:resume calls readSessionHistory() and then readHistoryAsMessages() — two full parses") is updated in the same change.
+- Provider `compact_metadata` accounting and any PR490 provider changes.
+- A timestamp/readiness-window/slack design, persisted readiness data, or new frontend polling.
+- `ChatResumeParams`, `chat-rpc.schema.ts`, `LiveUsageTracker`, aggregate usage, turn-state, dedup, revision floors, and compaction fan-out policy.
+- Deleting `readHistoryAsMessages`.
+- Removing the marked `[compaction-diag]` warnings.
 
-`readHistoryAsMessages` stays: it is documented public API of `@ptah-extension/agent-sdk` with its own specs, and `readHistoryForCuration` shares its core. It gets a doc note that `chat:resume` must not call it (single-snapshot rule). Deleting public API mid-bugfix is out of scope.
+## Acceptance-to-proof map
 
-**(b) Bounded boundary readiness (kills the stale snapshot).**
-The backend already knows, in-process, when it transformed a `compact_boundary` — the same process that serves `chat:resume`. No frontend timestamp plumbing, no clock skew.
+| Acceptance | Proof |
+| --- | --- |
+| Boundary-ready immutable resume | Batch 1 single-parse, ordinal-ready, stale, dedup, ownership specs; Batch 2 guard spec |
+| Context seed without synthetic zero | Batch 4 tab-manager specs |
+| Live/replay artifact handling | Batch 5 parity-first spec and only its proven regression |
+| Independent recovery timers | Batch 3 concurrent-session and cleanup specs |
+| Neutral wording | Batch 4 marker specs |
+| Targeted regressions | Batches 1–5 test gates and completion run |
 
-- New injectable `CompactionReadinessRegistry` (`agent-sdk`, helpers): bounded insertion-ordered map (64 entries, LRU-evicted — same bound pattern as `RESUME_BASELINE_LIMIT`), `record(sessionId, { boundaryRecordedAt, boundaryLineTimestamp? })` and `latest(sessionId)`. Retention rule: entries older than `COMPACTION_READINESS_WINDOW_MS` (15 min) answer `null` — recency is the validity token, not a TTL sweep (the LRU is only the leak guard; matches the repo's read-cache rules).
-- Producer: `transformCompactBoundary` records AFTER the resolvedSessionId guard (skip exactly when emission is skipped). `TransformerHelpers` (`transformer-helpers.ts:10`) gains a `readonly compactionReadiness` member; DI token `SDK_COMPACTION_READINESS_REGISTRY: Symbol.for('SdkCompactionReadinessRegistry')` in `di/tokens.ts` + `register.ts`.
-- Consumer: `readSessionHistory` gains an options param `{ awaitCompactionBoundary?: boolean }`. When set AND the registry holds a recent entry for the session, the reader verifies the parse's last `compact_boundary` line timestamp is at/after `entry.boundaryLineTimestamp - COMPACTION_READINESS_SLACK_MS` (60 s). If not: bounded retry — `MAX_COMPACTION_READINESS_ATTEMPTS = 5`, `COMPACTION_READINESS_RETRY_DELAY_MS = 150` (worst case ≈ 750 ms), re-calling `readJsonlMessages` (memoized: an unchanged `(size, mtimeMs)` token costs nothing; a changed token re-parses). No arbitrary sleep is the sole mechanism — the loop is token-gated and bounded.
-- Only `ChatSessionService.resumeSession` passes `awaitCompactionBoundary: true` (opt-in; the stats-only caller at `session-rpc.handlers.ts:834` is untouched). The registry's recency window is the real gate: normal resumes of sessions without a recent compaction take the exact same path as today.
-- Readiness result travels out as `ChatResumeResult.staleSnapshot?: boolean` (additive, `rpc-chat.types.ts`): `true` only when the hint was checked and the boundary never appeared within the budget; absent otherwise. No `ChatResumeParams` change, no `chat-rpc.schema.ts` change.
-- Check `libs/shared/src/lib/types/wire-parsers.equivalence.spec.ts` for any shape-pinning of `ChatResumeResult` and update if it enumerates result fields.
-
-**Frontend stale guard** (`session-loader.service.ts`, after the `chat:resume` return, before the apply block at line 697): when `opts?.reason === 'compaction'` and `resumeResult.data?.staleSnapshot === true` — do NOT apply events/messages/stats (the payload is a pre-compaction parse; applying it is exactly the defect), restore the tab (`markTabIdle`, status `loaded`, keep `preloadedStats` installed by `applyCompactionComplete`), warn once, return normally so the pending-settle counter still clears compaction state. The tab shows the compacted marker and refills correctly on the next session switch, which re-resumes and now finds the boundary. Non-compaction resumes keep today's behavior unchanged.
-
-**Unchanged guards, to be test-pinned (acceptance 1 "preserve newer live turns and tab isolation", acceptance 6 "existing load deduplication"):** `_inFlightSessions` dedup key `${sessionId}:${targetTabId}`, `requireTargetTab` ownership throw, `clearPendingUpdates` before targeted replay (`session-loader.service.ts:631-633`), turn-state revision floors (untouched — no writer in this task).
-
-### 4.2 Reliable post-compaction context stats (acceptance 2)
-
-- `TabManagerService.applyCompactionComplete` (`tab-manager.service.ts:1730-1753`) payload gains `postCompactionContextTokens?: number | null`. When it is a positive finite number AND the tab's current `liveModelStats` has a model, the write seeds `liveModelStats` with `{ model, contextUsed: postCompactionContextTokens, contextWindow, contextPercent }` instead of `null`. Zero, negative, NaN, or missing → `null` (unchanged) — **unknown is not zero, and zero is not evidence**.
-- `handleCompactionComplete` passes `result.postTokens` through (it already computes nothing new — the value rides the existing chain, §1 P4).
-- Cumulative cost/tokens are untouched: `preloadedStats` preservation and `SessionStatsAggregator` grace-window logic stay exactly as-is. `aggregateUsageStats` slicing is unchanged. No change to `LiveUsageTracker` semantics (TASK_2026_374 rules stand; `clearSessionTokenSnapshot` at boundary, lines `system-message.transformer.ts:81`, stays).
-- H1 (provider preTokens accounting) is explicitly not addressed beyond the marker wording.
-
-### 4.3 SDK artifact semantics, live vs replay (acceptance 3)
-
-Verified divergence — live user-message gate (`sdk-message-transformer.ts:159-191`): `isSynthetic === true`; skill-tool-active unless tool_result; `isSkillOrMetaContent` patterns (`message-transform-helpers.ts:28-77`: `sourceToolUseID`, `<skill-format>`, `<command-message>`, `<command-name>`, skill base-directory, invoked-skills, plan-file, frontmatter). Replay user gate (`session-replay.service.ts:122-144`): `isMeta === true`; `sourceToolUseID`; tool_result-only; `<task-notification>`; interrupt sentinel.
-
-Batch 5 lands a parity spec FIRST (fixture corpus: every pattern above, a genuine user text, a local-command-output line, and the `No response requested.` probe), running the same fixtures through `SdkMessageTransformer.transform` and `replayToStreamEvents`, asserting the same user-visible message set. Then only the divergences the spec proves are fixed — expected minimal change: replay gains the `isSkillOrMetaContent` content patterns for user lines (same lib, import from `message-transform-helpers`). Constraints: no timestamp sorting, no blanket drop of genuine user/assistant messages, compaction summary semantics (boundary drop + registry-persisted marker summary) unchanged.
-
-### 4.4 Per-session compaction timers (acceptance 4)
-
-Replace the singleton with `private readonly compactionTimers = new Map<SessionId, { timeoutId; tabIds; convIds }>()`:
-
-- `handleCompactionStart(sessionId)`: clear + re-arm ONLY the entry for that session; callback closes over that session's `tabIds`/`convIds` and re-verifies each tab still binds the session before `applyCompactionTimeoutReset` (a tab may have closed or re-bound during the 10 minutes).
-- `handleCompactionComplete(result.compactionSessionId)`: clear only that session's entry.
-- `clearCompactionState(tabId?)`: with tabId → clear entries whose `convIds` include the tab's conversation; without → clear ALL entries (full-sweep semantics preserved for `chat-lifecycle.service.ts:277`).
-- Timeout fire: delete own entry (`this.compactionTimers.delete(sessionId)` inside the callback — the current code already nulls its own handle, line 147).
-
-### 4.5 Neutral marker wording (acceptance 5)
-
-`tokenLine` (`compaction-marker.component.ts:97-105`): keep "shrank" only when `preTokens > postTokens` (a demonstrated reduction); when `postTokens >= preTokens` render `` `${format(pre)} → ${format(post)} tokens` `` with no verb. Either value null → no line (unchanged). No other refactors in the component.
-
-## 5. Explicitly out of scope
-
-- Provider-side `compact_metadata` accounting (H1).
-- The `No response requested.` screenshot provenance (H2) — probe only.
-- Deleting `readHistoryAsMessages` public API.
-- The `[compaction-diag]` `console.warn` blocks (`compaction-lifecycle.service.ts:325-345, 393-398`; `session-loader.service.ts:613-626`) — marked TEMPORARY, but removing them is an unrelated refactor (scope item 5); leave them unless a batch touches those exact lines for its own change.
-- Any change to `ChatResumeParams` / `chat-rpc.schema.ts`.
-- Turn-state, dedup, revision-floor, or `LiveUsageTracker` semantics.
-
-## 6. Race and concurrency guards (summary)
-
-| Race                                      | Guard                                                                                        |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Transcript appended between two reads     | Single snapshot — one parse feeds events + messages (§4.1a)                                  |
-| Boundary not yet flushed at reload        | Bounded token-gated retry + `staleSnapshot` flag + frontend no-apply guard (§4.1b)           |
-| Unchanged-file retry cost                 | `readJsonlMessages` memo on `(size, mtimeMs)` — retries are free until the file moves        |
-| Two concurrent compactions                | Per-session timer map, per-session clear (§4.4)                                              |
-| Tab closed/re-bound during a 10-min timer | Callback re-verifies session ownership before reset (§4.4)                                   |
-| Duplicate concurrent reloads              | `_inFlightSessions` keyed `${sessionId}:${targetTabId}` (existing, test-pinned)              |
-| Reload target drift                       | `requireTargetTab` ownership throw (existing, test-pinned)                                   |
-| Readiness registry growth                 | 64-entry LRU + 15-min recency window                                                         |
-| Stale guard misfiring on normal resumes   | Opt-in flag + registry recency gate; `staleSnapshot` consumed only on `reason: 'compaction'` |
-
-## 7. Test commands (verified project names)
+## Verified commands
 
 ```bash
-# Never `nx test projA projB projC` — first project only. Always run-many, then check the header count:
 npx nx run-many -t test -p @ptah-extension/shared @ptah-extension/agent-sdk @ptah-extension/rpc-handlers
 npx nx run-many -t test -p @ptah-extension/chat @ptah-extension/chat-state @ptah-extension/chat-ui
-npx nx run-many -t test -p @ptah-extension/chat-streaming   # only if a batch touches it (none planned)
-npx nx affected -t typecheck                                # after each batch
+npx nx affected -t typecheck
 ```
 
-Run from the worktree root. Verify the `Running target test for N projects` header shows the N requested. No `project.json` edits are planned, so no `npx nx reset` is required; if one becomes necessary, never run it while another executor works in the worktree.
+No `project.json` edit is planned; do not run `nx reset`.

--- a/.ptah/specs/TASK_2026_414/task.md
+++ b/.ptah/specs/TASK_2026_414/task.md
@@ -1,6 +1,6 @@
 ---
 id: TASK_2026_414
-status: in_progress
+status: in_review
 type: BUGFIX
 title: Fix compaction history refresh and context UI consistency
 depends_on: []

--- a/apps/ptah-extension-vscode/package.json
+++ b/apps/ptah-extension-vscode/package.json
@@ -218,14 +218,17 @@
         "ptah.compaction.enabled": {
           "type": "boolean",
           "default": true,
-          "description": "Enable automatic context compaction for long sessions. When enabled, the AI will summarize conversation history to stay within context limits."
+          "description": "Enable automatic context compaction for long sessions. Manual /compact always remains available."
         },
         "ptah.compaction.threshold": {
-          "type": "number",
-          "default": 100000,
-          "minimum": 50000,
-          "maximum": 500000,
-          "description": "Token threshold to trigger automatic compaction (default: 100,000 tokens)."
+          "type": [
+            "integer",
+            "null"
+          ],
+          "default": null,
+          "minimum": 100000,
+          "maximum": 1000000,
+          "description": "Auto-compact window in tokens (a whole number from 100000 to 1000000). Leave unset to let the agent runtime decide. The runtime compacts near the smaller of this window and the model's own context limit. An out-of-range value is ignored with a warning."
         },
         "ptah.reasoningEffort": {
           "type": "string",

--- a/libs/backend/agent-sdk/src/index.ts
+++ b/libs/backend/agent-sdk/src/index.ts
@@ -205,10 +205,18 @@ export {
   // definition of `Options.settings`.
   buildFlagSettings,
   getActiveProviderId,
+  // The one translation of compaction settings into runtime controls, shared
+  // by the interactive builder and the CLI-agent spawn path.
+  resolveAutoCompactControl,
+  isValidAutoCompactWindow,
+  SDK_AUTO_COMPACT_WINDOW_MIN,
+  SDK_AUTO_COMPACT_WINDOW_MAX,
 } from './lib/helpers';
 export type {
   AssembleSystemPromptInput,
   SystemPromptAssemblyResult,
+  AutoCompactSettings,
+  AutoCompactControlInput,
 } from './lib/helpers';
 export {
   PTAH_CORE_SYSTEM_PROMPT,

--- a/libs/backend/agent-sdk/src/lib/di/register.compaction-boundary-registry.smoke.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/di/register.compaction-boundary-registry.smoke.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * DI container smoke spec for CompactionBoundaryGenerationRegistry (TASK_2026_414
+ * regression, PR #493).
+ *
+ * `CompactionBoundaryGenerationRegistry`'s unit spec constructs it with `new`
+ * directly and never exercised container resolution, so a defaulted-primitive
+ * constructor parameter with no explicit type annotation
+ * (`constructor(private readonly maxEntries = 256)`) shipped registered as
+ * `useClass`. TypeScript emits `Object` for that parameter's
+ * `design:paramtypes` entry (no annotation means no metadata type, syntactically,
+ * regardless of the inferred default's type), and tsyringe's constructor
+ * auto-wiring then tries to resolve a dependency literally named "Object" and
+ * throws `TypeInfo not known for "Object"` — which every consumer's DI chain
+ * surfaces as "Cannot inject the dependency ... position #N", not as an error
+ * naming the registry itself. `cli-agent-runtime`'s
+ * `register.ptah-cli-registry.smoke.spec.ts` caught this only because
+ * `PtahCliRegistry` transitively pulls in `SdkMessageTransformer`; this spec
+ * pins the same failure at its source, inside the project that owns it, by
+ * resolving through the real `registerSdkServices` container rather than
+ * mocking the registry away.
+ *
+ * Verifies that:
+ * 1. `SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY` resolves.
+ * 2. `SDK_TOKENS.SDK_MESSAGE_TRANSFORMER` resolves, with the same registry
+ *    singleton injected.
+ * 3. `SDK_TOKENS.SDK_SESSION_HISTORY_READER` resolves, with the same registry
+ *    singleton injected.
+ */
+
+import 'reflect-metadata';
+
+import { container as rootContainer } from 'tsyringe';
+import type { DependencyContainer } from 'tsyringe';
+
+import { TOKENS, type Logger } from '@ptah-extension/vscode-core';
+import { PLATFORM_TOKENS } from '@ptah-extension/platform-core';
+import {
+  SDK_TOKENS,
+  registerSdkServices,
+  SdkMessageTransformer,
+  SessionHistoryReaderService,
+} from '@ptah-extension/agent-sdk';
+// `@ptah-extension/auth-providers-tokens` only, never the full
+// `@ptah-extension/auth-providers` lib: auth-providers depends on agent-sdk
+// one way (its own CLAUDE.md states this explicitly, to break what would
+// otherwise be a cycle through the provider registry). Importing the full lib
+// from an agent-sdk spec closes that cycle at the Nx project-graph level and
+// breaks every app's build task graph
+// (`ptah-cli:test -> ...:build-esbuild:production -> rpc-handlers:build ->
+// agent-sdk:build -> auth-providers:build -> agent-sdk:build`, reproduced and
+// reverted while writing this spec). The zero-dep tokens package is agent-sdk's
+// existing, real dependency (see AuthEnv/ModelResolver injections throughout
+// this lib) and is all a smoke test needs.
+import { AUTH_PROVIDERS_TOKENS } from '@ptah-extension/auth-providers-tokens';
+
+const ENHANCED_PROMPTS_SERVICE = Symbol.for('SdkEnhancedPromptsService');
+jest.mock('@ptah-extension/agent-generation', () => ({
+  AGENT_GENERATION_TOKENS: {
+    ENHANCED_PROMPTS_SERVICE: Symbol.for('SdkEnhancedPromptsService'),
+  },
+}));
+
+function createMockLogger(): Logger {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+  } as unknown as Logger;
+}
+
+function buildSmokeContainer(): DependencyContainer {
+  const c = rootContainer.createChildContainer();
+  const logger = createMockLogger();
+
+  c.register(TOKENS.LOGGER, { useValue: logger });
+
+  // Platform dependencies required by ConfigWatcher during registerSdkServices
+  c.register(TOKENS.CONFIG_MANAGER, {
+    useValue: {
+      get: jest.fn(() => undefined),
+      set: jest.fn(async () => undefined),
+      getWithDefault: jest.fn((_key, defaultValue) => defaultValue),
+      watch: jest.fn(() => ({ dispose: jest.fn() })),
+    },
+  });
+  c.register(PLATFORM_TOKENS.SECRET_STORAGE, {
+    useValue: {
+      get: jest.fn(async () => undefined),
+      store: jest.fn(async () => undefined),
+      delete: jest.fn(async () => undefined),
+      onDidChange: jest.fn(() => ({ dispose: jest.fn() })),
+    },
+  });
+
+  // Host platform & collaborator fakes required for SDK service resolution
+  c.register(TOKENS.AUTH_SECRETS_SERVICE, {
+    useValue: {
+      getProviderKey: jest.fn(async () => undefined),
+      hasProviderKey: jest.fn(async () => false),
+    },
+  });
+  c.register(TOKENS.SUBAGENT_REGISTRY_SERVICE, {
+    useValue: {
+      register: jest.fn(),
+      unregister: jest.fn(),
+      get: jest.fn(),
+    },
+  });
+  c.register(TOKENS.GIT_INFO_SERVICE, { useValue: {} });
+  c.register(Symbol.for('WorkspaceScopeResolver'), {
+    useValue: { read: jest.fn(() => undefined) },
+  });
+  c.register(TOKENS.SENTRY_SERVICE, {
+    useValue: { captureException: jest.fn(), captureMessage: jest.fn() },
+  });
+  c.register(TOKENS.WEBVIEW_MANAGER, {
+    useValue: { broadcastMessage: jest.fn(async () => undefined) },
+  });
+  c.register(ENHANCED_PROMPTS_SERVICE, {
+    useValue: {
+      setAnalysisReader: jest.fn(),
+      getStatus: jest.fn(),
+    },
+  });
+  c.register(PLATFORM_TOKENS.PLATFORM_INFO, {
+    useValue: {
+      platform: process.platform,
+      arch: process.arch,
+      osVersion: 'test',
+    },
+  });
+  c.register(PLATFORM_TOKENS.WORKSPACE_PROVIDER, {
+    useValue: {
+      getWorkspaceFolders: jest.fn(() => []),
+      getConfiguration: jest.fn(() => ({ get: jest.fn() })),
+      onDidChangeWorkspaceFolders: jest.fn(() => ({ dispose: jest.fn() })),
+    },
+  });
+  c.register(PLATFORM_TOKENS.WORKSPACE_STATE_STORAGE, {
+    useValue: {
+      get: jest.fn(() => undefined),
+      update: jest.fn(async () => undefined),
+      keys: jest.fn(() => []),
+    },
+  });
+
+  // Stubbed directly rather than via `registerAuthProvidersServices` — see the
+  // import comment above. Only the tokens SdkMessageTransformer,
+  // SessionHistoryReaderService and their transitive SDK dependencies actually
+  // inject are needed here.
+  c.register(AUTH_PROVIDERS_TOKENS.SDK_AUTH_ENV, { useValue: {} });
+  c.register(AUTH_PROVIDERS_TOKENS.SDK_MODEL_RESOLVER, {
+    useValue: { resolve: jest.fn((tier: string) => tier) },
+  });
+  c.register(SDK_TOKENS.PRICING_PROVIDER, {
+    useValue: { getPricePerMillionTokens: jest.fn(() => undefined) },
+  });
+
+  registerSdkServices(c, logger);
+  // SessionLifecycleManager pulls in the full query runner and auth strategy
+  // platform stacks. Stub it after registerSdkServices, same as
+  // cli-agent-runtime's smoke spec, to isolate resolution of the transformer
+  // and history reader under test — neither exercises session lifecycle here.
+  c.register(SDK_TOKENS.SDK_SESSION_LIFECYCLE_MANAGER, { useValue: {} });
+
+  return c;
+}
+
+describe('registerSdkServices — CompactionBoundaryGenerationRegistry DI smoke', () => {
+  let container: DependencyContainer;
+
+  beforeEach(() => {
+    container = buildSmokeContainer();
+  });
+
+  it('resolves SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY', () => {
+    const registry = container.resolve<object>(
+      SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY,
+    );
+
+    expect(registry).toBeDefined();
+    expect(registry.constructor.name).toBe(
+      'CompactionBoundaryGenerationRegistry',
+    );
+  });
+
+  it('injects the real CompactionBoundaryGenerationRegistry singleton into SdkMessageTransformer', () => {
+    const transformer = container.resolve<SdkMessageTransformer>(
+      SDK_TOKENS.SDK_MESSAGE_TRANSFORMER,
+    );
+    const registry = container.resolve(
+      SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY,
+    );
+
+    expect(transformer).toBeInstanceOf(SdkMessageTransformer);
+    const injected = (
+      transformer as unknown as {
+        compactionBoundaryRegistry: unknown;
+      }
+    ).compactionBoundaryRegistry;
+    expect(injected).toBe(registry);
+  });
+
+  it('injects the real CompactionBoundaryGenerationRegistry singleton into SessionHistoryReaderService', () => {
+    const reader = container.resolve<SessionHistoryReaderService>(
+      SDK_TOKENS.SDK_SESSION_HISTORY_READER,
+    );
+    const registry = container.resolve(
+      SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY,
+    );
+
+    expect(reader).toBeInstanceOf(SessionHistoryReaderService);
+    const injected = (
+      reader as unknown as {
+        compactionBoundaryRegistry: unknown;
+      }
+    ).compactionBoundaryRegistry;
+    expect(injected).toBe(registry);
+  });
+});

--- a/libs/backend/agent-sdk/src/lib/di/register.ts
+++ b/libs/backend/agent-sdk/src/lib/di/register.ts
@@ -45,6 +45,7 @@ import {
   CompactionConfigProvider,
   CompactionHookHandler,
   CompactionCallbackRegistry,
+  CompactionBoundaryGenerationRegistry,
   SessionIdResolvedCallbackRegistry,
   SessionMcpStatusCallbackRegistry,
   SessionTurnStateRegistry,
@@ -363,6 +364,12 @@ export function registerSdkServices(
   container.register(
     SDK_TOKENS.SDK_COMPACTION_CALLBACK_REGISTRY,
     { useClass: CompactionCallbackRegistry },
+    { lifecycle: Lifecycle.Singleton },
+  );
+
+  container.register(
+    SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY,
+    { useClass: CompactionBoundaryGenerationRegistry },
     { lifecycle: Lifecycle.Singleton },
   );
 

--- a/libs/backend/agent-sdk/src/lib/di/register.ts
+++ b/libs/backend/agent-sdk/src/lib/di/register.ts
@@ -397,12 +397,6 @@ export function registerSdkServices(
   const turnStateRegistry = container.resolve<SessionTurnStateRegistry>(
     SDK_TOKENS.SDK_SESSION_TURN_STATE_REGISTRY,
   );
-  // A PreCompact whose payload lacked `session_id` recorded its expectation
-  // under the tab id; move it onto the real id so chat:resume verifies it.
-  const boundaryRegistry =
-    container.resolve<CompactionBoundaryGenerationRegistry>(
-      SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY,
-    );
   container
     .resolve<SessionIdResolvedCallbackRegistry>(
       SDK_TOKENS.SDK_SESSION_ID_RESOLVED_CALLBACK_REGISTRY,
@@ -410,7 +404,17 @@ export function registerSdkServices(
     .register(({ tabId, realSessionId }) => {
       if (tabId) {
         turnStateRegistry.rekey(tabId, realSessionId);
-        boundaryRegistry.rekey(tabId, realSessionId);
+        // A PreCompact whose payload lacked `session_id` recorded its
+        // expectation under the tab id; move it onto the real id so
+        // chat:resume verifies it. Resolved LAZILY, at the first binding: an
+        // eager resolve here would make registration itself fail on any host
+        // where the registry cannot be constructed, instead of only the
+        // consumers that need it.
+        container
+          .resolve<CompactionBoundaryGenerationRegistry>(
+            SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY,
+          )
+          .rekey(tabId, realSessionId);
       }
     });
 

--- a/libs/backend/agent-sdk/src/lib/di/register.ts
+++ b/libs/backend/agent-sdk/src/lib/di/register.ts
@@ -397,6 +397,12 @@ export function registerSdkServices(
   const turnStateRegistry = container.resolve<SessionTurnStateRegistry>(
     SDK_TOKENS.SDK_SESSION_TURN_STATE_REGISTRY,
   );
+  // A PreCompact whose payload lacked `session_id` recorded its expectation
+  // under the tab id; move it onto the real id so chat:resume verifies it.
+  const boundaryRegistry =
+    container.resolve<CompactionBoundaryGenerationRegistry>(
+      SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY,
+    );
   container
     .resolve<SessionIdResolvedCallbackRegistry>(
       SDK_TOKENS.SDK_SESSION_ID_RESOLVED_CALLBACK_REGISTRY,
@@ -404,6 +410,7 @@ export function registerSdkServices(
     .register(({ tabId, realSessionId }) => {
       if (tabId) {
         turnStateRegistry.rekey(tabId, realSessionId);
+        boundaryRegistry.rekey(tabId, realSessionId);
       }
     });
 

--- a/libs/backend/agent-sdk/src/lib/di/register.ts
+++ b/libs/backend/agent-sdk/src/lib/di/register.ts
@@ -10,7 +10,7 @@
  * Registration uses singleton pattern to ensure consistent state across consumers.
  */
 
-import { DependencyContainer, Lifecycle } from 'tsyringe';
+import { DependencyContainer, instanceCachingFactory, Lifecycle } from 'tsyringe';
 import { TOKENS } from '@ptah-extension/vscode-core';
 import type { Logger } from '@ptah-extension/vscode-core';
 import { MEMORY_CONTRACT_TOKENS } from '@ptah-extension/memory-contracts';
@@ -367,11 +367,22 @@ export function registerSdkServices(
     { lifecycle: Lifecycle.Singleton },
   );
 
-  container.register(
-    SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY,
-    { useClass: CompactionBoundaryGenerationRegistry },
-    { lifecycle: Lifecycle.Singleton },
-  );
+  // `instanceCachingFactory` rather than `useClass`: the registry's only
+  // constructor parameter is a defaulted primitive (`maxEntries = 256`) with
+  // no explicit type annotation, so TypeScript emits `Object` for its
+  // `design:paramtypes` entry and tsyringe's constructor auto-wiring tries
+  // (and fails) to resolve a dependency named "Object" — surfaced as
+  // "TypeInfo not known for \"Object\"" through every consumer's DI chain
+  // (`SdkMessageTransformer`, `SessionHistoryReaderService`, `PtahCliRegistry`
+  // in cli-agent-runtime). A factory sidesteps tsyringe's parameter
+  // resolution entirely and just calls the constructor directly, keeping the
+  // default-parameter API every existing spec constructs with `new
+  // CompactionBoundaryGenerationRegistry()` / `(n)`.
+  container.register(SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY, {
+    useFactory: instanceCachingFactory(
+      () => new CompactionBoundaryGenerationRegistry(),
+    ),
+  });
 
   container.register(
     SDK_TOKENS.SDK_SESSION_ID_RESOLVED_CALLBACK_REGISTRY,

--- a/libs/backend/agent-sdk/src/lib/di/tokens.ts
+++ b/libs/backend/agent-sdk/src/lib/di/tokens.ts
@@ -39,6 +39,9 @@ export const SDK_TOKENS = {
   SDK_COMPACTION_HOOK_HANDLER: Symbol.for('SdkCompactionHookHandler'),
 
   SDK_COMPACTION_CALLBACK_REGISTRY: Symbol.for('SdkCompactionCallbackRegistry'),
+  SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY: Symbol.for(
+    'SdkCompactionBoundaryGenerationRegistry',
+  ),
 
   SDK_SESSION_END_CALLBACK_REGISTRY: Symbol.for(
     'SdkSessionEndCallbackRegistry',

--- a/libs/backend/agent-sdk/src/lib/helpers/auto-compact-control.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/auto-compact-control.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * resolveAutoCompactControl — the pure mapping from Ptah's compaction settings
+ * to the flag-tier keys the pinned runtime honours (TASK_2026_414).
+ *
+ * Contract: unset means the runtime decides (no key), disabled is explicit
+ * (`autoCompactEnabled: false`), and only a valid user window is sent. An
+ * out-of-range window is never clamped into range.
+ */
+
+import {
+  isValidAutoCompactWindow,
+  resolveAutoCompactControl,
+  SDK_AUTO_COMPACT_WINDOW_MAX,
+  SDK_AUTO_COMPACT_WINDOW_MIN,
+} from './auto-compact-control';
+
+describe('resolveAutoCompactControl', () => {
+  it('disabled → autoCompactEnabled false and no window', () => {
+    expect(
+      resolveAutoCompactControl({ enabled: false, windowTokens: 150_000 }),
+    ).toEqual({ autoCompactEnabled: false });
+  });
+
+  it('enabled with no threshold → no keys (the runtime decides)', () => {
+    const control = resolveAutoCompactControl({
+      enabled: true,
+      windowTokens: null,
+    });
+    expect(control).toEqual({});
+    expect('autoCompactEnabled' in control).toBe(false);
+    expect('autoCompactWindow' in control).toBe(false);
+  });
+
+  it('enabled with a valid threshold → that exact window', () => {
+    expect(
+      resolveAutoCompactControl({ enabled: true, windowTokens: 150_000 }),
+    ).toEqual({ autoCompactWindow: 150_000 });
+  });
+
+  it('accepts both inclusive bounds', () => {
+    expect(
+      resolveAutoCompactControl({
+        enabled: true,
+        windowTokens: SDK_AUTO_COMPACT_WINDOW_MIN,
+      }),
+    ).toEqual({ autoCompactWindow: 100_000 });
+    expect(
+      resolveAutoCompactControl({
+        enabled: true,
+        windowTokens: SDK_AUTO_COMPACT_WINDOW_MAX,
+      }),
+    ).toEqual({ autoCompactWindow: 1_000_000 });
+  });
+
+  it.each([
+    ['below the minimum', 99_999],
+    ['above the maximum', 1_000_001],
+    ['not an integer', 150_000.5],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])(
+    'never clamps an invalid window into range — %s → no window',
+    (_label, windowTokens) => {
+      expect(
+        resolveAutoCompactControl({ enabled: true, windowTokens }),
+      ).toEqual({});
+    },
+  );
+});
+
+describe('isValidAutoCompactWindow', () => {
+  it('mirrors the runtime schema: integer in [100000, 1000000]', () => {
+    expect(isValidAutoCompactWindow(100_000)).toBe(true);
+    expect(isValidAutoCompactWindow(1_000_000)).toBe(true);
+    expect(isValidAutoCompactWindow(99_999)).toBe(false);
+    expect(isValidAutoCompactWindow(1_000_001)).toBe(false);
+    expect(isValidAutoCompactWindow(123_456.7)).toBe(false);
+    expect(isValidAutoCompactWindow('150000')).toBe(false);
+    expect(isValidAutoCompactWindow(null)).toBe(false);
+    expect(isValidAutoCompactWindow(undefined)).toBe(false);
+  });
+});

--- a/libs/backend/agent-sdk/src/lib/helpers/auto-compact-control.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/auto-compact-control.ts
@@ -1,0 +1,86 @@
+/**
+ * Auto-compaction control — the ONE translation of Ptah's `compaction.enabled`
+ * and `compaction.threshold` settings into controls the pinned agent runtime
+ * actually honours. Pure: no I/O, no logging, no env reads.
+ *
+ * Evidence (pinned `@anthropic-ai/claude-agent-sdk` 0.3.150, bundled CLI
+ * 2.1.150, read from the shipped `sdk.mjs` and `claude.exe`):
+ *
+ * - The auto-compaction gate is
+ *   `function $G(){if(mH(process.env.DISABLE_COMPACT))return!1;
+ *   if(mH(process.env.DISABLE_AUTO_COMPACT))return!1;
+ *   return $5("autoCompactEnabled",!0).value}`.
+ *   `$5` walks `km()` sources last-to-first, and `km()` always adds
+ *   `"flagSettings"` (the `--settings` tier) to the allowed set, so a flag-tier
+ *   `autoCompactEnabled: false` turns AUTO compaction off. Manual `/compact` is
+ *   not behind `$G`; only `DISABLE_COMPACT` would remove it, and Ptah never sets
+ *   that.
+ * - The settings schema is
+ *   `autoCompactWindow: number().int().min(1e5).max(1e6).optional().catch(void 0)`.
+ *   An out-of-range value is silently DROPPED, so Ptah validates first and
+ *   treats an invalid value as unset rather than sending something the runtime
+ *   will ignore. The runtime compacts near `min(model window, configured window)`.
+ * - The SDK forwards `Options.settings` to the CLI as `--settings <json>`
+ *   (`ProcessTransport.initialize`: `if(this.options.settings)GX.settings=...`,
+ *   then `i.push("--"+key, value)`).
+ * - `CLAUDE_CODE_MAX_CONTEXT_TOKENS` is read only inside
+ *   `if(mH(process.env.DISABLE_COMPACT)&&process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS)`
+ *   (`function XZ`), so it is not a usable control while compaction is on.
+ * - There is no `Options.compactionControl`; that name appears only in the
+ *   deprecated Messages-API `BetaToolRunner` inside the same bundle.
+ */
+
+/** Smallest window the runtime accepts (`min(1e5)`). */
+export const SDK_AUTO_COMPACT_WINDOW_MIN = 100_000;
+/** Largest window the runtime accepts (`max(1e6)`). */
+export const SDK_AUTO_COMPACT_WINDOW_MAX = 1_000_000;
+
+/**
+ * The flag-tier keys Ptah may contribute. A key is PRESENT only when Ptah has
+ * an opinion: the flag tier outranks the user's own settings files, so
+ * emitting `autoCompactEnabled: true` for Ptah's default would silently
+ * override a user who disabled auto compaction for their own CLI.
+ */
+export interface AutoCompactSettings {
+  readonly autoCompactEnabled?: false;
+  readonly autoCompactWindow?: number;
+}
+
+export interface AutoCompactControlInput {
+  /** `compaction.enabled`; Ptah's default is `true`. */
+  readonly enabled: boolean;
+  /** A user-set window in tokens, or `null` when unset (the runtime decides). */
+  readonly windowTokens: number | null;
+}
+
+/** Integer in `[SDK_AUTO_COMPACT_WINDOW_MIN, SDK_AUTO_COMPACT_WINDOW_MAX]`. */
+export function isValidAutoCompactWindow(value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= SDK_AUTO_COMPACT_WINDOW_MIN &&
+    value <= SDK_AUTO_COMPACT_WINDOW_MAX
+  );
+}
+
+/**
+ * Resolve the flag-tier auto-compaction keys for one session.
+ *
+ * - disabled → `{ autoCompactEnabled: false }` (manual `/compact` still works);
+ * - enabled with a valid user window → `{ autoCompactWindow }`;
+ * - enabled with no (or an invalid) window → `{}`: the runtime decides.
+ *
+ * An out-of-range window is never clamped into range — a clamp would apply a
+ * value the user did not choose. Validation and its warning belong to the
+ * settings boundary (`CompactionConfigProvider`); this re-check only keeps a
+ * direct caller from sending a value the runtime would drop.
+ */
+export function resolveAutoCompactControl(
+  input: AutoCompactControlInput,
+): AutoCompactSettings {
+  if (!input.enabled) return { autoCompactEnabled: false };
+  if (isValidAutoCompactWindow(input.windowTokens)) {
+    return { autoCompactWindow: input.windowTokens };
+  }
+  return {};
+}

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.spec.ts
@@ -1,0 +1,223 @@
+import 'reflect-metadata';
+import { CompactionBoundaryGenerationRegistry } from './compaction-boundary-generation-registry';
+
+describe('CompactionBoundaryGenerationRegistry', () => {
+  it('records a verified next count after the baseline has been observed', () => {
+    const registry = new CompactionBoundaryGenerationRegistry();
+    registry.observeBoundaryCount('session-a', 2);
+    registry.recordExpectedBoundary('session-a');
+
+    expect(registry.capturePendingExpectation('session-a')).toEqual({
+      kind: 'verified',
+      expectedCount: 3,
+    });
+    expect(registry.inspect('session-a')).toEqual({
+      baselineObserved: true,
+      observedCount: 2,
+      pendingExpectation: { kind: 'verified', expectedCount: 3 },
+    });
+  });
+
+  it('records an explicitly unverified expectation when the baseline is absent', () => {
+    const registry = new CompactionBoundaryGenerationRegistry();
+    registry.recordExpectedBoundary('session-b');
+
+    expect(registry.capturePendingExpectation('session-b')).toEqual({
+      kind: 'unverified',
+    });
+    expect(registry.inspect('session-b')).toEqual({
+      baselineObserved: false,
+      observedCount: 0,
+      pendingExpectation: { kind: 'unverified' },
+    });
+  });
+
+  it('keeps a baseline-absent expectation unverified even after a later observation', () => {
+    const registry = new CompactionBoundaryGenerationRegistry();
+    registry.recordExpectedBoundary('session-b');
+    registry.observeBoundaryCount('session-b', 5);
+
+    expect(registry.capturePendingExpectation('session-b')).toEqual({
+      kind: 'unverified',
+    });
+    expect(registry.inspect('session-b')).toEqual({
+      baselineObserved: true,
+      observedCount: 5,
+      pendingExpectation: { kind: 'unverified' },
+    });
+  });
+
+  it('captures pending expectation before updating observation', () => {
+    const registry = new CompactionBoundaryGenerationRegistry();
+    registry.observeBoundaryCount('session-c', 1);
+    registry.recordExpectedBoundary('session-c');
+
+    const captured = registry.capturePendingExpectation('session-c');
+    expect(captured).toEqual({ kind: 'verified', expectedCount: 2 });
+
+    registry.observeBoundaryCount('session-c', 2);
+    expect(registry.inspect('session-c')).toEqual({
+      baselineObserved: true,
+      observedCount: 2,
+      pendingExpectation: { kind: 'verified', expectedCount: 2 },
+    });
+  });
+
+  it('claims an already observed persisted boundary when history reads before stream transformation', () => {
+    const registry = new CompactionBoundaryGenerationRegistry();
+    registry.observeBoundaryCount('session-race', 1);
+
+    // An ordinary history read sees the newly persisted boundary before the
+    // SDK stream emits the matching compact_boundary into the transformer.
+    registry.observeBoundaryCount('session-race', 2, 'boundary-2');
+    registry.recordExpectedBoundary('session-race', 'boundary-2');
+
+    expect(registry.capturePendingExpectation('session-race')).toBeUndefined();
+    expect(registry.inspect('session-race')).toEqual({
+      baselineObserved: true,
+      observedCount: 2,
+      pendingExpectation: null,
+    });
+  });
+
+  it('consumes expectation only on explicit consume call', () => {
+    const registry = new CompactionBoundaryGenerationRegistry();
+    registry.observeBoundaryCount('session-d', 0);
+    registry.recordExpectedBoundary('session-d');
+    expect(registry.capturePendingExpectation('session-d')).toEqual({
+      kind: 'verified',
+      expectedCount: 1,
+    });
+
+    registry.consumeExpectation('session-d');
+    expect(registry.capturePendingExpectation('session-d')).toBeUndefined();
+    expect(registry.inspect('session-d')).toEqual({
+      baselineObserved: true,
+      observedCount: 0,
+      pendingExpectation: null,
+    });
+  });
+
+  it('is per-session: one session expectation does not leak to another', () => {
+    const registry = new CompactionBoundaryGenerationRegistry();
+    registry.observeBoundaryCount('session-x', 5);
+    registry.recordExpectedBoundary('session-x');
+
+    expect(registry.capturePendingExpectation('session-y')).toBeUndefined();
+    expect(registry.inspect('session-y')).toBeUndefined();
+  });
+
+  it('bounds the number of sessions and evicts the oldest', () => {
+    const registry = new CompactionBoundaryGenerationRegistry(2);
+    registry.observeBoundaryCount('session-1', 1);
+    registry.observeBoundaryCount('session-2', 1);
+    registry.observeBoundaryCount('session-3', 1);
+
+    expect(registry.inspect('session-1')).toBeUndefined();
+    expect(registry.inspect('session-2')).toEqual({
+      baselineObserved: true,
+      observedCount: 1,
+      pendingExpectation: null,
+    });
+    expect(registry.inspect('session-3')).toEqual({
+      baselineObserved: true,
+      observedCount: 1,
+      pendingExpectation: null,
+    });
+  });
+
+  it('does not evict the oldest pending expectation when later observations exceed capacity', () => {
+    const registry = new CompactionBoundaryGenerationRegistry(2);
+    registry.observeBoundaryCount('pending-oldest', 1);
+    registry.recordExpectedBoundary('pending-oldest');
+    registry.observeBoundaryCount('ordinary-1', 1);
+    registry.observeBoundaryCount('ordinary-2', 1);
+    registry.observeBoundaryCount('ordinary-3', 1);
+
+    expect(registry.capturePendingExpectation('pending-oldest')).toEqual({
+      kind: 'verified',
+      expectedCount: 2,
+    });
+    expect(registry.inspect('ordinary-1')).toBeUndefined();
+    expect(registry.inspect('ordinary-2')).toBeUndefined();
+    expect(registry.inspect('ordinary-3')).toEqual({
+      baselineObserved: true,
+      observedCount: 1,
+      pendingExpectation: null,
+    });
+  });
+
+  it('records an explicit unverified expectation when all primary capacity is pending', () => {
+    const registry = new CompactionBoundaryGenerationRegistry(2);
+    for (const sessionId of ['pending-a', 'pending-b']) {
+      registry.observeBoundaryCount(sessionId, 1);
+      registry.recordExpectedBoundary(sessionId);
+    }
+
+    registry.recordExpectedBoundary('overflow-c');
+
+    expect(registry.capturePendingExpectation('pending-a')).toEqual({
+      kind: 'verified',
+      expectedCount: 2,
+    });
+    expect(registry.capturePendingExpectation('pending-b')).toEqual({
+      kind: 'verified',
+      expectedCount: 2,
+    });
+    expect(registry.capturePendingExpectation('overflow-c')).toEqual({
+      kind: 'unverified',
+    });
+  });
+
+  it('captures and consumes an overflow fail-stale expectation without crossing sessions', () => {
+    const registry = new CompactionBoundaryGenerationRegistry(1);
+    registry.observeBoundaryCount('pending-a', 1);
+    registry.recordExpectedBoundary('pending-a');
+    registry.recordExpectedBoundary('overflow-b');
+
+    expect(registry.capturePendingExpectation('overflow-b')).toEqual({
+      kind: 'unverified',
+    });
+    registry.consumeExpectation('overflow-b');
+
+    expect(registry.capturePendingExpectation('overflow-b')).toBeUndefined();
+    expect(registry.capturePendingExpectation('pending-a')).toEqual({
+      kind: 'verified',
+      expectedCount: 2,
+    });
+  });
+
+  it('reuses a consumed pending session for its next expected generation', () => {
+    const registry = new CompactionBoundaryGenerationRegistry(1);
+    registry.observeBoundaryCount('reused', 1);
+    registry.recordExpectedBoundary('reused');
+    registry.consumeExpectation('reused');
+    registry.observeBoundaryCount('reused', 2);
+    registry.recordExpectedBoundary('reused');
+
+    expect(registry.capturePendingExpectation('reused')).toEqual({
+      kind: 'verified',
+      expectedCount: 3,
+    });
+  });
+
+  it('refreshes LRU order on access so active sessions survive', () => {
+    const registry = new CompactionBoundaryGenerationRegistry(2);
+    registry.observeBoundaryCount('session-1', 1);
+    registry.observeBoundaryCount('session-2', 1);
+    registry.observeBoundaryCount('session-1', 2);
+    registry.observeBoundaryCount('session-3', 1);
+
+    expect(registry.inspect('session-1')).toEqual({
+      baselineObserved: true,
+      observedCount: 2,
+      pendingExpectation: null,
+    });
+    expect(registry.inspect('session-2')).toBeUndefined();
+    expect(registry.inspect('session-3')).toEqual({
+      baselineObserved: true,
+      observedCount: 1,
+      pendingExpectation: null,
+    });
+  });
+});

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.spec.ts
@@ -107,6 +107,50 @@ describe('CompactionBoundaryGenerationRegistry', () => {
     expect(registry.inspect('session-y')).toBeUndefined();
   });
 
+  it('advances the expected count once per distinct boundary recorded before the next observation', () => {
+    // PR #493 review B: two distinct boundaries used to both write
+    // observedCount + 1, so a transcript holding only the first new boundary
+    // satisfied the second expectation.
+    const registry = new CompactionBoundaryGenerationRegistry();
+    registry.observeBoundaryCount('session-stack', 1);
+    registry.recordExpectedBoundary('session-stack', 'boundary-1');
+    registry.recordExpectedBoundary('session-stack', 'boundary-2');
+
+    expect(registry.capturePendingExpectation('session-stack')).toEqual({
+      kind: 'verified',
+      expectedCount: 3,
+    });
+  });
+
+  it('treats a duplicate delivery of the same boundary id as idempotent', () => {
+    const registry = new CompactionBoundaryGenerationRegistry();
+    registry.observeBoundaryCount('session-dup', 1);
+    registry.recordExpectedBoundary('session-dup', 'boundary-1');
+    registry.recordExpectedBoundary('session-dup', 'boundary-1');
+
+    expect(registry.capturePendingExpectation('session-dup')).toEqual({
+      kind: 'verified',
+      expectedCount: 2,
+    });
+  });
+
+  it('keeps an already pending expectation alive when a later boundary claims the observed one', () => {
+    // A history read observes boundary-0 with no expectation pending, then
+    // boundary-1 is recorded, then boundary-0's stream event finally arrives
+    // and claims the observed generation. boundary-1's expectation must
+    // survive the claim.
+    const registry = new CompactionBoundaryGenerationRegistry();
+    registry.observeBoundaryCount('session-claim', 1);
+    registry.observeBoundaryCount('session-claim', 2, 'boundary-0');
+    registry.recordExpectedBoundary('session-claim', 'boundary-1');
+    registry.recordExpectedBoundary('session-claim', 'boundary-0');
+
+    expect(registry.capturePendingExpectation('session-claim')).toEqual({
+      kind: 'verified',
+      expectedCount: 3,
+    });
+  });
+
   it('bounds the number of sessions and evicts the oldest', () => {
     const registry = new CompactionBoundaryGenerationRegistry(2);
     registry.observeBoundaryCount('session-1', 1);

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.spec.ts
@@ -322,15 +322,70 @@ describe('CompactionBoundaryGenerationRegistry', () => {
       });
     });
 
-    it('a stale consume without a PreCompact claim still clears the expectation', () => {
+    it('a stale consume retains a verified boundary expectation for a bounded recovery budget', () => {
+      // PR #493 review C: clearing on the FIRST stale read meant the next read
+      // of the same still-incomplete transcript found no expectation at all and
+      // returned the incomplete snapshot WITHOUT `staleSnapshot`. The
+      // expectation survives two stale reads — the renderer's fallback reload
+      // plus its single retry — and is given up on after that.
       const registry = new CompactionBoundaryGenerationRegistry();
       registry.observeBoundaryCount('boundary-only', 1);
       registry.recordExpectedBoundary('boundary-only', 'boundary-2');
-      registry.consumeExpectation('boundary-only', 'stale');
 
+      registry.consumeExpectation('boundary-only', 'stale');
+      expect(registry.capturePendingExpectation('boundary-only')).toEqual({
+        kind: 'verified',
+        expectedCount: 2,
+      });
+
+      registry.consumeExpectation('boundary-only', 'stale');
+      expect(registry.capturePendingExpectation('boundary-only')).toEqual({
+        kind: 'verified',
+        expectedCount: 2,
+      });
+
+      registry.consumeExpectation('boundary-only', 'stale');
       expect(
         registry.capturePendingExpectation('boundary-only'),
       ).toBeUndefined();
+    });
+
+    it('a satisfied read settles the PreCompact claim so the session becomes evictable again', () => {
+      // PR #493 review C: `satisfied` cleared only the expectation and left
+      // `preCompactUnclaimed` above zero, which protected the entry from
+      // eviction permanently. Enough PostCompact-only sessions then filled the
+      // registry and every later expectation came back unverified.
+      const registry = new CompactionBoundaryGenerationRegistry(2);
+      registry.observeBoundaryCount('post-only', 1);
+      registry.recordPreCompact('post-only');
+      registry.observeBoundaryCount('post-only', 2);
+      registry.consumeExpectation('post-only', 'satisfied');
+
+      registry.observeBoundaryCount('ordinary-1', 1);
+      registry.observeBoundaryCount('ordinary-2', 1);
+
+      expect(registry.inspect('post-only')).toBeUndefined();
+
+      // The freed capacity is available to a real expectation.
+      registry.observeBoundaryCount('later', 3);
+      registry.recordExpectedBoundary('later');
+      expect(registry.capturePendingExpectation('later')).toEqual({
+        kind: 'verified',
+        expectedCount: 4,
+      });
+    });
+
+    it('hasUnsettledPreCompact is true only while the announcement is still pending', () => {
+      const registry = new CompactionBoundaryGenerationRegistry();
+      expect(registry.hasUnsettledPreCompact('pre')).toBe(false);
+
+      registry.observeBoundaryCount('pre', 1);
+      registry.recordPreCompact('pre');
+      expect(registry.hasUnsettledPreCompact('pre')).toBe(true);
+
+      registry.observeBoundaryCount('pre', 2);
+      registry.consumeExpectation('pre', 'satisfied');
+      expect(registry.hasUnsettledPreCompact('pre')).toBe(false);
     });
 
     it('two distinct compactions (Pre, Pre, boundary, boundary) expect +2 then settle', () => {

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.spec.ts
@@ -89,7 +89,7 @@ describe('CompactionBoundaryGenerationRegistry', () => {
       expectedCount: 1,
     });
 
-    registry.consumeExpectation('session-d');
+    registry.consumeExpectation('session-d', 'satisfied');
     expect(registry.capturePendingExpectation('session-d')).toBeUndefined();
     expect(registry.inspect('session-d')).toEqual({
       baselineObserved: true,
@@ -222,7 +222,7 @@ describe('CompactionBoundaryGenerationRegistry', () => {
     expect(registry.capturePendingExpectation('overflow-b')).toEqual({
       kind: 'unverified',
     });
-    registry.consumeExpectation('overflow-b');
+    registry.consumeExpectation('overflow-b', 'stale');
 
     expect(registry.capturePendingExpectation('overflow-b')).toBeUndefined();
     expect(registry.capturePendingExpectation('pending-a')).toEqual({
@@ -235,13 +235,173 @@ describe('CompactionBoundaryGenerationRegistry', () => {
     const registry = new CompactionBoundaryGenerationRegistry(1);
     registry.observeBoundaryCount('reused', 1);
     registry.recordExpectedBoundary('reused');
-    registry.consumeExpectation('reused');
+    registry.consumeExpectation('reused', 'satisfied');
     registry.observeBoundaryCount('reused', 2);
     registry.recordExpectedBoundary('reused');
 
     expect(registry.capturePendingExpectation('reused')).toEqual({
       kind: 'verified',
       expectedCount: 3,
+    });
+  });
+
+  describe('PreCompact expectations (TASK_2026_414 Gap 2)', () => {
+    it('recordPreCompact creates a verified expectation from the observed baseline', () => {
+      const registry = new CompactionBoundaryGenerationRegistry();
+      registry.observeBoundaryCount('pre', 2);
+      registry.recordPreCompact('pre');
+
+      expect(registry.capturePendingExpectation('pre')).toEqual({
+        kind: 'verified',
+        expectedCount: 3,
+      });
+    });
+
+    it('recordPreCompact without a baseline is explicitly unverified', () => {
+      const registry = new CompactionBoundaryGenerationRegistry();
+      registry.recordPreCompact('pre-no-baseline');
+
+      expect(registry.capturePendingExpectation('pre-no-baseline')).toEqual({
+        kind: 'unverified',
+      });
+    });
+
+    it('a live boundary after recordPreCompact claims it without advancing the expected count', () => {
+      const registry = new CompactionBoundaryGenerationRegistry();
+      registry.observeBoundaryCount('pre', 2);
+      registry.recordPreCompact('pre');
+      registry.recordExpectedBoundary('pre', 'boundary-3');
+
+      expect(registry.capturePendingExpectation('pre')).toEqual({
+        kind: 'verified',
+        expectedCount: 3,
+      });
+    });
+
+    it('a history read that satisfies the PreCompact expectation followed by the live boundary does not create a new expectation', () => {
+      const registry = new CompactionBoundaryGenerationRegistry();
+      registry.observeBoundaryCount('pre', 2);
+      registry.recordPreCompact('pre');
+      registry.observeBoundaryCount('pre', 3, 'boundary-3');
+      registry.consumeExpectation('pre', 'satisfied');
+      registry.recordExpectedBoundary('pre', 'boundary-3');
+
+      expect(registry.capturePendingExpectation('pre')).toBeUndefined();
+    });
+
+    it('a stale read keeps a verified PreCompact expectation so the retry is still verified', () => {
+      const registry = new CompactionBoundaryGenerationRegistry();
+      registry.observeBoundaryCount('pre', 2);
+      registry.recordPreCompact('pre');
+      registry.observeBoundaryCount('pre', 2);
+      registry.consumeExpectation('pre', 'stale');
+
+      expect(registry.capturePendingExpectation('pre')).toEqual({
+        kind: 'verified',
+        expectedCount: 3,
+      });
+
+      registry.observeBoundaryCount('pre', 3, 'boundary-3');
+      registry.consumeExpectation('pre', 'satisfied');
+      registry.recordExpectedBoundary('pre', 'boundary-3');
+      expect(registry.capturePendingExpectation('pre')).toBeUndefined();
+    });
+
+    it('a stale consumption of an unverified PreCompact expectation resets the claim so the later live boundary re-establishes an expectation', () => {
+      const registry = new CompactionBoundaryGenerationRegistry();
+      registry.recordPreCompact('pre');
+      registry.observeBoundaryCount('pre', 2);
+      registry.consumeExpectation('pre', 'stale');
+      expect(registry.capturePendingExpectation('pre')).toBeUndefined();
+
+      registry.recordExpectedBoundary('pre', 'boundary-3');
+
+      expect(registry.capturePendingExpectation('pre')).toEqual({
+        kind: 'verified',
+        expectedCount: 3,
+      });
+    });
+
+    it('a stale consume without a PreCompact claim still clears the expectation', () => {
+      const registry = new CompactionBoundaryGenerationRegistry();
+      registry.observeBoundaryCount('boundary-only', 1);
+      registry.recordExpectedBoundary('boundary-only', 'boundary-2');
+      registry.consumeExpectation('boundary-only', 'stale');
+
+      expect(
+        registry.capturePendingExpectation('boundary-only'),
+      ).toBeUndefined();
+    });
+
+    it('two distinct compactions (Pre, Pre, boundary, boundary) expect +2 then settle', () => {
+      const registry = new CompactionBoundaryGenerationRegistry();
+      registry.observeBoundaryCount('two', 1);
+      registry.recordPreCompact('two');
+      registry.recordPreCompact('two');
+      expect(registry.capturePendingExpectation('two')).toEqual({
+        kind: 'verified',
+        expectedCount: 3,
+      });
+
+      registry.recordExpectedBoundary('two', 'boundary-2');
+      registry.recordExpectedBoundary('two', 'boundary-3');
+      expect(registry.capturePendingExpectation('two')).toEqual({
+        kind: 'verified',
+        expectedCount: 3,
+      });
+
+      registry.observeBoundaryCount('two', 3, 'boundary-3');
+      registry.consumeExpectation('two', 'satisfied');
+      expect(registry.capturePendingExpectation('two')).toBeUndefined();
+    });
+
+    it('rekey moves a tabId entry onto the real id when the real id has no entry', () => {
+      const registry = new CompactionBoundaryGenerationRegistry();
+      registry.recordPreCompact('tab-1');
+      registry.rekey('tab-1', 'real-1');
+
+      expect(registry.capturePendingExpectation('tab-1')).toBeUndefined();
+      expect(registry.capturePendingExpectation('real-1')).toEqual({
+        kind: 'unverified',
+      });
+    });
+
+    it('rekey moves a tabId entry onto the real id without overwriting real-id evidence', () => {
+      const registry = new CompactionBoundaryGenerationRegistry();
+      registry.observeBoundaryCount('real-2', 4);
+      registry.recordExpectedBoundary('real-2', 'boundary-5');
+      registry.recordPreCompact('tab-2');
+
+      registry.rekey('tab-2', 'real-2');
+
+      expect(registry.inspect('tab-2')).toBeUndefined();
+      expect(registry.inspect('real-2')).toEqual({
+        baselineObserved: true,
+        observedCount: 4,
+        pendingExpectation: { kind: 'verified', expectedCount: 5 },
+      });
+      // The carried PreCompact claim absorbs its own live boundary.
+      registry.recordExpectedBoundary('real-2', 'boundary-6');
+      expect(registry.capturePendingExpectation('real-2')).toEqual({
+        kind: 'verified',
+        expectedCount: 5,
+      });
+    });
+
+    it('rekey ignores blank ids, equal ids and a missing source', () => {
+      const registry = new CompactionBoundaryGenerationRegistry();
+      registry.observeBoundaryCount('real-3', 1);
+      registry.recordPreCompact('real-3');
+
+      registry.rekey('', 'real-3');
+      registry.rekey('real-3', '');
+      registry.rekey('real-3', 'real-3');
+      registry.rekey('missing', 'real-3');
+
+      expect(registry.capturePendingExpectation('real-3')).toEqual({
+        kind: 'verified',
+        expectedCount: 2,
+      });
     });
   });
 

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.ts
@@ -1,0 +1,225 @@
+/**
+ * CompactionBoundaryGenerationRegistry
+ *
+ * Process-local, per-session registry that tracks observed compact-boundary
+ * counts and a single pending expected count. It exists so that
+ * `chat:resume` can verify, with one immutable parse, whether the JSONL it
+ * just read already contains the boundary that a freshly-completed compaction
+ * promised.
+ *
+ * Design constraints (TASK_2026_414):
+ * - No timestamps, TTLs, delay constants, or slack.
+ * - Bounded number of sessions; never grows without limit.
+ * - Expectation is recorded only after a compact_boundary message resolves to
+ *   a real session id.
+ * - A baseline-absent expectation is explicitly unverified and stays stale
+ *   regardless of any historical boundary count.
+ * - The reader captures any pending expectation BEFORE it observes the count
+ *   from the current parse, and consumes the expectation after the response.
+ */
+
+import { injectable } from 'tsyringe';
+
+export interface VerifiedExpectation {
+  readonly kind: 'verified';
+  readonly expectedCount: number;
+}
+
+export interface UnverifiedExpectation {
+  readonly kind: 'unverified';
+}
+
+export type PendingExpectation = VerifiedExpectation | UnverifiedExpectation;
+
+interface CompactionBoundaryEntry {
+  /**
+   * True once this session's compact-boundary baseline has been observed by a
+   * real history parse. False means the registry has no baseline for the
+   * session and cannot verify an expectation.
+   */
+  baselineObserved: boolean;
+  /** Latest observed compact-boundary count from a full history parse. */
+  observedCount: number;
+  /** Pending expectation, or null when none. */
+  pendingExpectation: PendingExpectation | null;
+  /**
+   * Boundary generation that has already been persisted and observed before
+   * its matching streamed compact_boundary reaches the transformer. The stream
+   * side records this as fulfilled rather than expecting an additional boundary.
+   */
+  observedUnclaimedBoundaryId: string | null;
+}
+
+@injectable()
+export class CompactionBoundaryGenerationRegistry {
+  private readonly entries = new Map<string, CompactionBoundaryEntry>();
+  /**
+   * A bounded set of expectations rejected because every primary slot was
+   * pending. They are deliberately unverified: retaining the session id makes
+   * the later resume stale rather than silently treating it as expectationless.
+   */
+  private readonly overflowUnverifiedSessions = new Map<string, true>();
+
+  /**
+   * Only reached if both bounded stores are full of pending expectations.
+   * From then on an unknown compaction check fails stale conservatively. There
+   * is no safe per-session fact left to retain without making memory unbounded.
+   */
+  private overflowSaturated = false;
+
+  constructor(private readonly maxEntries = 256) {}
+
+  /**
+   * Record that a streamed compaction boundary completed for `sessionId`.
+   *
+   * A history read can observe the persisted boundary before this transformer
+   * call. `observedUnclaimedBoundaryId` is an ordering fact, not a clock:
+   * claim that observed generation instead of expecting a fictitious next one.
+   * Otherwise, a known baseline yields the next expected generation; without a
+   * baseline the expectation remains explicitly unverified.
+   */
+  recordExpectedBoundary(sessionId: string, boundaryId?: string): void {
+    const entry = this.ensureEntry(sessionId);
+    if (!entry) {
+      this.recordOverflowUnverifiedExpectation(sessionId);
+      return;
+    }
+    if (
+      boundaryId !== undefined &&
+      entry.observedUnclaimedBoundaryId === boundaryId
+    ) {
+      entry.observedUnclaimedBoundaryId = null;
+      entry.pendingExpectation = null;
+      return;
+    }
+    if (entry.baselineObserved) {
+      entry.pendingExpectation = {
+        kind: 'verified',
+        expectedCount: entry.observedCount + 1,
+      };
+    } else {
+      entry.pendingExpectation = { kind: 'unverified' };
+    }
+  }
+
+  /**
+   * Read any pending expectation for `sessionId`. The caller must capture this
+   * BEFORE observing the current parse so the observed count is not influenced
+   * by a same-loop observation. Non-consuming.
+   */
+  capturePendingExpectation(sessionId: string): PendingExpectation | undefined {
+    const entry = this.entries.get(sessionId);
+    if (entry?.pendingExpectation) {
+      return entry.pendingExpectation;
+    }
+    if (
+      this.overflowUnverifiedSessions.has(sessionId) ||
+      this.overflowSaturated
+    ) {
+      return { kind: 'unverified' };
+    }
+    return undefined;
+  }
+
+  /**
+   * Record the observed compact-boundary count from a successful full parse and
+   * mark the baseline as observed. A count advance with no pending expectation
+   * is retained as an unclaimed persisted generation for a later streamed
+   * boundary to claim.
+   */
+  observeBoundaryCount(
+    sessionId: string,
+    count: number,
+    latestBoundaryId?: string,
+  ): void {
+    const entry = this.ensureEntry(sessionId);
+    if (!entry) return;
+    const previousCount = entry.observedCount;
+    const hadBaseline = entry.baselineObserved;
+    entry.baselineObserved = true;
+    entry.observedCount = count;
+    if (
+      hadBaseline &&
+      entry.pendingExpectation === null &&
+      count > previousCount &&
+      latestBoundaryId !== undefined
+    ) {
+      entry.observedUnclaimedBoundaryId = latestBoundaryId;
+    }
+  }
+
+  /**
+   * Consume the pending expectation after the response is ready or exhausted.
+   */
+  consumeExpectation(sessionId: string): void {
+    const entry = this.entries.get(sessionId);
+    if (entry) {
+      entry.pendingExpectation = null;
+    }
+    this.overflowUnverifiedSessions.delete(sessionId);
+  }
+
+  /** Test-only inspection. */
+  inspect(
+    sessionId: string,
+  ): Omit<
+    CompactionBoundaryEntry,
+    'observedUnclaimedBoundaryId'
+  > | undefined {
+    const entry = this.entries.get(sessionId);
+    if (!entry) return undefined;
+    const {
+      observedUnclaimedBoundaryId: _unclaimed,
+      ...inspection
+    } = entry;
+    return inspection;
+  }
+
+  private ensureEntry(
+    sessionId: string,
+  ): CompactionBoundaryEntry | undefined {
+    let entry = this.entries.get(sessionId);
+    if (!entry) {
+      this.evictOldestNonPendingEntry();
+      if (this.entries.size >= this.maxEntries) {
+        return undefined;
+      }
+      entry = {
+        baselineObserved: false,
+        observedCount: 0,
+        pendingExpectation: null,
+        observedUnclaimedBoundaryId: null,
+      };
+    } else {
+      // Refresh LRU position.
+      this.entries.delete(sessionId);
+    }
+    this.entries.set(sessionId, entry);
+    return entry;
+  }
+
+  private evictOldestNonPendingEntry(): void {
+    while (this.entries.size >= this.maxEntries) {
+      const evictable = [...this.entries.entries()].find(
+        ([, entry]) => entry.pendingExpectation === null,
+      );
+      if (!evictable) {
+        return;
+      }
+      this.entries.delete(evictable[0]);
+    }
+  }
+
+  private recordOverflowUnverifiedExpectation(sessionId: string): void {
+    if (this.overflowSaturated) return;
+
+    this.overflowUnverifiedSessions.delete(sessionId);
+    this.overflowUnverifiedSessions.set(sessionId, true);
+    if (this.overflowUnverifiedSessions.size > this.maxEntries) {
+      // Do not evict an active fail-stale marker. A single conservative mode is
+      // bounded and safe; dropping the marker would make the next resume ready.
+      this.overflowSaturated = true;
+      this.overflowUnverifiedSessions.clear();
+    }
+  }
+}

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.ts
@@ -72,6 +72,16 @@ interface CompactionBoundaryEntry {
    * boundary claims it rather than advancing the count again.
    */
   preCompactUnclaimed: number;
+  /**
+   * How many more `stale` reads a VERIFIED expectation survives before it is
+   * given up on. This is the recovery deadline, counted in reads rather than
+   * milliseconds: a stale read is not evidence that the promised boundary will
+   * never land, so clearing on the first one made the NEXT read of the same
+   * incomplete transcript return a snapshot with no `staleSnapshot` flag at all
+   * (PR #493 review C). Zero for an unverified expectation, which can never be
+   * satisfied and so is cleared on its first stale read.
+   */
+  staleRetainsRemaining: number;
 }
 
 @injectable()
@@ -90,6 +100,14 @@ export class CompactionBoundaryGenerationRegistry {
    * is no safe per-session fact left to retain without making memory unbounded.
    */
   private overflowSaturated = false;
+
+  /**
+   * How many consecutive `stale` reads a verified expectation survives. Two
+   * covers the renderer's own recovery shape — the advisory fallback reload
+   * plus its single stale retry — after which the expectation is given up on
+   * so the session can settle and become evictable again.
+   */
+  private static readonly STALE_RETAIN_BUDGET = 2;
 
   constructor(private readonly maxEntries = 256) {}
 
@@ -207,31 +225,61 @@ export class CompactionBoundaryGenerationRegistry {
   /**
    * Consume the pending expectation after the response is ready or exhausted.
    *
-   * One exception keeps an expectation alive: a VERIFIED expectation backed by
-   * an unclaimed PreCompact that a read found `stale`. That compaction was
-   * announced and its boundary is merely not on disk yet, so the next read (the
-   * renderer's single retry) must still be verified rather than accept whatever
-   * is on disk. It resolves on the first satisfied read or when the live
-   * boundary's claim is followed by one. An unverified expectation can never be
+   * A VERIFIED expectation survives a `stale` read while its recovery budget
+   * lasts. A stale read means the promised boundary is not on disk YET, not
+   * that it will never arrive; clearing on the first one made the next read of
+   * the same incomplete transcript find no expectation and return the
+   * incomplete snapshot with no `staleSnapshot` flag at all (PR #493 review C).
+   * The budget is the recovery deadline, counted in reads so this class keeps
+   * its no-clock design constraint. An UNVERIFIED expectation can never be
    * satisfied, so a stale read clears it and drops the PreCompact claim: the
    * eventual live boundary then opens a fresh, verifiable expectation.
+   *
+   * A `satisfied` read clears the expectation but KEEPS `preCompactUnclaimed`,
+   * which from that point is dedup state only — it lets the late live boundary
+   * of the same compaction claim its announcement instead of expecting a
+   * fictitious next generation. It no longer protects the entry from eviction
+   * (see {@link evictOldestNonPendingEntry}), so a run of PostCompact-only
+   * sessions can no longer fill the registry (PR #493 review C).
    */
   consumeExpectation(sessionId: string, outcome: ExpectationOutcome): void {
     const entry = this.entries.get(sessionId);
     if (entry) {
       const retainForRetry =
         outcome === 'stale' &&
-        entry.preCompactUnclaimed > 0 &&
-        entry.pendingExpectation?.kind === 'verified';
-      if (!retainForRetry) {
+        entry.pendingExpectation?.kind === 'verified' &&
+        entry.staleRetainsRemaining > 0;
+      if (retainForRetry) {
+        entry.staleRetainsRemaining -= 1;
+      } else {
         entry.pendingExpectation = null;
         entry.pendingBoundaryIds.clear();
+        entry.staleRetainsRemaining = 0;
         if (outcome === 'stale') {
           entry.preCompactUnclaimed = 0;
         }
       }
     }
     this.overflowUnverifiedSessions.delete(sessionId);
+  }
+
+  /**
+   * Whether a PreCompact announcement for `sessionId` is still open: it has an
+   * unclaimed announcement AND an expectation nothing has settled yet.
+   *
+   * `CompactionHookHandler` asks this before treating a second PreCompact as a
+   * retry of the first. Keying retry detection on the session id alone meant a
+   * compaction that completed without a PostCompact left the marker set
+   * forever, so the NEXT genuine compaction was mistaken for a retry and
+   * recorded no expectation at all (PR #493 review C).
+   */
+  hasUnsettledPreCompact(sessionId: string): boolean {
+    const entry = this.entries.get(sessionId);
+    return (
+      entry !== undefined &&
+      entry.preCompactUnclaimed > 0 &&
+      entry.pendingExpectation !== null
+    );
   }
 
   /**
@@ -266,6 +314,10 @@ export class CompactionBoundaryGenerationRegistry {
       to.observedUnclaimedBoundaryId ?? from.observedUnclaimedBoundaryId;
     for (const id of from.pendingBoundaryIds) to.pendingBoundaryIds.add(id);
     to.preCompactUnclaimed += from.preCompactUnclaimed;
+    to.staleRetainsRemaining = Math.max(
+      to.staleRetainsRemaining,
+      from.staleRetainsRemaining,
+    );
   }
 
   /** Test-only inspection. */
@@ -273,7 +325,10 @@ export class CompactionBoundaryGenerationRegistry {
     sessionId: string,
   ): Omit<
     CompactionBoundaryEntry,
-    'observedUnclaimedBoundaryId' | 'pendingBoundaryIds' | 'preCompactUnclaimed'
+    | 'observedUnclaimedBoundaryId'
+    | 'pendingBoundaryIds'
+    | 'preCompactUnclaimed'
+    | 'staleRetainsRemaining'
   > | undefined {
     const entry = this.entries.get(sessionId);
     if (!entry) return undefined;
@@ -281,6 +336,7 @@ export class CompactionBoundaryGenerationRegistry {
       observedUnclaimedBoundaryId: _unclaimed,
       pendingBoundaryIds: _pendingIds,
       preCompactUnclaimed: _preCompact,
+      staleRetainsRemaining: _staleRetains,
       ...inspection
     } = entry;
     return inspection;
@@ -297,8 +353,11 @@ export class CompactionBoundaryGenerationRegistry {
         kind: 'verified',
         expectedCount: Math.max(entry.observedCount, currentExpectedCount) + 1,
       };
+      entry.staleRetainsRemaining =
+        CompactionBoundaryGenerationRegistry.STALE_RETAIN_BUDGET;
     } else {
       entry.pendingExpectation = { kind: 'unverified' };
+      entry.staleRetainsRemaining = 0;
     }
   }
 
@@ -333,6 +392,7 @@ export class CompactionBoundaryGenerationRegistry {
         observedUnclaimedBoundaryId: null,
         pendingBoundaryIds: new Set<string>(),
         preCompactUnclaimed: 0,
+        staleRetainsRemaining: 0,
       };
     } else {
       // Refresh LRU position.
@@ -342,11 +402,18 @@ export class CompactionBoundaryGenerationRegistry {
     return entry;
   }
 
+  /**
+   * Evict the oldest entry that owes nothing. A PENDING expectation is the only
+   * thing worth protecting: an entry whose expectation is already settled holds
+   * at most a PreCompact claim kept for late-boundary dedup, and losing that to
+   * eviction costs one conservative extra expectation, never a false
+   * verification. Protecting the claim as well is what let a run of
+   * PostCompact-only sessions fill the registry permanently (PR #493 review C).
+   */
   private evictOldestNonPendingEntry(): void {
     while (this.entries.size >= this.maxEntries) {
       const evictable = [...this.entries.entries()].find(
-        ([, entry]) =>
-          entry.pendingExpectation === null && entry.preCompactUnclaimed === 0,
+        ([, entry]) => entry.pendingExpectation === null,
       );
       if (!evictable) {
         return;

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.ts
@@ -10,8 +10,12 @@
  * Design constraints (TASK_2026_414):
  * - No timestamps, TTLs, delay constants, or slack.
  * - Bounded number of sessions; never grows without limit.
- * - Expectation is recorded only after a compact_boundary message resolves to
- *   a real session id.
+ * - An expectation is recorded when a compact_boundary message resolves to a
+ *   real session id, OR when an interactive PreCompact hook resolves one
+ *   (`recordPreCompact`) — the boundary is the one signal that may be missing,
+ *   so a PostCompact-only reload still needs an expectation to verify against.
+ *   A later live boundary for the same compaction CLAIMS the PreCompact
+ *   expectation instead of counting a second generation.
  * - A baseline-absent expectation is explicitly unverified and stays stale
  *   regardless of any historical boundary count.
  * - The reader captures any pending expectation BEFORE it observes the count
@@ -30,6 +34,14 @@ export interface UnverifiedExpectation {
 }
 
 export type PendingExpectation = VerifiedExpectation | UnverifiedExpectation;
+
+/**
+ * What a history read concluded about the expectation it captured.
+ * - `satisfied`: the parse contained the expected boundary generation.
+ * - `stale`: the read could not verify it (unmet, missing file, error).
+ * - `none`: there was no expectation to verify.
+ */
+export type ExpectationOutcome = 'satisfied' | 'stale' | 'none';
 
 interface CompactionBoundaryEntry {
   /**
@@ -54,6 +66,12 @@ interface CompactionBoundaryEntry {
    * delivery of the same id must not (PR #493 review B).
    */
   pendingBoundaryIds: Set<string>;
+  /**
+   * Compactions announced by PreCompact whose live compact_boundary has not
+   * arrived yet. Each one already advanced the expected count, so the matching
+   * boundary claims it rather than advancing the count again.
+   */
+  preCompactUnclaimed: number;
 }
 
 @injectable()
@@ -76,13 +94,33 @@ export class CompactionBoundaryGenerationRegistry {
   constructor(private readonly maxEntries = 256) {}
 
   /**
+   * Record that an interactive PreCompact hook announced a compaction for
+   * `sessionId`. It advances the expectation exactly as a distinct boundary
+   * would, and leaves a claim for the live boundary of the same compaction.
+   *
+   * Callers must gate this to interactive sessions: a callback-less child
+   * compaction never reaches a UI reload, and pending entries are not evicted.
+   */
+  recordPreCompact(sessionId: string): void {
+    const entry = this.ensureEntry(sessionId);
+    if (!entry) {
+      this.recordOverflowUnverifiedExpectation(sessionId);
+      return;
+    }
+    entry.preCompactUnclaimed += 1;
+    this.advanceExpectation(entry);
+  }
+
+  /**
    * Record that a streamed compaction boundary completed for `sessionId`.
    *
    * A history read can observe the persisted boundary before this transformer
    * call. `observedUnclaimedBoundaryId` is an ordering fact, not a clock:
    * claim that observed generation instead of expecting a fictitious next one.
-   * Otherwise, a known baseline yields the next expected generation; without a
-   * baseline the expectation remains explicitly unverified.
+   * A boundary for a compaction PreCompact already announced claims that
+   * announcement. Otherwise, a known baseline yields the next expected
+   * generation; without a baseline the expectation remains explicitly
+   * unverified.
    *
    * Distinct boundaries stack: each one recorded before the next history
    * observation advances the expected count from max(observedCount, the
@@ -103,6 +141,7 @@ export class CompactionBoundaryGenerationRegistry {
         // belongs to other boundaries and must survive the claim.
         entry.observedUnclaimedBoundaryId = null;
         entry.pendingBoundaryIds.delete(boundaryId);
+        entry.preCompactUnclaimed = Math.max(0, entry.preCompactUnclaimed - 1);
         return;
       }
       if (entry.pendingBoundaryIds.has(boundaryId)) {
@@ -111,18 +150,12 @@ export class CompactionBoundaryGenerationRegistry {
       }
       entry.pendingBoundaryIds.add(boundaryId);
     }
-    if (entry.baselineObserved) {
-      const currentExpectedCount =
-        entry.pendingExpectation?.kind === 'verified'
-          ? entry.pendingExpectation.expectedCount
-          : entry.observedCount;
-      entry.pendingExpectation = {
-        kind: 'verified',
-        expectedCount: Math.max(entry.observedCount, currentExpectedCount) + 1,
-      };
-    } else {
-      entry.pendingExpectation = { kind: 'unverified' };
+    if (entry.preCompactUnclaimed > 0) {
+      // PreCompact already counted this compaction.
+      entry.preCompactUnclaimed -= 1;
+      return;
     }
+    this.advanceExpectation(entry);
   }
 
   /**
@@ -173,14 +206,66 @@ export class CompactionBoundaryGenerationRegistry {
 
   /**
    * Consume the pending expectation after the response is ready or exhausted.
+   *
+   * One exception keeps an expectation alive: a VERIFIED expectation backed by
+   * an unclaimed PreCompact that a read found `stale`. That compaction was
+   * announced and its boundary is merely not on disk yet, so the next read (the
+   * renderer's single retry) must still be verified rather than accept whatever
+   * is on disk. It resolves on the first satisfied read or when the live
+   * boundary's claim is followed by one. An unverified expectation can never be
+   * satisfied, so a stale read clears it and drops the PreCompact claim: the
+   * eventual live boundary then opens a fresh, verifiable expectation.
    */
-  consumeExpectation(sessionId: string): void {
+  consumeExpectation(sessionId: string, outcome: ExpectationOutcome): void {
     const entry = this.entries.get(sessionId);
     if (entry) {
-      entry.pendingExpectation = null;
-      entry.pendingBoundaryIds.clear();
+      const retainForRetry =
+        outcome === 'stale' &&
+        entry.preCompactUnclaimed > 0 &&
+        entry.pendingExpectation?.kind === 'verified';
+      if (!retainForRetry) {
+        entry.pendingExpectation = null;
+        entry.pendingBoundaryIds.clear();
+        if (outcome === 'stale') {
+          entry.preCompactUnclaimed = 0;
+        }
+      }
     }
     this.overflowUnverifiedSessions.delete(sessionId);
+  }
+
+  /**
+   * Move `fromId`'s state onto `toId` when a provisional id (a tab id) resolves
+   * to the real SDK session id. Real-id evidence is never overwritten: when
+   * both exist the real id keeps its baseline, the larger verified expected
+   * count wins, and PreCompact claims and pending boundary ids are combined.
+   * Blank or equal ids are ignored.
+   */
+  rekey(fromId: string, toId: string): void {
+    if (!fromId || !toId || fromId === toId) return;
+    if (this.overflowUnverifiedSessions.delete(fromId)) {
+      this.overflowUnverifiedSessions.set(toId, true);
+    }
+    const from = this.entries.get(fromId);
+    if (!from) return;
+    this.entries.delete(fromId);
+    const to = this.entries.get(toId);
+    if (!to) {
+      this.entries.set(toId, from);
+      return;
+    }
+    if (!to.baselineObserved && from.baselineObserved) {
+      to.baselineObserved = true;
+      to.observedCount = from.observedCount;
+    }
+    to.pendingExpectation = this.mergeExpectations(
+      to.pendingExpectation,
+      from.pendingExpectation,
+    );
+    to.observedUnclaimedBoundaryId =
+      to.observedUnclaimedBoundaryId ?? from.observedUnclaimedBoundaryId;
+    for (const id of from.pendingBoundaryIds) to.pendingBoundaryIds.add(id);
+    to.preCompactUnclaimed += from.preCompactUnclaimed;
   }
 
   /** Test-only inspection. */
@@ -188,16 +273,48 @@ export class CompactionBoundaryGenerationRegistry {
     sessionId: string,
   ): Omit<
     CompactionBoundaryEntry,
-    'observedUnclaimedBoundaryId' | 'pendingBoundaryIds'
+    'observedUnclaimedBoundaryId' | 'pendingBoundaryIds' | 'preCompactUnclaimed'
   > | undefined {
     const entry = this.entries.get(sessionId);
     if (!entry) return undefined;
     const {
       observedUnclaimedBoundaryId: _unclaimed,
       pendingBoundaryIds: _pendingIds,
+      preCompactUnclaimed: _preCompact,
       ...inspection
     } = entry;
     return inspection;
+  }
+
+  /** Advance the expectation by one generation, as one distinct compaction. */
+  private advanceExpectation(entry: CompactionBoundaryEntry): void {
+    if (entry.baselineObserved) {
+      const currentExpectedCount =
+        entry.pendingExpectation?.kind === 'verified'
+          ? entry.pendingExpectation.expectedCount
+          : entry.observedCount;
+      entry.pendingExpectation = {
+        kind: 'verified',
+        expectedCount: Math.max(entry.observedCount, currentExpectedCount) + 1,
+      };
+    } else {
+      entry.pendingExpectation = { kind: 'unverified' };
+    }
+  }
+
+  private mergeExpectations(
+    real: PendingExpectation | null,
+    provisional: PendingExpectation | null,
+  ): PendingExpectation | null {
+    if (!provisional) return real;
+    if (!real) return provisional;
+    if (real.kind === 'verified' && provisional.kind === 'verified') {
+      return {
+        kind: 'verified',
+        expectedCount: Math.max(real.expectedCount, provisional.expectedCount),
+      };
+    }
+    return real;
   }
 
   private ensureEntry(
@@ -215,6 +332,7 @@ export class CompactionBoundaryGenerationRegistry {
         pendingExpectation: null,
         observedUnclaimedBoundaryId: null,
         pendingBoundaryIds: new Set<string>(),
+        preCompactUnclaimed: 0,
       };
     } else {
       // Refresh LRU position.
@@ -227,7 +345,8 @@ export class CompactionBoundaryGenerationRegistry {
   private evictOldestNonPendingEntry(): void {
     while (this.entries.size >= this.maxEntries) {
       const evictable = [...this.entries.entries()].find(
-        ([, entry]) => entry.pendingExpectation === null,
+        ([, entry]) =>
+          entry.pendingExpectation === null && entry.preCompactUnclaimed === 0,
       );
       if (!evictable) {
         return;

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-boundary-generation-registry.ts
@@ -48,6 +48,12 @@ interface CompactionBoundaryEntry {
    * side records this as fulfilled rather than expecting an additional boundary.
    */
   observedUnclaimedBoundaryId: string | null;
+  /**
+   * Distinct boundary ids recorded but not yet observed by a history parse.
+   * Each distinct boundary must advance the expected count by one; a duplicate
+   * delivery of the same id must not (PR #493 review B).
+   */
+  pendingBoundaryIds: Set<string>;
 }
 
 @injectable()
@@ -77,6 +83,12 @@ export class CompactionBoundaryGenerationRegistry {
    * claim that observed generation instead of expecting a fictitious next one.
    * Otherwise, a known baseline yields the next expected generation; without a
    * baseline the expectation remains explicitly unverified.
+   *
+   * Distinct boundaries stack: each one recorded before the next history
+   * observation advances the expected count from max(observedCount, the
+   * current pending expected count) + 1, so a transcript containing only the
+   * first of two boundaries stays stale. A duplicate of the same boundary id
+   * is idempotent.
    */
   recordExpectedBoundary(sessionId: string, boundaryId?: string): void {
     const entry = this.ensureEntry(sessionId);
@@ -84,18 +96,29 @@ export class CompactionBoundaryGenerationRegistry {
       this.recordOverflowUnverifiedExpectation(sessionId);
       return;
     }
-    if (
-      boundaryId !== undefined &&
-      entry.observedUnclaimedBoundaryId === boundaryId
-    ) {
-      entry.observedUnclaimedBoundaryId = null;
-      entry.pendingExpectation = null;
-      return;
+    if (boundaryId !== undefined) {
+      if (entry.observedUnclaimedBoundaryId === boundaryId) {
+        // Read-before-transform claim: the boundary is already persisted and
+        // counted, so it adds no expectation. An expectation still pending
+        // belongs to other boundaries and must survive the claim.
+        entry.observedUnclaimedBoundaryId = null;
+        entry.pendingBoundaryIds.delete(boundaryId);
+        return;
+      }
+      if (entry.pendingBoundaryIds.has(boundaryId)) {
+        // Duplicate delivery of the same boundary — idempotent no-op.
+        return;
+      }
+      entry.pendingBoundaryIds.add(boundaryId);
     }
     if (entry.baselineObserved) {
+      const currentExpectedCount =
+        entry.pendingExpectation?.kind === 'verified'
+          ? entry.pendingExpectation.expectedCount
+          : entry.observedCount;
       entry.pendingExpectation = {
         kind: 'verified',
-        expectedCount: entry.observedCount + 1,
+        expectedCount: Math.max(entry.observedCount, currentExpectedCount) + 1,
       };
     } else {
       entry.pendingExpectation = { kind: 'unverified' };
@@ -155,6 +178,7 @@ export class CompactionBoundaryGenerationRegistry {
     const entry = this.entries.get(sessionId);
     if (entry) {
       entry.pendingExpectation = null;
+      entry.pendingBoundaryIds.clear();
     }
     this.overflowUnverifiedSessions.delete(sessionId);
   }
@@ -164,12 +188,13 @@ export class CompactionBoundaryGenerationRegistry {
     sessionId: string,
   ): Omit<
     CompactionBoundaryEntry,
-    'observedUnclaimedBoundaryId'
+    'observedUnclaimedBoundaryId' | 'pendingBoundaryIds'
   > | undefined {
     const entry = this.entries.get(sessionId);
     if (!entry) return undefined;
     const {
       observedUnclaimedBoundaryId: _unclaimed,
+      pendingBoundaryIds: _pendingIds,
       ...inspection
     } = entry;
     return inspection;
@@ -189,6 +214,7 @@ export class CompactionBoundaryGenerationRegistry {
         observedCount: 0,
         pendingExpectation: null,
         observedUnclaimedBoundaryId: null,
+        pendingBoundaryIds: new Set<string>(),
       };
     } else {
       // Refresh LRU position.

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-config-provider.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-config-provider.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * CompactionConfigProvider — the settings boundary for compaction
+ * (TASK_2026_414). An unset threshold is NOT a 100000 default: it means the
+ * runtime decides. An invalid persisted value warns and is treated as unset,
+ * never clamped.
+ */
+
+import 'reflect-metadata';
+
+import type { ConfigManager, Logger } from '@ptah-extension/vscode-core';
+import { CompactionConfigProvider } from './compaction-config-provider';
+
+function makeProvider(values: Record<string, unknown>): {
+  provider: CompactionConfigProvider;
+  warn: jest.Mock;
+} {
+  const warn = jest.fn();
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn,
+    error: jest.fn(),
+  } as unknown as Logger;
+  const config = {
+    get: jest.fn((key: string) => values[key]),
+  } as unknown as ConfigManager;
+  return { provider: new CompactionConfigProvider(config, logger), warn };
+}
+
+describe('CompactionConfigProvider.getConfig', () => {
+  it('unset threshold → null, with no warning', () => {
+    const { provider, warn } = makeProvider({});
+    expect(provider.getConfig()).toEqual({
+      enabled: true,
+      contextTokenThreshold: null,
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('a null threshold (the contributed default) → null, with no warning', () => {
+    const { provider, warn } = makeProvider({ 'compaction.threshold': null });
+    expect(provider.getConfig().contextTokenThreshold).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('explicit 120000 → 120000', () => {
+    const { provider } = makeProvider({ 'compaction.threshold': 120_000 });
+    expect(provider.getConfig().contextTokenThreshold).toBe(120_000);
+  });
+
+  it('accepts the inclusive bounds 100000 and 1000000', () => {
+    expect(
+      makeProvider({ 'compaction.threshold': 100_000 }).provider.getConfig()
+        .contextTokenThreshold,
+    ).toBe(100_000);
+    expect(
+      makeProvider({ 'compaction.threshold': 1_000_000 }).provider.getConfig()
+        .contextTokenThreshold,
+    ).toBe(1_000_000);
+  });
+
+  it.each([
+    ['below the minimum', 50_000],
+    ['above the maximum', 1_000_001],
+    ['not an integer', 150_000.5],
+    ['a string', '150000'],
+  ])('invalid persisted threshold (%s) → warn + null', (_label, value) => {
+    const { provider, warn } = makeProvider({ 'compaction.threshold': value });
+    expect(provider.getConfig().contextTokenThreshold).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid compaction threshold'),
+      expect.objectContaining({
+        providedType: typeof value,
+        validRange: [100_000, 1_000_000],
+      }),
+    );
+  });
+
+  it('reads compaction.enabled and defaults it to true', () => {
+    expect(
+      makeProvider({ 'compaction.enabled': false }).provider.getConfig()
+        .enabled,
+    ).toBe(false);
+    expect(makeProvider({}).provider.getConfig().enabled).toBe(true);
+  });
+});

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-config-provider.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-config-provider.ts
@@ -1,50 +1,40 @@
 /**
- * Compaction Configuration Provider - Provides SDK compaction configuration from VS Code settings
+ * Compaction Configuration Provider - reads Ptah's compaction settings at the
+ * ConfigManager boundary and validates them.
  *
- * Responsibilities:
- * - Read compaction settings from VS Code configuration
- * - Provide sensible defaults when settings not configured
- * - Log configuration retrieval for debugging
- *
- * The SDK handles automatic compaction - we only configure thresholds and enable/disable.
- *
+ * The agent runtime owns automatic compaction. Ptah contributes at most two
+ * opinions, applied through the flag-tier settings (see
+ * `resolveAutoCompactControl`): auto compaction off, or an explicit window.
+ * An UNSET threshold is not a default of any size — it means the runtime
+ * decides.
  */
 
 import { injectable, inject } from 'tsyringe';
 import { Logger, ConfigManager, TOKENS } from '@ptah-extension/vscode-core';
+import {
+  isValidAutoCompactWindow,
+  SDK_AUTO_COMPACT_WINDOW_MAX,
+  SDK_AUTO_COMPACT_WINDOW_MIN,
+} from './auto-compact-control';
 
 /**
  * Compaction configuration settings
  */
 export interface CompactionConfig {
-  /** Enable automatic compaction (default: true) */
+  /** Enable automatic compaction (default: true). Manual /compact is unaffected. */
   readonly enabled: boolean;
-  /** Token threshold to trigger compaction (default: 100000) */
-  readonly contextTokenThreshold: number;
+  /**
+   * User-set auto-compact window in tokens, passed to the runtime as
+   * `autoCompactWindow`. `null` when unset or invalid: the runtime decides.
+   */
+  readonly contextTokenThreshold: number | null;
 }
 
 /**
- * Default compaction configuration values
- * These are used when VS Code settings are not configured
- */
-const DEFAULT_COMPACTION_CONFIG: CompactionConfig = {
-  enabled: true,
-  contextTokenThreshold: 100000,
-};
-
-/**
- * Provides compaction configuration from VS Code settings
+ * Provides compaction configuration from settings
  *
  * Pattern: Configuration provider (similar to AuthManager)
- * Single Responsibility: Read and provide compaction settings
- *
- * @example
- * ```typescript
- * const config = compactionConfigProvider.getConfig();
- * if (config.enabled) {
- *   // Pass compactionControl to SDK query
- * }
- * ```
+ * Single Responsibility: Read and validate compaction settings
  */
 @injectable()
 export class CompactionConfigProvider {
@@ -54,35 +44,35 @@ export class CompactionConfigProvider {
   ) {}
 
   /**
-   * Get compaction configuration from VS Code settings
+   * Get compaction configuration from settings
    *
    * Settings keys:
    * - ptah.compaction.enabled: boolean (default: true)
-   * - ptah.compaction.threshold: number (default: 100000)
+   * - ptah.compaction.threshold: integer in [100000, 1000000], or unset
    *
-   * @returns CompactionConfig with current settings or defaults
+   * A persisted threshold outside that range, or not an integer, is warned
+   * about and treated as UNSET. It is never clamped: the runtime would then
+   * compact at a size the user did not choose.
    */
   getConfig(): CompactionConfig {
-    const enabled =
-      this.config.get<boolean>('compaction.enabled') ??
-      DEFAULT_COMPACTION_CONFIG.enabled;
-    const rawThreshold = this.config.get<number>('compaction.threshold');
-    const contextTokenThreshold =
-      typeof rawThreshold === 'number' && rawThreshold >= 1000
-        ? rawThreshold
-        : DEFAULT_COMPACTION_CONFIG.contextTokenThreshold;
-    if (
-      rawThreshold !== undefined &&
-      (typeof rawThreshold !== 'number' || rawThreshold < 1000)
-    ) {
-      this.logger.warn(
-        '[CompactionConfigProvider] Invalid threshold value, using default',
-        {
-          providedValue: rawThreshold,
-          providedType: typeof rawThreshold,
-          defaultValue: DEFAULT_COMPACTION_CONFIG.contextTokenThreshold,
-        },
-      );
+    const enabled = this.config.get<boolean>('compaction.enabled') ?? true;
+    const rawThreshold = this.config.get<unknown>('compaction.threshold');
+
+    let contextTokenThreshold: number | null = null;
+    if (rawThreshold !== undefined && rawThreshold !== null) {
+      if (isValidAutoCompactWindow(rawThreshold)) {
+        contextTokenThreshold = rawThreshold;
+      } else {
+        this.logger.warn(
+          '[CompactionConfigProvider] Invalid compaction threshold, treating it as unset so the runtime decides',
+          {
+            providedValue:
+              typeof rawThreshold === 'number' ? rawThreshold : undefined,
+            providedType: typeof rawThreshold,
+            validRange: [SDK_AUTO_COMPACT_WINDOW_MIN, SDK_AUTO_COMPACT_WINDOW_MAX],
+          },
+        );
+      }
     }
 
     const compactionConfig: CompactionConfig = {
@@ -95,10 +85,6 @@ export class CompactionConfigProvider {
       {
         enabled: compactionConfig.enabled,
         contextTokenThreshold: compactionConfig.contextTokenThreshold,
-        usingDefaults:
-          enabled === DEFAULT_COMPACTION_CONFIG.enabled &&
-          contextTokenThreshold ===
-            DEFAULT_COMPACTION_CONFIG.contextTokenThreshold,
       },
     );
 

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-hook-handler.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-hook-handler.spec.ts
@@ -24,6 +24,7 @@ import {
   NoActivityWatchdog,
   NO_ACTIVITY_TIMEOUT_MS,
 } from './no-activity-watchdog';
+import { CompactionBoundaryGenerationRegistry } from './compaction-boundary-generation-registry';
 import type { CompactionCallbackRegistry } from './compaction-callback-registry';
 import type {
   SdkAdapterEvents,
@@ -254,6 +255,161 @@ describe('CompactionHookHandler — PreCompact sessionId resolution (TASK_2026_2
  * compaction as overdue and keep waiting, and the late PostCompact must still
  * reach the completion bus and release the compaction from the watchdog.
  */
+describe('CompactionHookHandler — PreCompact → PostCompact correlation (TASK_2026_414 Gap 2)', () => {
+  const signal = new AbortController().signal;
+
+  function makeEventsStub(): {
+    stub: SdkAdapterEvents;
+    emitted: SdkAdapterCompactionCompleteEvent[];
+  } {
+    const emitted: SdkAdapterCompactionCompleteEvent[] = [];
+    const stub = {
+      emitCompactionComplete: jest.fn(
+        (event: SdkAdapterCompactionCompleteEvent) => {
+          emitted.push(event);
+        },
+      ),
+    } as unknown as SdkAdapterEvents;
+    return { stub, emitted };
+  }
+
+  function makeHandler(registry = new CompactionBoundaryGenerationRegistry()): {
+    handler: CompactionHookHandler;
+    emitted: SdkAdapterCompactionCompleteEvent[];
+    registry: CompactionBoundaryGenerationRegistry;
+  } {
+    const { stub, emitted } = makeEventsStub();
+    const handler = new CompactionHookHandler(
+      makeLogger(),
+      makeUsageTracker(0) as unknown as LiveUsageTracker,
+      undefined,
+      stub,
+      registry,
+    );
+    return { handler, emitted, registry };
+  }
+
+  function pre(sessionIdOnPayload?: string): HookInput {
+    return {
+      hook_event_name: 'PreCompact',
+      trigger: 'auto',
+      cwd: '/repo',
+      custom_instructions: null,
+      ...(sessionIdOnPayload ? { session_id: sessionIdOnPayload } : {}),
+    } as unknown as HookInput;
+  }
+
+  function post(sessionIdOnPayload?: string): HookInput {
+    return {
+      hook_event_name: 'PostCompact',
+      trigger: 'auto',
+      cwd: '/repo',
+      compact_summary: 'summary',
+      ...(sessionIdOnPayload ? { session_id: sessionIdOnPayload } : {}),
+    } as unknown as HookInput;
+  }
+
+  it('PostCompact without session_id publishes the PreCompact-resolved id, not the captured closure id', async () => {
+    const { handler, emitted } = makeHandler();
+    const hooks = handler.createHooks('TAB-closure-id', '/repo', jest.fn());
+
+    await hooks.PreCompact?.[0]?.hooks?.[0]?.(pre('REAL-sdk-id'), undefined, {
+      signal,
+    });
+    await hooks.PostCompact?.[0]?.hooks?.[0]?.(post(), undefined, { signal });
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].sessionId).toBe('REAL-sdk-id');
+  });
+
+  it('PostCompact with its own session_id still wins over the PreCompact id', async () => {
+    const { handler, emitted } = makeHandler();
+    const hooks = handler.createHooks('TAB-closure-id', '/repo', jest.fn());
+
+    await hooks.PreCompact?.[0]?.hooks?.[0]?.(pre('REAL-sdk-id'), undefined, {
+      signal,
+    });
+    await hooks.PostCompact?.[0]?.hooks?.[0]?.(
+      post('POST-payload-id'),
+      undefined,
+      { signal },
+    );
+
+    expect(emitted[0].sessionId).toBe('POST-payload-id');
+  });
+
+  it('a later PostCompact without session_id and no PreCompact falls back to the closure id again', async () => {
+    const { handler, emitted } = makeHandler();
+    const hooks = handler.createHooks('TAB-closure-id', '/repo', jest.fn());
+
+    await hooks.PreCompact?.[0]?.hooks?.[0]?.(pre('REAL-sdk-id'), undefined, {
+      signal,
+    });
+    await hooks.PostCompact?.[0]?.hooks?.[0]?.(post(), undefined, { signal });
+    await hooks.PostCompact?.[0]?.hooks?.[0]?.(post(), undefined, { signal });
+
+    expect(emitted.map((e) => e.sessionId)).toEqual([
+      'REAL-sdk-id',
+      'TAB-closure-id',
+    ]);
+  });
+
+  it('PreCompact records a boundary expectation only when an interactive callback is present', async () => {
+    const { handler, registry } = makeHandler();
+    registry.observeBoundaryCount('REAL-interactive', 1);
+    const hooks = handler.createHooks('TAB', '/repo', jest.fn());
+
+    await hooks.PreCompact?.[0]?.hooks?.[0]?.(
+      pre('REAL-interactive'),
+      undefined,
+      { signal },
+    );
+
+    expect(registry.capturePendingExpectation('REAL-interactive')).toEqual({
+      kind: 'verified',
+      expectedCount: 2,
+    });
+  });
+
+  it('PreCompact does not record an expectation for a callback-less child spawn', async () => {
+    const { handler, registry } = makeHandler();
+    registry.observeBoundaryCount('REAL-child', 1);
+    const hooks = handler.createHooks(undefined, '/repo');
+
+    await hooks.PreCompact?.[0]?.hooks?.[0]?.(pre('REAL-child'), undefined, {
+      signal,
+    });
+
+    expect(registry.capturePendingExpectation('REAL-child')).toBeUndefined();
+  });
+
+  it('a retried PreCompact before PostCompact does not count a second compaction', async () => {
+    const { handler, registry } = makeHandler();
+    registry.observeBoundaryCount('REAL-retry', 1);
+    const hooks = handler.createHooks('TAB', '/repo', jest.fn());
+    const firePre = () =>
+      hooks.PreCompact?.[0]?.hooks?.[0]?.(pre('REAL-retry'), undefined, {
+        signal,
+      });
+
+    await firePre();
+    await firePre();
+    expect(registry.capturePendingExpectation('REAL-retry')).toEqual({
+      kind: 'verified',
+      expectedCount: 2,
+    });
+
+    await hooks.PostCompact?.[0]?.hooks?.[0]?.(post('REAL-retry'), undefined, {
+      signal,
+    });
+    await firePre();
+    expect(registry.capturePendingExpectation('REAL-retry')).toEqual({
+      kind: 'verified',
+      expectedCount: 3,
+    });
+  });
+});
+
 describe('CompactionHookHandler — attempt timing and the 180 s watchdog (TASK_2026_411 B8)', () => {
   const SECRET_SUMMARY = 'SECRET-SUMMARY-TEXT-must-not-be-logged';
   const SECRET_INSTRUCTIONS = 'SECRET-INSTRUCTIONS-must-not-be-logged';

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-hook-handler.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-hook-handler.spec.ts
@@ -408,6 +408,35 @@ describe('CompactionHookHandler — PreCompact → PostCompact correlation (TASK
       expectedCount: 3,
     });
   });
+
+  it('a distinct PreCompact after the previous compaction settled records its own expectation even with no PostCompact', async () => {
+    // PR #493 review C: the retry marker was the session id ALONE, so a
+    // compaction whose PostCompact never fired left it set forever and the
+    // NEXT genuine compaction was mistaken for a retry. That compaction
+    // recorded nothing, so its Post-only reload had no expectation to verify
+    // and the renderer accepted whatever was on disk.
+    const { handler, registry } = makeHandler();
+    registry.observeBoundaryCount('REAL-two', 1);
+    const hooks = handler.createHooks('TAB', '/repo', jest.fn());
+    const firePre = () =>
+      hooks.PreCompact?.[0]?.hooks?.[0]?.(pre('REAL-two'), undefined, {
+        signal,
+      });
+
+    await firePre();
+
+    // The first compaction's boundary lands and a history read verifies it.
+    // No PostCompact ever fires for it.
+    registry.observeBoundaryCount('REAL-two', 2);
+    registry.consumeExpectation('REAL-two', 'satisfied');
+
+    await firePre();
+
+    expect(registry.capturePendingExpectation('REAL-two')).toEqual({
+      kind: 'verified',
+      expectedCount: 3,
+    });
+  });
 });
 
 describe('CompactionHookHandler — attempt timing and the 180 s watchdog (TASK_2026_411 B8)', () => {

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-hook-handler.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-hook-handler.spec.ts
@@ -20,6 +20,10 @@ import type { LiveUsageTracker } from './live-usage-tracker';
 import type { HookInput } from '../types/sdk-types/claude-sdk.types';
 
 import { CompactionHookHandler } from './compaction-hook-handler';
+import {
+  NoActivityWatchdog,
+  NO_ACTIVITY_TIMEOUT_MS,
+} from './no-activity-watchdog';
 import type { CompactionCallbackRegistry } from './compaction-callback-registry';
 import type {
   SdkAdapterEvents,
@@ -239,6 +243,186 @@ describe('CompactionHookHandler — PreCompact sessionId resolution (TASK_2026_2
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('missing sessionId'),
       expect.objectContaining({ trigger: 'auto', hasCwd: false }),
+    );
+  });
+});
+
+/**
+ * TASK_2026_411 B8 — metadata-only attempt timing, and the proof that a slow
+ * compaction is not killed. Upstream summarization was measured at 213-216 s,
+ * longer than the 180 s no-activity window, so the watchdog must report the
+ * compaction as overdue and keep waiting, and the late PostCompact must still
+ * reach the completion bus and release the compaction from the watchdog.
+ */
+describe('CompactionHookHandler — attempt timing and the 180 s watchdog (TASK_2026_411 B8)', () => {
+  const SECRET_SUMMARY = 'SECRET-SUMMARY-TEXT-must-not-be-logged';
+  const SECRET_INSTRUCTIONS = 'SECRET-INSTRUCTIONS-must-not-be-logged';
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function makeEvents(): {
+    stub: SdkAdapterEvents;
+    emitted: SdkAdapterCompactionCompleteEvent[];
+  } {
+    const emitted: SdkAdapterCompactionCompleteEvent[] = [];
+    const stub = {
+      emitCompactionComplete: jest.fn(
+        (event: SdkAdapterCompactionCompleteEvent) => {
+          emitted.push(event);
+        },
+      ),
+    } as unknown as SdkAdapterEvents;
+    return { stub, emitted };
+  }
+
+  function preCompact(): HookInput {
+    return {
+      hook_event_name: 'PreCompact',
+      session_id: 'sess-slow',
+      cwd: '/repo',
+      trigger: 'auto',
+      custom_instructions: SECRET_INSTRUCTIONS,
+    } as unknown as HookInput;
+  }
+
+  function postCompact(): HookInput {
+    return {
+      hook_event_name: 'PostCompact',
+      session_id: 'sess-slow',
+      cwd: '/repo',
+      trigger: 'auto',
+      compact_summary: SECRET_SUMMARY,
+    } as unknown as HookInput;
+  }
+
+  function loggedPayloads(logger: jest.Mocked<Logger>): string {
+    return JSON.stringify([
+      ...logger.debug.mock.calls,
+      ...logger.info.mock.calls,
+      ...logger.warn.mock.calls,
+      ...logger.error.mock.calls,
+    ]);
+  }
+
+  it('a delayed 216 s compaction reaches PostCompact and clears state while the watchdog reports overdue-but-continuing at 180 s', async () => {
+    jest.useFakeTimers();
+    const logger = makeLogger();
+    const { stub, emitted } = makeEvents();
+    const handler = new CompactionHookHandler(
+      logger,
+      makeUsageTracker(0) as unknown as LiveUsageTracker,
+      undefined,
+      stub,
+    );
+    const onTimeout = jest.fn();
+    const onOverdue = jest.fn();
+    const watchdog = new NoActivityWatchdog(
+      NO_ACTIVITY_TIMEOUT_MS,
+      onTimeout,
+      onOverdue,
+    );
+    const handlerHooks = handler.createHooks('sess-slow', '/repo', jest.fn());
+    const watchdogHooks = watchdog.lifecycleHooks();
+    const signal = new AbortController().signal;
+    const fire = async (
+      event: 'PreCompact' | 'PostCompact',
+      input: HookInput,
+    ): Promise<void> => {
+      for (const hooks of [watchdogHooks, handlerHooks]) {
+        await hooks[event]?.[0]?.hooks?.[0]?.(input, undefined, { signal });
+      }
+    };
+    watchdog.start();
+
+    await fire('PreCompact', preCompact());
+    jest.advanceTimersByTime(180_000);
+
+    // Overdue, reported, and NOT aborted.
+    expect(onOverdue).toHaveBeenCalledWith(['compaction']);
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(36_000);
+    await fire('PostCompact', postCompact());
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toEqual(
+      expect.objectContaining({ sessionId: 'sess-slow', trigger: 'auto' }),
+    );
+    expect(onTimeout).not.toHaveBeenCalled();
+    const completed = logger.info.mock.calls.find(
+      ([message]) =>
+        message === '[CompactionHookHandler] Compaction attempt completed',
+    );
+    expect(completed?.[1]).toEqual({
+      attempt: 1,
+      trigger: 'auto',
+      status: 'completed',
+      durationMs: 216_000,
+      overlappingAttemptsAtStart: 0,
+      overlappingAttemptsAtEnd: 0,
+      overlapCorrelation: { exact: false },
+    });
+    // Metadata only: no summary or instruction text reaches any log.
+    const logs = loggedPayloads(logger);
+    expect(logs).not.toContain(SECRET_SUMMARY);
+    expect(logs).not.toContain(SECRET_INSTRUCTIONS);
+
+    // The compaction no longer accounts for silence: the next unaccounted
+    // window is a real no-activity timeout again.
+    jest.advanceTimersByTime(NO_ACTIVITY_TIMEOUT_MS);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+    watchdog.stop();
+  });
+
+  it('a retried PreCompact closes the open attempt as superseded and counts overlap across queries (inexact)', async () => {
+    jest.useFakeTimers();
+    const logger = makeLogger();
+    const handler = new CompactionHookHandler(
+      logger,
+      makeUsageTracker(0) as unknown as LiveUsageTracker,
+      undefined,
+      makeEvents().stub,
+    );
+    const signal = new AbortController().signal;
+    const queryA = handler.createHooks('sess-a', '/repo');
+    const queryB = handler.createHooks('sess-b', '/repo');
+
+    await queryA.PreCompact?.[0]?.hooks?.[0]?.(preCompact(), undefined, {
+      signal,
+    });
+    jest.advanceTimersByTime(20_000);
+    await queryB.PreCompact?.[0]?.hooks?.[0]?.(preCompact(), undefined, {
+      signal,
+    });
+    jest.advanceTimersByTime(1_000);
+    await queryA.PreCompact?.[0]?.hooks?.[0]?.(preCompact(), undefined, {
+      signal,
+    });
+
+    const infos = logger.info.mock.calls;
+    const startedB = infos.filter(
+      ([m]) => m === '[CompactionHookHandler] Compaction attempt started',
+    )[1];
+    expect(startedB?.[1]).toEqual(
+      expect.objectContaining({
+        attempt: 1,
+        overlappingAttempts: 1,
+        overlapCorrelation: { exact: false },
+      }),
+    );
+    const superseded = infos.find(
+      ([m]) =>
+        m ===
+        '[CompactionHookHandler] Compaction attempt superseded before PostCompact',
+    );
+    expect(superseded?.[1]).toEqual(
+      expect.objectContaining({
+        attempt: 1,
+        status: 'superseded',
+        durationMs: 21_000,
+      }),
     );
   });
 });

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-hook-handler.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-hook-handler.ts
@@ -36,6 +36,7 @@ import { resolveHookCwd, resolveHookSessionId } from './hook-session-resolver';
 import type { LiveUsageTracker } from './live-usage-tracker';
 import type { CompactionCallbackRegistry } from './compaction-callback-registry';
 import type { SdkAdapterEvents } from './sdk-adapter-events.service';
+import type { CompactionBoundaryGenerationRegistry } from './compaction-boundary-generation-registry';
 
 /**
  * Callback type for notifying when compaction starts
@@ -129,6 +130,12 @@ export class CompactionHookHandler {
     private readonly callbackRegistry?: CompactionCallbackRegistry,
     @inject(SDK_TOKENS.SDK_ADAPTER_EVENTS)
     private readonly sdkAdapterEvents?: SdkAdapterEvents,
+    /**
+     * Receives the PreCompact expectation so a PostCompact-only reload is
+     * verified against the JSONL even when no live compact_boundary arrives.
+     */
+    @inject(SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY)
+    private readonly boundaryRegistry?: CompactionBoundaryGenerationRegistry,
   ) {}
 
   /**
@@ -159,6 +166,14 @@ export class CompactionHookHandler {
     });
 
     const sdkAdapterEvents = this.sdkAdapterEvents;
+
+    // PreCompact and PostCompact of ONE compaction share this closure. The id
+    // PreCompact resolved is a better fallback for a PostCompact payload that
+    // lacks `session_id` than the captured closure id, which for a new session
+    // is the tab id — no tab owns that as a session, so the renderer no-oped.
+    // Reset once PostCompact has been handled; a PreCompact that finds it still
+    // set is a retry of the same open compaction.
+    let preCompactSessionId: string | null = null;
 
     // Metadata-only attempt timing (TASK_2026_411 B8). One query compacts one
     // attempt at a time; a PreCompact that arrives while one is still open is
@@ -283,6 +298,28 @@ export class CompactionHookHandler {
                   );
                   return { continue: true };
                 }
+                const retryOfOpenCompaction =
+                  preCompactSessionId === resolvedSessionId;
+                preCompactSessionId = resolvedSessionId;
+                // Interactive sessions only: a callback-less child compaction
+                // never drives a UI reload, and a pending expectation is never
+                // evicted — recording those could saturate the registry. A retry
+                // of the still-open compaction must not count a second one.
+                if (capturedCallback && !retryOfOpenCompaction) {
+                  try {
+                    this.boundaryRegistry?.recordPreCompact(resolvedSessionId);
+                  } catch (registryError: unknown) {
+                    this.logger.warn(
+                      '[CompactionHookHandler] Failed to record PreCompact expectation',
+                      {
+                        error:
+                          registryError instanceof Error
+                            ? registryError.message
+                            : String(registryError),
+                      },
+                    );
+                  }
+                }
                 this.logger.info(
                   '[CompactionHookHandler] PreCompact hook triggered',
                   {
@@ -391,10 +428,14 @@ export class CompactionHookHandler {
                 }
                 endAttempt();
 
+                const postFallbackSessionId = preCompactSessionId ?? sessionId;
+                preCompactSessionId = null;
                 if (sdkAdapterEvents) {
+                  // Payload first (hook identity rule); the PreCompact-resolved
+                  // id of this same compaction before the captured closure id.
                   const resolvedSessionId = resolveHookSessionId(
                     input.session_id,
-                    sessionId,
+                    postFallbackSessionId,
                   );
                   const resolvedCwd = resolveHookCwd(input.cwd, cwd);
                   if (!resolvedSessionId || !resolvedCwd) {

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-hook-handler.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-hook-handler.ts
@@ -298,8 +298,21 @@ export class CompactionHookHandler {
                   );
                   return { continue: true };
                 }
-                const retryOfOpenCompaction =
+                // A retry needs BOTH halves: the hook-level marker for this
+                // same session still open (PostCompact has not closed it), AND
+                // an announcement the registry has not settled. The marker
+                // alone is not enough — a compaction whose PostCompact never
+                // fires leaves it set forever, and the NEXT genuine compaction
+                // was then mistaken for a retry and recorded no expectation, so
+                // its Post-only reload had nothing to verify (PR #493 review C).
+                const markerStillOpen =
                   preCompactSessionId === resolvedSessionId;
+                const retryOfOpenCompaction =
+                  markerStillOpen &&
+                  (this.boundaryRegistry?.hasUnsettledPreCompact(
+                    resolvedSessionId,
+                  ) ??
+                    true);
                 preCompactSessionId = resolvedSessionId;
                 // Interactive sessions only: a callback-less child compaction
                 // never drives a UI reload, and a pending expectation is never

--- a/libs/backend/agent-sdk/src/lib/helpers/compaction-hook-handler.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/compaction-hook-handler.ts
@@ -103,8 +103,24 @@ export function isPostCompactHook(
  * const options = { ...otherOptions, hooks: { ...existingHooks, ...hooks } };
  * ```
  */
+/**
+ * Monotonic clock for attempt timing. `performance.now()` never jumps with the
+ * wall clock, so a duration is a duration even across an NTP correction.
+ */
+function monotonicNowMs(): number {
+  return performance.now();
+}
+
 @injectable()
 export class CompactionHookHandler {
+  /**
+   * Compaction attempts opened by PreCompact and not yet closed by PostCompact,
+   * across every query in this process. It is the only overlap signal we have:
+   * the hooks carry no request id, so pairing an attempt with a concurrent
+   * provider call is interval overlap, never an exact correlation.
+   */
+  private openCompactionAttempts = 0;
+
   constructor(
     @inject(TOKENS.LOGGER) private readonly logger: Logger,
     @inject(SDK_TOKENS.SDK_LIVE_USAGE_TRACKER)
@@ -143,6 +159,74 @@ export class CompactionHookHandler {
     });
 
     const sdkAdapterEvents = this.sdkAdapterEvents;
+
+    // Metadata-only attempt timing (TASK_2026_411 B8). One query compacts one
+    // attempt at a time; a PreCompact that arrives while one is still open is
+    // a retry, and the open attempt is closed as superseded. Nothing here reads
+    // a prompt, summary, instruction, header or credential. Every step is
+    // wrapped: timing must never throw into the SDK's hook path.
+    let attemptOrdinal = 0;
+    let openAttempt: {
+      readonly ordinal: number;
+      readonly trigger: 'manual' | 'auto';
+      readonly startedAtMs: number;
+      readonly overlappingAtStart: number;
+    } | null = null;
+    const closeAttempt = (status: 'completed' | 'superseded'): void => {
+      if (!openAttempt) return;
+      this.openCompactionAttempts = Math.max(
+        0,
+        this.openCompactionAttempts - 1,
+      );
+      this.logger.info(
+        status === 'completed'
+          ? '[CompactionHookHandler] Compaction attempt completed'
+          : '[CompactionHookHandler] Compaction attempt superseded before PostCompact',
+        {
+          attempt: openAttempt.ordinal,
+          trigger: openAttempt.trigger,
+          status,
+          durationMs: Math.round(monotonicNowMs() - openAttempt.startedAtMs),
+          overlappingAttemptsAtStart: openAttempt.overlappingAtStart,
+          overlappingAttemptsAtEnd: this.openCompactionAttempts,
+          overlapCorrelation: { exact: false },
+        },
+      );
+      openAttempt = null;
+    };
+    const beginAttempt = (trigger: 'manual' | 'auto'): void => {
+      try {
+        closeAttempt('superseded');
+        attemptOrdinal += 1;
+        openAttempt = {
+          ordinal: attemptOrdinal,
+          trigger,
+          startedAtMs: monotonicNowMs(),
+          overlappingAtStart: this.openCompactionAttempts,
+        };
+        this.openCompactionAttempts += 1;
+        this.logger.info('[CompactionHookHandler] Compaction attempt started', {
+          attempt: attemptOrdinal,
+          trigger,
+          overlappingAttempts: openAttempt.overlappingAtStart,
+          overlapCorrelation: { exact: false },
+        });
+      } catch (error: unknown) {
+        this.logger.debug('[CompactionHookHandler] Attempt timing failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
+    const endAttempt = (): void => {
+      try {
+        closeAttempt('completed');
+      } catch (error: unknown) {
+        this.logger.debug('[CompactionHookHandler] Attempt timing failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
+
     return {
       PreCompact: [
         {
@@ -182,6 +266,7 @@ export class CompactionHookHandler {
                   );
                   return { continue: true };
                 }
+                beginAttempt(trigger);
                 const resolvedSessionId = resolveHookSessionId(
                   input.session_id,
                   sessionId,
@@ -304,6 +389,7 @@ export class CompactionHookHandler {
                   );
                   return { continue: true };
                 }
+                endAttempt();
 
                 if (sdkAdapterEvents) {
                   const resolvedSessionId = resolveHookSessionId(

--- a/libs/backend/agent-sdk/src/lib/helpers/history/history.types.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/history/history.types.ts
@@ -35,6 +35,7 @@ export interface JsonlMessageLine {
     };
   };
   isMeta?: boolean;
+  isSynthetic?: boolean;
   slug?: string;
 }
 
@@ -55,6 +56,7 @@ export interface SessionHistoryMessage extends Omit<JSONLMessage, 'message'> {
   readonly sessionId?: string;
   readonly timestamp?: string;
   readonly isMeta?: boolean;
+  readonly isSynthetic?: boolean;
   readonly slug?: string;
   /** Model identifier from system init messages (e.g., 'claude-sonnet-4-20250514') */
   readonly model?: string;

--- a/libs/backend/agent-sdk/src/lib/helpers/history/jsonl-reader.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/history/jsonl-reader.service.spec.ts
@@ -685,6 +685,42 @@ describe('JsonlReaderService', () => {
       expect(mockedCreateReadStream).toHaveBeenCalledTimes(2);
     });
 
+    it('re-parses when (size, mtimeMs) change and the new short transcript contains the expected boundary', async () => {
+      const short = JSON.stringify({
+        uuid: 'b1',
+        sessionId: 's1',
+        type: 'system',
+        subtype: 'compact_boundary',
+      });
+      const changed = [
+        short,
+        JSON.stringify({
+          uuid: 'b2',
+          sessionId: 's1',
+          type: 'system',
+          subtype: 'compact_boundary',
+        }),
+      ].join('\n');
+
+      mockedStat.mockResolvedValueOnce(statsOf(Buffer.byteLength(short), 1000));
+      mockedStat.mockResolvedValueOnce(statsOf(Buffer.byteLength(short), 1000));
+      mockedStat.mockResolvedValueOnce(
+        statsOf(Buffer.byteLength(changed), 2000),
+      );
+      primeFileContent(short, changed);
+
+      const first = await service.readJsonlMessages(FILE);
+      const second = await service.readJsonlMessages(FILE);
+      const third = await service.readJsonlMessages(FILE);
+
+      // First parse is cached; changed stats force a re-parse on the third call.
+      expect(mockedCreateReadStream).toHaveBeenCalledTimes(2);
+      expect(first).toHaveLength(1);
+      expect(second).toEqual(first);
+      expect(third).toHaveLength(2);
+      expect(third[1].uuid).toBe('b2');
+    });
+
     it('keys on the file path — one transcript never answers for another', async () => {
       mockedStat.mockResolvedValue(statsOf(SIZE, 5000));
       primeFileContentAlways(LINE);

--- a/libs/backend/agent-sdk/src/lib/helpers/history/jsonl-reader.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/history/jsonl-reader.service.spec.ts
@@ -498,6 +498,33 @@ describe('JsonlReaderService', () => {
       expect(out[0].type).toBe('assistant');
     });
 
+    it('preserves isSynthetic so replay can suppress synthetic user records', async () => {
+      // Regression (PR #493 review A): convertToSessionHistoryMessage dropped
+      // isSynthetic, so the replay filter in session-replay.service never saw
+      // it and synthetic user records leaked into replayed history.
+      const jsonl = [
+        JSON.stringify({
+          uuid: 'u-synthetic',
+          type: 'user',
+          isSynthetic: true,
+          message: { role: 'user', content: 'synthetic cue' },
+        }),
+        JSON.stringify({
+          uuid: 'u-real',
+          type: 'user',
+          message: { role: 'user', content: 'real message' },
+        }),
+      ].join('\n');
+      mockedStat.mockResolvedValueOnce(statsWithSize(Buffer.byteLength(jsonl)));
+      primeFileContent(jsonl);
+
+      const out = await service.readJsonlMessages('/tmp/session.jsonl');
+
+      expect(out).toHaveLength(2);
+      expect(out[0].isSynthetic).toBe(true);
+      expect(out[1].isSynthetic).toBeUndefined();
+    });
+
     it('rejects files over the 50 MB cap with SdkError before reading content', async () => {
       // `await expect(...).rejects.toThrow(...)` invokes the thunk once, so we
       // need exactly one stat reply — any extra primed replies stay queued

--- a/libs/backend/agent-sdk/src/lib/helpers/history/jsonl-reader.service.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/history/jsonl-reader.service.ts
@@ -344,9 +344,9 @@ export class JsonlReaderService {
    *
    * ## The parse is memoised on `(path, size, mtimeMs)`
    *
-   * Three independent callers read the SAME transcript within a second of each
-   * other on the resume path: `chat:resume` calls `readSessionHistory()` and
-   * then `readHistoryAsMessages()` — two full parses of one file — and
+   * Two independent callers read the SAME transcript within a second of each
+   * other on the resume path: `chat:resume` now calls `readSessionHistory()`
+   * once and uses the single-parse `messages` it returns, and
    * `session:stats-batch` parses it again for the sidebar. Nothing about the
    * bytes changed between them.
    *

--- a/libs/backend/agent-sdk/src/lib/helpers/history/jsonl-reader.service.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/history/jsonl-reader.service.ts
@@ -660,6 +660,7 @@ export class JsonlReaderService {
       sessionId: line.sessionId,
       timestamp: line.timestamp,
       isMeta: line.isMeta,
+      isSynthetic: line.isSynthetic,
       slug: line.slug,
       message: line.message as SessionHistoryMessage['message'],
       model: line.model,

--- a/libs/backend/agent-sdk/src/lib/helpers/history/session-replay.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/history/session-replay.service.spec.ts
@@ -180,6 +180,27 @@ describe('SessionReplayService', () => {
     ]);
   });
 
+  it('suppresses user messages flagged as isSynthetic', () => {
+    // Regression (PR #493 review A): JsonlReaderService used to drop the
+    // isSynthetic flag during conversion, so these records reached replay.
+    const messages: SessionHistoryMessage[] = [
+      {
+        type: 'user',
+        isSynthetic: true,
+        timestamp: '2026-01-01T00:00:00.000Z',
+        uuid: 'u-synthetic',
+        message: { role: 'user', content: 'synthetic cue' },
+      } as SessionHistoryMessage,
+      u({ role: 'user', content: 'real user message' }),
+    ];
+    const out = service.replayToStreamEvents('s', messages, []);
+    expect(eventTypes(out)).toEqual([
+      'message_start',
+      'text_delta',
+      'message_complete',
+    ]);
+  });
+
   it('suppresses user messages starting with <task-notification>', () => {
     const messages: SessionHistoryMessage[] = [
       u({

--- a/libs/backend/agent-sdk/src/lib/helpers/history/session-replay.service.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/history/session-replay.service.ts
@@ -43,6 +43,7 @@ import type {
   SessionHistoryMessage,
 } from './history.types';
 import { isInterruptSentinelText } from '../../types/sdk-types/claude-sdk.types';
+import { isSkillOrMetaContent } from '../../message-transform/message-transform-helpers';
 
 /**
  * Service for replaying session history as stream events.
@@ -120,7 +121,7 @@ export class SessionReplayService {
       }
 
       if (msg.type === 'user' && msg.message?.content) {
-        if (msg.isMeta === true) continue;
+        if (msg.isMeta === true || msg.isSynthetic === true) continue;
         if (
           (msg as unknown as Record<string, unknown>)['sourceToolUseID'] !==
           undefined
@@ -128,6 +129,13 @@ export class SessionReplayService {
           continue;
         }
         const contentRaw = msg.message.content;
+        if (
+          isSkillOrMetaContent(
+            msg as unknown as Parameters<typeof isSkillOrMetaContent>[0],
+          )
+        ) {
+          continue;
+        }
         if (
           Array.isArray(contentRaw) &&
           contentRaw.length > 0 &&

--- a/libs/backend/agent-sdk/src/lib/helpers/history/session-replay.service.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/history/session-replay.service.ts
@@ -43,7 +43,10 @@ import type {
   SessionHistoryMessage,
 } from './history.types';
 import { isInterruptSentinelText } from '../../types/sdk-types/claude-sdk.types';
-import { isSkillOrMetaContent } from '../../message-transform/message-transform-helpers';
+import {
+  isHiddenTranscriptRecord,
+  isSkillOrMetaContent,
+} from '../../message-transform/message-transform-helpers';
 
 /**
  * Service for replaying session history as stream events.
@@ -121,7 +124,7 @@ export class SessionReplayService {
       }
 
       if (msg.type === 'user' && msg.message?.content) {
-        if (msg.isMeta === true || msg.isSynthetic === true) continue;
+        if (isHiddenTranscriptRecord(msg)) continue;
         if (
           (msg as unknown as Record<string, unknown>)['sourceToolUseID'] !==
           undefined

--- a/libs/backend/agent-sdk/src/lib/helpers/index.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/index.ts
@@ -48,6 +48,7 @@ export {
   isPostCompactHook,
 } from './compaction-hook-handler';
 export { CompactionCallbackRegistry } from './compaction-callback-registry';
+export { CompactionBoundaryGenerationRegistry } from './compaction-boundary-generation-registry';
 export {
   SessionTurnStateRegistry,
   toTurnStateEvent,

--- a/libs/backend/agent-sdk/src/lib/helpers/index.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/index.ts
@@ -42,6 +42,14 @@ export {
   type CompactionConfig,
 } from './compaction-config-provider';
 export {
+  resolveAutoCompactControl,
+  isValidAutoCompactWindow,
+  SDK_AUTO_COMPACT_WINDOW_MIN,
+  SDK_AUTO_COMPACT_WINDOW_MAX,
+  type AutoCompactSettings,
+  type AutoCompactControlInput,
+} from './auto-compact-control';
+export {
   CompactionHookHandler,
   type CompactionStartCallback,
   isPreCompactHook,

--- a/libs/backend/agent-sdk/src/lib/helpers/model-identity-prompt.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/model-identity-prompt.spec.ts
@@ -129,7 +129,7 @@ function makeBuilder(): SdkQueryOptionsBuilder {
     {
       getConfig: jest
         .fn()
-        .mockReturnValue({ enabled: false, contextTokenThreshold: 200_000 }),
+        .mockReturnValue({ enabled: true, contextTokenThreshold: null }),
     },
     noopHooks,
     noopHooks,

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-adapter-events.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-adapter-events.service.spec.ts
@@ -156,6 +156,23 @@ describe('SdkAdapterEvents', () => {
       expect(listener).toHaveBeenCalledWith(payload);
     });
 
+    it('logs a positive diagnostic when publishing the PostCompact advisory', () => {
+      const { events, logger } = make();
+
+      events.emitCompactionComplete({
+        sessionId: 'sess-diagnostic',
+        cwd: '/repo',
+        trigger: 'auto',
+        compactSummary: 'summary',
+        timestamp: 3,
+      });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        '[SdkAdapterEvents] Publishing PostCompact advisory',
+        { sessionId: 'sess-diagnostic', trigger: 'auto' },
+      );
+    });
+
     it('supports auto trigger and multiple subscribers', () => {
       const { events } = make();
       const a = jest.fn();

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-adapter-events.service.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-adapter-events.service.ts
@@ -129,6 +129,10 @@ export class SdkAdapterEvents {
   }
 
   emitCompactionComplete(event: SdkAdapterCompactionCompleteEvent): void {
+    this.logger.info('[SdkAdapterEvents] Publishing PostCompact advisory', {
+      sessionId: event.sessionId,
+      trigger: event.trigger,
+    });
     this.safeEmit('compactionComplete', event);
   }
 

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.auto-compact-argv.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.auto-compact-argv.spec.ts
@@ -1,0 +1,359 @@
+/**
+ * Effective compaction settings on the INTERACTIVE path, proven through the
+ * real pinned `@anthropic-ai/claude-agent-sdk` (TASK_2026_414 / 411 B8).
+ *
+ * An assertion against Ptah's options object is not enough: what matters is
+ * what the SDK hands the CLI. Each case builds options with the real
+ * `SdkQueryOptionsBuilder` and the real `CompactionConfigProvider`, then runs
+ * the pinned SDK's `query()` in a child Node process (the SDK is ESM-only)
+ * with a FAKE `spawnClaudeCodeProcess` that records `SpawnOptions.args` and
+ * the `initialize` control request written to stdin. Nothing is launched.
+ */
+
+import 'reflect-metadata';
+
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+
+import type { AISessionConfig, AuthEnv } from '@ptah-extension/shared';
+import type { ConfigManager, Logger } from '@ptah-extension/vscode-core';
+
+import { SdkQueryOptionsBuilder } from './sdk-query-options-builder';
+import { CompactionConfigProvider } from './compaction-config-provider';
+
+const PINNED_SDK_VERSION = '0.3.150';
+
+const PROBE_SCRIPT = `
+const { sdkUrl, runs } = JSON.parse(process.env.PTAH_SDK_ARGV_PROBE);
+const { query } = await import(sdkUrl);
+const { PassThrough } = await import('node:stream');
+const { EventEmitter } = await import('node:events');
+const results = [];
+for (const options of runs) {
+  let captured = null;
+  let stdinText = '';
+  const q = query({ prompt: 'probe', options: { ...options, cwd: process.cwd(), pathToClaudeCodeExecutable: process.execPath, spawnClaudeCodeProcess: (spawnOptions) => {
+    captured = { args: spawnOptions.args };
+    const stdin = new PassThrough();
+    stdin.on('data', (chunk) => { stdinText += String(chunk); });
+    const stdout = new PassThrough();
+    const events = new EventEmitter();
+    return { stdin, stdout, killed: false, exitCode: null, kill: () => true, on: events.on.bind(events), once: events.once.bind(events), off: events.off.bind(events) };
+  } } });
+  q[Symbol.asyncIterator]().next().catch(() => undefined);
+  const deadline = Date.now() + 10000;
+  while ((!captured || !stdinText.includes('"initialize"')) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  results.push({ args: captured ? captured.args : null, stdinText });
+}
+process.stdout.write(JSON.stringify(results));
+process.exit(0);
+`;
+
+interface ProbeResult {
+  readonly args: string[] | null;
+  readonly stdinText: string;
+}
+
+function findPinnedSdk(): { entry: string; version: string } {
+  let dir = __dirname;
+  for (;;) {
+    const root = path.join(dir, 'node_modules', '@anthropic-ai', 'claude-agent-sdk');
+    const entry = path.join(root, 'sdk.mjs');
+    if (existsSync(entry)) {
+      const pkg = JSON.parse(
+        readFileSync(path.join(root, 'package.json'), 'utf8'),
+      ) as { version: string };
+      return { entry, version: pkg.version };
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error('@anthropic-ai/claude-agent-sdk is not installed');
+    }
+    dir = parent;
+  }
+}
+
+function runProbe(
+  sdkEntry: string,
+  runs: ReadonlyArray<Record<string, unknown>>,
+): ProbeResult[] {
+  const child = spawnSync(
+    process.execPath,
+    ['--input-type=module', '-e', PROBE_SCRIPT],
+    {
+      encoding: 'utf8',
+      timeout: 120_000,
+      env: {
+        ...process.env,
+        PTAH_SDK_ARGV_PROBE: JSON.stringify({
+          sdkUrl: pathToFileURL(sdkEntry).href,
+          runs,
+        }),
+      },
+    },
+  );
+  if (child.status !== 0) {
+    throw new Error(
+      `SDK probe failed (${child.status}): ${child.stderr || child.error}`,
+    );
+  }
+  return JSON.parse(child.stdout) as ProbeResult[];
+}
+
+function flagValue(args: readonly string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index >= 0) return args[index + 1];
+  const joined = args.find((arg) => arg.startsWith(`${flag}=`));
+  return joined?.slice(flag.length + 1);
+}
+
+function settingsFromArgv(args: readonly string[]): Record<string, unknown> {
+  const raw = flagValue(args, '--settings');
+  if (raw === undefined) throw new Error('no --settings on argv');
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+function initializeRequest(stdinText: string): Record<string, unknown> {
+  for (const line of stdinText.split('\n')) {
+    if (!line.trim()) continue;
+    const message = JSON.parse(line) as {
+      type?: string;
+      request?: Record<string, unknown>;
+    };
+    if (
+      message.type === 'control_request' &&
+      message.request?.['subtype'] === 'initialize'
+    ) {
+      return message.request;
+    }
+  }
+  throw new Error('no initialize request was written');
+}
+
+type CaseName =
+  | 'enabled-unset'
+  | 'disabled'
+  | 'min'
+  | 'max'
+  | 'invalid-low'
+  | 'invalid-high'
+  | 'style-and-window';
+
+const CASES: ReadonlyArray<{
+  readonly name: CaseName;
+  readonly values: Record<string, unknown>;
+  readonly outputStyleName?: string;
+}> = [
+  { name: 'enabled-unset', values: {} },
+  {
+    name: 'disabled',
+    values: { 'compaction.enabled': false, 'compaction.threshold': 300_000 },
+  },
+  { name: 'min', values: { 'compaction.threshold': 100_000 } },
+  { name: 'max', values: { 'compaction.threshold': 1_000_000 } },
+  { name: 'invalid-low', values: { 'compaction.threshold': 50_000 } },
+  { name: 'invalid-high', values: { 'compaction.threshold': 1_000_001 } },
+  {
+    name: 'style-and-window',
+    values: { 'compaction.threshold': 400_000 },
+    outputStyleName: 'Explanatory',
+  },
+];
+
+function makeLogger(): jest.Mocked<Logger> {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as jest.Mocked<Logger>;
+}
+
+function makeBuilder(
+  values: Record<string, unknown>,
+  logger: jest.Mocked<Logger>,
+): SdkQueryOptionsBuilder {
+  const noopHooks = { createHooks: jest.fn().mockReturnValue({}) };
+  const config = {
+    get: jest.fn((key: string) => values[key]),
+  } as unknown as ConfigManager;
+  const ctor = SdkQueryOptionsBuilder as unknown as new (
+    ...args: unknown[]
+  ) => SdkQueryOptionsBuilder;
+  return new ctor(
+    logger,
+    {
+      createCallback: jest.fn().mockReturnValue(() => ({ behavior: 'allow' })),
+    },
+    noopHooks,
+    new CompactionConfigProvider(config, logger),
+    noopHooks,
+    noopHooks,
+    {} as AuthEnv,
+    {
+      resolveModelId: jest.fn().mockImplementation((m: string) => m),
+      hasCachedModels: jest.fn().mockReturnValue(false),
+      getSupportedModels: jest.fn(),
+    },
+    {
+      buildBlock: jest.fn().mockResolvedValue(''),
+      buildSessionStartBlock: jest.fn().mockResolvedValue(''),
+      buildCorpusBlock: jest.fn().mockResolvedValue(''),
+    },
+    noopHooks,
+    noopHooks,
+    noopHooks,
+    noopHooks,
+    noopHooks,
+    noopHooks,
+    noopHooks,
+    noopHooks,
+    noopHooks,
+    noopHooks,
+    noopHooks,
+    noopHooks,
+  );
+}
+
+describe('interactive path — compaction settings on the real SDK argv', () => {
+  const MODEL = 'claude-sonnet-4-5';
+  const results = new Map<
+    CaseName,
+    {
+      probe: ProbeResult;
+      options: Record<string, unknown>;
+      logger: jest.Mocked<Logger>;
+    }
+  >();
+  let sdkVersion = '';
+
+  beforeAll(async () => {
+    const sdk = findPinnedSdk();
+    sdkVersion = sdk.version;
+    const built: Array<{
+      name: CaseName;
+      options: Record<string, unknown>;
+      logger: jest.Mocked<Logger>;
+    }> = [];
+    for (const testCase of CASES) {
+      const logger = makeLogger();
+      const cfg = await makeBuilder(testCase.values, logger).build({
+        userMessageStream: (async function* () {
+          // Intentionally empty.
+        })(),
+        abortController: new AbortController(),
+        sessionConfig: {
+          model: MODEL,
+          projectPath: 'D:/tmp/ws',
+          tabId: 'tab-fixture',
+          ...(testCase.outputStyleName
+            ? { outputStyleName: testCase.outputStyleName }
+            : {}),
+        } as AISessionConfig,
+      });
+      built.push({
+        name: testCase.name,
+        logger,
+        options: {
+          model: cfg.options.model,
+          settings: cfg.options.settings,
+          systemPrompt: cfg.options.systemPrompt,
+          settingSources: cfg.options.settingSources,
+        },
+      });
+    }
+    const probes = runProbe(
+      sdk.entry,
+      built.map((entry) => entry.options),
+    );
+    built.forEach((entry, index) => {
+      results.set(entry.name, {
+        probe: probes[index],
+        options: entry.options,
+        logger: entry.logger,
+      });
+    });
+  }, 180_000);
+
+  function argvSettings(name: CaseName): Record<string, unknown> {
+    const args = results.get(name)?.probe.args;
+    if (!args) throw new Error(`no argv captured for ${name}`);
+    return settingsFromArgv(args);
+  }
+
+  it('runs against the pinned SDK version', () => {
+    expect(sdkVersion).toBe(PINNED_SDK_VERSION);
+  });
+
+  it('enabled + unset threshold → no autoCompactWindow and no autoCompactEnabled', () => {
+    expect(argvSettings('enabled-unset')).toEqual({
+      autoMemoryEnabled: false,
+      autoDreamEnabled: false,
+    });
+  });
+
+  it('disabled → autoCompactEnabled false (auto compact off, no window)', () => {
+    expect(argvSettings('disabled')).toEqual({
+      autoMemoryEnabled: false,
+      autoDreamEnabled: false,
+      autoCompactEnabled: false,
+    });
+  });
+
+  it('min threshold → autoCompactWindow 100000 on argv', () => {
+    expect(argvSettings('min')).toMatchObject({ autoCompactWindow: 100_000 });
+  });
+
+  it('max threshold → autoCompactWindow 1000000 on argv', () => {
+    expect(argvSettings('max')).toMatchObject({
+      autoCompactWindow: 1_000_000,
+    });
+  });
+
+  it.each(['invalid-low', 'invalid-high'] as const)(
+    'invalid persisted threshold (%s) → warn + treated as unset',
+    (name) => {
+      expect(argvSettings(name)).toEqual({
+        autoMemoryEnabled: false,
+        autoDreamEnabled: false,
+      });
+      expect(results.get(name)?.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid compaction threshold'),
+        expect.anything(),
+      );
+    },
+  );
+
+  it('output style and window coexist on the flag tier', () => {
+    expect(argvSettings('style-and-window')).toEqual({
+      autoMemoryEnabled: false,
+      autoDreamEnabled: false,
+      outputStyle: 'Explanatory',
+      autoCompactWindow: 400_000,
+    });
+  });
+
+  it('preserves model, setting sources and the system prompt in every case', () => {
+    for (const [name, { probe, options }] of results) {
+      const args = probe.args;
+      if (!args) throw new Error(`no argv captured for ${name}`);
+      expect(flagValue(args, '--model')).toBe(MODEL);
+      expect(flagValue(args, '--setting-sources')).toBe(
+        (options['settingSources'] as string[]).join(','),
+      );
+      const init = initializeRequest(probe.stdinText);
+      const systemPrompt = options['systemPrompt'];
+      if (typeof systemPrompt === 'string') {
+        expect(init['systemPrompt']).toBe(systemPrompt);
+      } else {
+        expect(init['appendSystemPrompt']).toBe(
+          (systemPrompt as { append?: string }).append,
+        );
+      }
+    }
+  });
+});

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.auto-compact-argv.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.auto-compact-argv.spec.ts
@@ -13,7 +13,8 @@
 import 'reflect-metadata';
 
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
 
@@ -25,8 +26,14 @@ import { CompactionConfigProvider } from './compaction-config-provider';
 
 const PINNED_SDK_VERSION = '0.3.150';
 
+// The probe payload (system prompts across 7 cases routinely exceed 100 KB
+// combined) is read from stdin, never argv or env — both are capped by the
+// OS (Linux MAX_ARG_STRLEN is 131072 bytes per string; spawnSync fails with
+// E2BIG once argv+environ crosses ARG_MAX). See assertWithinArgLimit below.
 const PROBE_SCRIPT = `
-const { sdkUrl, runs } = JSON.parse(process.env.PTAH_SDK_ARGV_PROBE);
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+const { sdkUrl, runs } = JSON.parse(Buffer.concat(chunks).toString('utf8'));
 const { query } = await import(sdkUrl);
 const { PassThrough } = await import('node:stream');
 const { EventEmitter } = await import('node:events');
@@ -77,31 +84,68 @@ function findPinnedSdk(): { entry: string; version: string } {
   }
 }
 
+// Linux caps a single argv/env string at MAX_ARG_STRLEN (131072 bytes) and
+// the whole argv+environ block at ARG_MAX; exceeding either fails spawnSync
+// with E2BIG (`child.status === null`, `child.error.code === 'E2BIG'`).
+// Windows enforces no such limit, so a regression here passes locally and
+// only fails in CI. Guarding argv/env directly — rather than only moving the
+// known-large payload off them — makes a future regression fail everywhere.
+const MAX_ARG_BYTES = 100_000;
+
+function assertWithinArgLimit(label: string, value: string): void {
+  const bytes = Buffer.byteLength(value, 'utf8');
+  if (bytes >= MAX_ARG_BYTES) {
+    throw new Error(
+      `${label} is ${bytes} bytes, at/over the ${MAX_ARG_BYTES}-byte guard ` +
+        '(Linux argv/env strings are capped at 131072 bytes and spawnSync ' +
+        'fails with E2BIG well before that on the full argv+env block). ' +
+        'Send this payload over stdin or a temp file instead.',
+    );
+  }
+}
+
 function runProbe(
   sdkEntry: string,
   runs: ReadonlyArray<Record<string, unknown>>,
 ): ProbeResult[] {
-  const child = spawnSync(
-    process.execPath,
-    ['--input-type=module', '-e', PROBE_SCRIPT],
-    {
+  const scriptPath = path.join(
+    os.tmpdir(),
+    `ptah-sdk-argv-probe-${process.pid}-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}.mjs`,
+  );
+  writeFileSync(scriptPath, PROBE_SCRIPT, 'utf8');
+  try {
+    const args = [scriptPath];
+    for (const arg of args) assertWithinArgLimit(`argv "${arg}"`, arg);
+    for (const [key, value] of Object.entries(process.env)) {
+      if (typeof value === 'string') {
+        assertWithinArgLimit(`env[${key}]`, value);
+      }
+    }
+    const payload = JSON.stringify({
+      sdkUrl: pathToFileURL(sdkEntry).href,
+      runs,
+    });
+    const child = spawnSync(process.execPath, args, {
       encoding: 'utf8',
       timeout: 120_000,
-      env: {
-        ...process.env,
-        PTAH_SDK_ARGV_PROBE: JSON.stringify({
-          sdkUrl: pathToFileURL(sdkEntry).href,
-          runs,
-        }),
-      },
-    },
-  );
-  if (child.status !== 0) {
-    throw new Error(
-      `SDK probe failed (${child.status}): ${child.stderr || child.error}`,
-    );
+      input: payload,
+      env: process.env,
+    });
+    if (child.status !== 0) {
+      throw new Error(
+        `SDK probe failed (${child.status}): ${child.stderr || child.error}`,
+      );
+    }
+    return JSON.parse(child.stdout) as ProbeResult[];
+  } finally {
+    try {
+      unlinkSync(scriptPath);
+    } catch {
+      // best-effort cleanup; a leftover temp file is not worth failing the test over
+    }
   }
-  return JSON.parse(child.stdout) as ProbeResult[];
 }
 
 function flagValue(args: readonly string[], flag: string): string | undefined {

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.auto-compact-argv.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.auto-compact-argv.spec.ts
@@ -56,8 +56,10 @@ for (const options of runs) {
   }
   results.push({ args: captured ? captured.args : null, stdinText });
 }
-process.stdout.write(JSON.stringify(results));
-process.exit(0);
+// Exit only once the payload has actually left the process. stdout is a PIPE
+// here, so process.stdout.write() buffers and an immediate process.exit(0)
+// truncates a large JSON result — the parent then fails at JSON.parse.
+process.stdout.write(JSON.stringify(results), () => process.exit(0));
 `;
 
 interface ProbeResult {

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.betas.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.betas.spec.ts
@@ -58,7 +58,7 @@ async function buildWithAuthEnv(authEnv: AuthEnv): Promise<BuildResult> {
     {
       getConfig: jest
         .fn()
-        .mockReturnValue({ enabled: false, contextTokenThreshold: 200_000 }),
+        .mockReturnValue({ enabled: true, contextTokenThreshold: null }),
     },
     noopHooks,
     noopHooks,

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.cli-notice.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.cli-notice.spec.ts
@@ -69,7 +69,7 @@ async function makeHarness(
     {
       getConfig: jest
         .fn()
-        .mockReturnValue({ enabled: false, contextTokenThreshold: 200_000 }),
+        .mockReturnValue({ enabled: true, contextTokenThreshold: null }),
     },
     noopHooks,
     noopHooks,

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.output-style.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.output-style.spec.ts
@@ -83,6 +83,46 @@ describe('buildFlagSettings — a style is active', () => {
   });
 });
 
+describe('buildFlagSettings — auto-compact keys (TASK_2026_414)', () => {
+  it('returns the shared constant when the auto-compact control has no opinion', () => {
+    expect(buildFlagSettings(undefined, {})).toBe(PTAH_DISABLE_SDK_AUTO_MEMORY);
+  });
+
+  it('merges autoCompactEnabled false into a fresh object', () => {
+    const settings = buildFlagSettings(undefined, {
+      autoCompactEnabled: false,
+    });
+    expect(settings).toEqual({
+      autoMemoryEnabled: false,
+      autoDreamEnabled: false,
+      autoCompactEnabled: false,
+    });
+    expect(settings).not.toBe(PTAH_DISABLE_SDK_AUTO_MEMORY);
+  });
+
+  it('merges autoCompactWindow alongside an output style without mutating the constant', () => {
+    const snapshot = { ...PTAH_DISABLE_SDK_AUTO_MEMORY };
+    const settings = buildFlagSettings(
+      { outputStyleName: 'Explanatory' },
+      { autoCompactWindow: 400_000 },
+    );
+    expect(settings).toEqual({
+      autoMemoryEnabled: false,
+      autoDreamEnabled: false,
+      outputStyle: 'Explanatory',
+      autoCompactWindow: 400_000,
+    });
+    expect(PTAH_DISABLE_SDK_AUTO_MEMORY).toEqual(snapshot);
+  });
+
+  it('never emits an autoCompactEnabled key for the enabled default', () => {
+    const settings = buildFlagSettings(undefined, {
+      autoCompactWindow: 200_000,
+    }) as Record<string, unknown>;
+    expect('autoCompactEnabled' in settings).toBe(false);
+  });
+});
+
 describe('buildFlagSettings — no style is active (G4b)', () => {
   it.each([
     ['undefined sessionConfig', undefined],
@@ -156,7 +196,10 @@ describe('build() wiring', () => {
     expect(existsSync(BUILDER_PATH)).toBe(true);
     const source = readFileSync(BUILDER_PATH, 'utf8');
 
-    expect(source).toContain('settings: buildFlagSettings(sessionConfig)');
+    // Auto-compaction keys ride the same builder call (TASK_2026_414).
+    expect(source).toContain(
+      'settings: buildFlagSettings(sessionConfig, autoCompact)',
+    );
     // The bare reference is what this task replaced. If it reappears on the
     // options object, the flag tier stops carrying the style.
     expect(source).not.toContain('settings: PTAH_DISABLE_SDK_AUTO_MEMORY');

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.spec.ts
@@ -22,6 +22,7 @@ import {
   type SdkQueryOptions,
 } from './sdk-query-options-builder';
 import { ModelNotAvailableError, SdkError } from '../errors';
+import { PTAH_DISABLE_SDK_AUTO_MEMORY } from '../constants';
 import type {
   McpHttpServerConfig,
   HookEvent,
@@ -179,7 +180,7 @@ describe('SdkQueryOptionsBuilder.build — file checkpointing wiring', () => {
     const compactionConfigProvider = {
       getConfig: jest
         .fn()
-        .mockReturnValue({ enabled: false, contextTokenThreshold: 200_000 }),
+        .mockReturnValue({ enabled: true, contextTokenThreshold: null }),
     };
 
     const compactionHookHandler = {
@@ -367,7 +368,7 @@ describe('SdkQueryOptionsBuilder.build — activityHold forwarded to subagent ho
       {
         getConfig: jest
           .fn()
-          .mockReturnValue({ enabled: false, contextTokenThreshold: 200_000 }),
+          .mockReturnValue({ enabled: true, contextTokenThreshold: null }),
       },
       noopHooks(),
       noopHooks(),
@@ -437,14 +438,20 @@ describe('SdkQueryOptionsBuilder.build — activityHold forwarded to subagent ho
 });
 
 // ---------------------------------------------------------------------------
-// build() — CLAUDE_CODE_MAX_CONTEXT_TOKENS override for proxied providers.
-// The SDK only auto-detects the context window for first-party Anthropic; behind
-// a translation proxy it defaults to 200k, mis-timing auto-compaction. We pin the
-// real window when known, only for non-Anthropic base URLs.
+// build() — auto-compact control (TASK_2026_414 / TASK_2026_411 B8).
+// Compaction settings reach the runtime ONLY through the flag-tier settings
+// object. The old CLAUDE_CODE_MAX_CONTEXT_TOKENS override is gone: the pinned
+// CLI reads that variable only when DISABLE_COMPACT is also set.
 // ---------------------------------------------------------------------------
 
-describe('SdkQueryOptionsBuilder.build — context-window override', () => {
-  function makeBuilder(baseUrl: string | undefined): SdkQueryOptionsBuilder {
+describe('SdkQueryOptionsBuilder.build — auto-compact control', () => {
+  function makeBuilder(
+    baseUrl: string | undefined,
+    compactionConfig: {
+      enabled: boolean;
+      contextTokenThreshold: number | null;
+    } = { enabled: true, contextTokenThreshold: null },
+  ): SdkQueryOptionsBuilder {
     const noopHooks = { createHooks: jest.fn().mockReturnValue({}) };
     const ctor = SdkQueryOptionsBuilder as unknown as new (
       ...args: unknown[]
@@ -457,11 +464,7 @@ describe('SdkQueryOptionsBuilder.build — context-window override', () => {
           .mockReturnValue(() => ({ behavior: 'allow' })),
       },
       noopHooks,
-      {
-        getConfig: jest
-          .fn()
-          .mockReturnValue({ enabled: true, contextTokenThreshold: 100_000 }),
-      },
+      { getConfig: jest.fn().mockReturnValue(compactionConfig) },
       noopHooks,
       noopHooks,
       (baseUrl ? { ANTHROPIC_BASE_URL: baseUrl } : {}) as AuthEnv,
@@ -490,59 +493,95 @@ describe('SdkQueryOptionsBuilder.build — context-window override', () => {
     );
   }
 
-  async function buildEnv(
+  async function buildOptions(
     baseUrl: string | undefined,
     model: string,
-  ): Promise<Record<string, string | undefined>> {
+    compactionConfig?: {
+      enabled: boolean;
+      contextTokenThreshold: number | null;
+    },
+    outputStyleName?: string,
+  ): Promise<Awaited<ReturnType<SdkQueryOptionsBuilder['build']>>['options']> {
     const userMessageStream = (async function* () {
       // Intentionally empty.
     })();
-    const cfg = await makeBuilder(baseUrl).build({
+    const cfg = await makeBuilder(baseUrl, compactionConfig).build({
       userMessageStream,
       abortController: new AbortController(),
       sessionConfig: {
         model,
         projectPath: 'D:/tmp/ws',
         tabId: 'tab-fixture',
+        ...(outputStyleName ? { outputStyleName } : {}),
       } as AISessionConfig,
     });
-    return cfg.options.env as Record<string, string | undefined>;
+    return cfg.options;
   }
 
-  const savedEnv = process.env['CLAUDE_CODE_MAX_CONTEXT_TOKENS'];
-  afterEach(() => {
-    if (savedEnv === undefined) {
-      delete process.env['CLAUDE_CODE_MAX_CONTEXT_TOKENS'];
-    } else {
-      process.env['CLAUDE_CODE_MAX_CONTEXT_TOKENS'] = savedEnv;
+  it('never emits CLAUDE_CODE_MAX_CONTEXT_TOKENS, even for a proxied model with a known window', async () => {
+    const saved = process.env['CLAUDE_CODE_MAX_CONTEXT_TOKENS'];
+    delete process.env['CLAUDE_CODE_MAX_CONTEXT_TOKENS'];
+    try {
+      const opts = await buildOptions(
+        'http://127.0.0.1:4000',
+        'claude-sonnet-4-5',
+      );
+      const env = opts.env as Record<string, string | undefined>;
+      expect(env['CLAUDE_CODE_MAX_CONTEXT_TOKENS']).toBeUndefined();
+    } finally {
+      if (saved !== undefined) {
+        process.env['CLAUDE_CODE_MAX_CONTEXT_TOKENS'] = saved;
+      }
     }
   });
-  beforeEach(() => {
-    delete process.env['CLAUDE_CODE_MAX_CONTEXT_TOKENS'];
+
+  it('explicit threshold sets settings.autoCompactWindow', async () => {
+    const opts = await buildOptions(undefined, 'claude-sonnet-4-5', {
+      enabled: true,
+      contextTokenThreshold: 150_000,
+    });
+    expect(opts.settings).toEqual({
+      autoMemoryEnabled: false,
+      autoDreamEnabled: false,
+      autoCompactWindow: 150_000,
+    });
   });
 
-  it('pins the model window for a non-Anthropic base URL when known', async () => {
-    const env = await buildEnv('http://127.0.0.1:4000', 'claude-sonnet-4-5');
-    expect(env['CLAUDE_CODE_MAX_CONTEXT_TOKENS']).toBe('200000');
+  it('compaction disabled sets settings.autoCompactEnabled false and no window', async () => {
+    const opts = await buildOptions(undefined, 'claude-sonnet-4-5', {
+      enabled: false,
+      contextTokenThreshold: 150_000,
+    });
+    expect(opts.settings).toEqual({
+      autoMemoryEnabled: false,
+      autoDreamEnabled: false,
+      autoCompactEnabled: false,
+    });
   });
 
-  it('does NOT set the override for a first-party Anthropic base URL', async () => {
-    const env = await buildEnv(
+  it('outputStyleName and autoCompactWindow coexist and PTAH_DISABLE_SDK_AUTO_MEMORY is not mutated', async () => {
+    const snapshot = { ...PTAH_DISABLE_SDK_AUTO_MEMORY };
+    const opts = await buildOptions(
+      undefined,
+      'claude-sonnet-4-5',
+      { enabled: true, contextTokenThreshold: 1_000_000 },
+      'Explanatory',
+    );
+    expect(opts.settings).toEqual({
+      autoMemoryEnabled: false,
+      autoDreamEnabled: false,
+      outputStyle: 'Explanatory',
+      autoCompactWindow: 1_000_000,
+    });
+    expect(PTAH_DISABLE_SDK_AUTO_MEMORY).toEqual(snapshot);
+  });
+
+  it('first-party with defaults sends neither key (the shared constant itself)', async () => {
+    const opts = await buildOptions(
       'https://api.anthropic.com',
       'claude-sonnet-4-5',
     );
-    expect(env['CLAUDE_CODE_MAX_CONTEXT_TOKENS']).toBeUndefined();
-  });
-
-  it('does NOT set the override when the model window is unknown', async () => {
-    const env = await buildEnv('http://127.0.0.1:4000', 'mystery-model-xyz');
-    expect(env['CLAUDE_CODE_MAX_CONTEXT_TOKENS']).toBeUndefined();
-  });
-
-  it('respects an explicit CLAUDE_CODE_MAX_CONTEXT_TOKENS already in the env', async () => {
-    process.env['CLAUDE_CODE_MAX_CONTEXT_TOKENS'] = '512000';
-    const env = await buildEnv('http://127.0.0.1:4000', 'claude-sonnet-4-5');
-    expect(env['CLAUDE_CODE_MAX_CONTEXT_TOKENS']).toBe('512000');
+    expect(opts.settings).toBe(PTAH_DISABLE_SDK_AUTO_MEMORY);
   });
 });
 
@@ -577,8 +616,8 @@ describe('SdkQueryOptionsBuilder.buildSystemPrompt — prepend order', () => {
     };
     const compactionConfigProvider = {
       getConfig: jest.fn().mockReturnValue({
-        enabled: false,
-        contextTokenThreshold: 200_000,
+        enabled: true,
+        contextTokenThreshold: null,
       }),
     };
     const compactionHookHandler = {
@@ -759,7 +798,7 @@ describe('SdkQueryOptionsBuilder.validateModelAvailability (pre-flight, via buil
     const compactionConfigProvider = {
       getConfig: jest
         .fn()
-        .mockReturnValue({ enabled: false, contextTokenThreshold: 200_000 }),
+        .mockReturnValue({ enabled: true, contextTokenThreshold: null }),
     };
     const compactionHookHandler = {
       createHooks: jest
@@ -933,7 +972,7 @@ describe('SdkQueryOptionsBuilder.validateModelAvailability (pre-flight, via buil
     const compactionConfigProvider = {
       getConfig: jest
         .fn()
-        .mockReturnValue({ enabled: false, contextTokenThreshold: 200_000 }),
+        .mockReturnValue({ enabled: true, contextTokenThreshold: null }),
     };
     const compactionHookHandler = {
       createHooks: jest.fn().mockReturnValue({}),
@@ -1052,7 +1091,7 @@ describe('SdkQueryOptionsBuilder.build — permission routing safeParse fallback
     const compactionConfigProvider = {
       getConfig: jest
         .fn()
-        .mockReturnValue({ enabled: false, contextTokenThreshold: 200_000 }),
+        .mockReturnValue({ enabled: true, contextTokenThreshold: null }),
     };
     const compactionHookHandler = {
       createHooks: jest
@@ -1359,7 +1398,7 @@ describe('SdkQueryOptionsBuilder.build — workflows.disabled env injection', ()
       {
         getConfig: jest
           .fn()
-          .mockReturnValue({ enabled: false, contextTokenThreshold: 200_000 }),
+          .mockReturnValue({ enabled: true, contextTokenThreshold: null }),
       },
       noopHooks,
       noopHooks,
@@ -1482,7 +1521,7 @@ describe('SdkQueryOptionsBuilder.createHooks — PostToolUse + UserPromptSubmit 
     const compactionConfigProvider = {
       getConfig: jest
         .fn()
-        .mockReturnValue({ enabled: false, contextTokenThreshold: 200_000 }),
+        .mockReturnValue({ enabled: true, contextTokenThreshold: null }),
     };
     const compactionHookHandler = {
       createHooks: jest.fn().mockReturnValue({

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-options-builder.ts
@@ -69,9 +69,12 @@ import type { SDKUserMessage } from './session-lifecycle-manager';
 import {
   getAnthropicProvider,
   getAllAnthropicProviders,
-  getModelContextWindow,
   includesUserSettingSource,
 } from '@ptah-extension/shared';
+import {
+  resolveAutoCompactControl,
+  type AutoCompactSettings,
+} from './auto-compact-control';
 import {
   SdkModelService,
   TIER_ENV_VAR_MAP,
@@ -354,15 +357,34 @@ export function assertSingleOutputStylePath(
  * OUTRANKS user/project/local settings, so emitting the key when Ptah has no
  * opinion would silently clobber a style the user picked for their own Claude
  * Code CLI usage. Absence is the only correct "no opinion" value (G4b).
+ *
+ * The same rule governs auto compaction: `autoCompact` comes from
+ * `resolveAutoCompactControl`, which yields `{}` when Ptah has no opinion, and
+ * only its present keys are merged. With neither a style nor an auto-compact
+ * key, the shared constant is still returned untouched.
  */
 export function buildFlagSettings(
   sessionConfig?: OutputStyleActivationFields,
+  autoCompact?: AutoCompactSettings,
 ): Settings {
   assertSingleOutputStylePath(sessionConfig);
   const styleName = sessionConfig?.outputStyleName?.trim();
-  return styleName
-    ? { ...PTAH_DISABLE_SDK_AUTO_MEMORY, outputStyle: styleName }
-    : PTAH_DISABLE_SDK_AUTO_MEMORY;
+  const autoCompactKeys: AutoCompactSettings = {
+    ...(autoCompact?.autoCompactEnabled === false
+      ? { autoCompactEnabled: false }
+      : {}),
+    ...(autoCompact?.autoCompactWindow !== undefined
+      ? { autoCompactWindow: autoCompact.autoCompactWindow }
+      : {}),
+  };
+  if (!styleName && Object.keys(autoCompactKeys).length === 0) {
+    return PTAH_DISABLE_SDK_AUTO_MEMORY;
+  }
+  return {
+    ...PTAH_DISABLE_SDK_AUTO_MEMORY,
+    ...(styleName ? { outputStyle: styleName } : {}),
+    ...autoCompactKeys,
+  };
 }
 
 /**
@@ -760,6 +782,10 @@ export class SdkQueryOptionsBuilder {
       activityHold,
     );
     const compactionConfig = this.compactionConfigProvider.getConfig();
+    const autoCompact = resolveAutoCompactControl({
+      enabled: compactionConfig.enabled,
+      windowTokens: compactionConfig.contextTokenThreshold,
+    });
     this.logger.info('[SdkQueryOptionsBuilder] Building SDK query options', {
       cwd,
       model,
@@ -771,6 +797,7 @@ export class SdkQueryOptionsBuilder {
       hasCanUseToolCallback: !!canUseToolCallback,
       compactionEnabled: compactionConfig.enabled,
       compactionThreshold: compactionConfig.contextTokenThreshold,
+      autoCompact,
       mcpEnabled: mcpServerRunning,
       hasEnhancedPrompts: !!enhancedPromptsContent,
       mcpOverrideKeys: mcpServersOverride
@@ -791,8 +818,9 @@ export class SdkQueryOptionsBuilder {
         // Flag tier. Fresh per session when a style is active; the shared
         // PTAH_DISABLE_SDK_AUTO_MEMORY constant itself is never mutated (G4),
         // and the `outputStyle` key is absent entirely when no style is
-        // chosen so a CLI-chosen style is not clobbered (G4b).
-        settings: buildFlagSettings(sessionConfig),
+        // chosen so a CLI-chosen style is not clobbered (G4b). Auto-compaction
+        // keys ride the same tier under the same absence rule.
+        settings: buildFlagSettings(sessionConfig, autoCompact),
         tools: {
           type: 'preset' as const,
           preset: 'claude_code' as const,
@@ -834,10 +862,8 @@ export class SdkQueryOptionsBuilder {
           ...effectiveAuthEnv,
           NO_PROXY: '127.0.0.1,localhost',
           ...experimentalBetaEnv(effectiveAuthEnv.ANTHROPIC_BASE_URL),
-          ...this.resolveContextWindowOverride(
-            model,
-            effectiveAuthEnv.ANTHROPIC_BASE_URL,
-          ),
+          // No CLAUDE_CODE_MAX_CONTEXT_TOKENS: the pinned CLI reads it only
+          // when DISABLE_COMPACT is also set (see auto-compact-control.ts).
           // Kill switch: disable the SDK's built-in workflows (ultracode/workflow
           // keyword) only when the persisted `workflows.disabled` config resolved
           // to true at the session origination point (chat-session.service). When
@@ -893,34 +919,6 @@ export class SdkQueryOptionsBuilder {
         forkSession: resumeSessionId ? forkSession : undefined,
       },
     };
-  }
-
-  /**
-   * Resolve a `CLAUDE_CODE_MAX_CONTEXT_TOKENS` override for proxied providers.
-   *
-   * The SDK only auto-detects a model's context window for first-party
-   * Anthropic base URLs; behind a translation proxy it falls back to a
-   * hardcoded 200k window, so auto-compaction triggers at the wrong point
-   * (too late for smaller models, which then overflow). When the selected
-   * model's real window is known, pin it explicitly so the SDK's
-   * auto-compaction threshold tracks the actual model.
-   *
-   * Skipped for first-party Anthropic (native detection is correct), when the
-   * window is unknown (window === 0 → leave the SDK default), and when the
-   * value is already set upstream (respect an explicit override).
-   */
-  private resolveContextWindowOverride(
-    model: string,
-    baseUrl: string | undefined,
-  ): Record<string, string> {
-    if (process.env['CLAUDE_CODE_MAX_CONTEXT_TOKENS']) return {};
-    const trimmed = baseUrl?.trim();
-    const isFirstPartyAnthropic =
-      !trimmed || /^https?:\/\/api\.anthropic\.com\/?$/i.test(trimmed);
-    if (isFirstPartyAnthropic) return {};
-    const window = getModelContextWindow(model);
-    if (window <= 0) return {};
-    return { CLAUDE_CODE_MAX_CONTEXT_TOKENS: String(window) };
   }
 
   /**

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-runner.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-runner.service.spec.ts
@@ -118,7 +118,7 @@ function makeRunner(
   const compactionConfig = {
     getConfig: jest
       .fn()
-      .mockReturnValue({ enabled: true, contextTokenThreshold: 100_000 }),
+      .mockReturnValue({ enabled: true, contextTokenThreshold: null }),
   } as unknown as CompactionConfigProvider;
   const authEnv: AuthEnv = opts.authEnv ?? ({} as AuthEnv);
   // Mirrors the one branch of ModelResolver.resolve() these specs exercise: a

--- a/libs/backend/agent-sdk/src/lib/helpers/sdk-query-runner.service.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/sdk-query-runner.service.ts
@@ -388,7 +388,7 @@ export class SdkQueryRunner {
 
     const compactionConfig = this.compactionConfigProvider.getConfig();
     this.logger.debug(
-      `${SERVICE_TAG} Compaction config: enabled=${compactionConfig.enabled}, threshold=${compactionConfig.contextTokenThreshold} (managed via hooks)`,
+      `${SERVICE_TAG} Compaction config: enabled=${compactionConfig.enabled}, threshold=${compactionConfig.contextTokenThreshold ?? 'unset'} (not applied to one-shot queries)`,
     );
 
     const options: SdkQueryOptions = {

--- a/libs/backend/agent-sdk/src/lib/helpers/stream-transformer.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/stream-transformer.spec.ts
@@ -397,6 +397,20 @@ describe('StreamTransformer — discovered context windows on proxies (TASK_2026
 
     expect(usage?.[0]?.contextWindow).toBe(200_000);
   });
+
+  it('a proxied model that only FUZZY-matches the bundled table keeps the SDK window', async () => {
+    // PR #493 review C: the override used getModelContextWindow(), whose
+    // pricing-table fallback matches partially — `gpt-4o-ultra-414` resolved
+    // to the bundled `gpt-4o` entry's 128000 and replaced the SDK value for a
+    // model provider discovery never registered. Only an EXACT discovered
+    // window may override the SDK.
+    const usage = await runResult(
+      makeAuthEnv({ ANTHROPIC_BASE_URL: 'http://127.0.0.1:43123' }),
+      'gpt-4o-ultra-414',
+    );
+
+    expect(usage?.[0]?.contextWindow).toBe(200_000);
+  });
 });
 
 describe('StreamTransformer — lastTurnContextTokens (TASK_2026_109_FOLLOWUP)', () => {

--- a/libs/backend/agent-sdk/src/lib/helpers/stream-transformer.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/stream-transformer.spec.ts
@@ -26,7 +26,10 @@ import 'reflect-metadata';
 
 import type { Logger } from '@ptah-extension/vscode-core';
 import type { AuthEnv, ModelPricing, SessionId } from '@ptah-extension/shared';
-import { findModelPricing } from '@ptah-extension/shared';
+import {
+  findModelPricing,
+  registerModelContextWindows,
+} from '@ptah-extension/shared';
 import type { SdkMessageTransformer } from '../sdk-message-transformer';
 import type { IModelResolver } from '../auth-env.port';
 import type {
@@ -339,6 +342,62 @@ async function drain(iter: AsyncIterable<unknown>): Promise<void> {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe('StreamTransformer — discovered context windows on proxies (TASK_2026_414)', () => {
+  async function runResult(
+    authEnv: AuthEnv,
+    model: string,
+  ): Promise<ResultModelUsage[] | undefined> {
+    const { transformer } = makeHarness(authEnv);
+    let modelUsage: ResultModelUsage[] | undefined;
+    await drain(
+      transformer.transform({
+        sdkQuery: asAsyncIterable([
+          resultMessage(model, { inputTokens: 1000, outputTokens: 100 }),
+        ]),
+        sessionId: 'sess-1' as SessionId,
+        initialModel: model,
+        onResultStats: (stats) => {
+          modelUsage = stats.modelUsage;
+        },
+      }),
+    );
+    return modelUsage;
+  }
+
+  it('proxied result modelUsage contextWindow 200000 is replaced by the registered 400000', async () => {
+    const model = 'gpt-ctx-stream-proxy-414';
+    registerModelContextWindows([{ id: model, contextLength: 400_000 }]);
+
+    const usage = await runResult(
+      makeAuthEnv({ ANTHROPIC_BASE_URL: 'http://127.0.0.1:43123' }),
+      model,
+    );
+
+    expect(usage?.[0]).toMatchObject({ model, contextWindow: 400_000 });
+  });
+
+  it('direct Anthropic keeps the SDK-reported window', async () => {
+    const model = 'claude-ctx-stream-direct-414';
+    registerModelContextWindows([{ id: model, contextLength: 1_000_000 }]);
+
+    const usage = await runResult(
+      makeAuthEnv({ ANTHROPIC_BASE_URL: 'https://api.anthropic.com' }),
+      model,
+    );
+
+    expect(usage?.[0]).toMatchObject({ model, contextWindow: 200_000 });
+  });
+
+  it('proxied model with no known window keeps the SDK-reported window', async () => {
+    const usage = await runResult(
+      makeAuthEnv({ ANTHROPIC_BASE_URL: 'http://127.0.0.1:43123' }),
+      'mystery-ctx-stream-414',
+    );
+
+    expect(usage?.[0]?.contextWindow).toBe(200_000);
+  });
+});
 
 describe('StreamTransformer — lastTurnContextTokens (TASK_2026_109_FOLLOWUP)', () => {
   it('clears lastTurnContextByModel on compact_boundary — next result without message_start emits lastTurnContextTokens=undefined', async () => {

--- a/libs/backend/agent-sdk/src/lib/helpers/stream-transformer.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/stream-transformer.ts
@@ -17,6 +17,7 @@ import {
   FlatStreamEventUnion,
   MessageTokenUsage,
   calculateMessageCost,
+  getDiscoveredContextWindow,
   getModelContextWindow,
   AuthEnv,
   isDirectAnthropic,
@@ -53,6 +54,32 @@ export type SessionIdResolvedCallback = (
   tabId: string | undefined,
   realSessionId: string,
 ) => void;
+
+/**
+ * The context window to publish for one model of a `result` message.
+ *
+ * Precedence, and the reason for each step:
+ * 1. On a PROXY, a window provider discovery reported for this EXACT id. The
+ *    CLI cannot know a non-Claude model's window and reports its generic
+ *    200000 fallback, so the provider's own answer outranks it. Exact only —
+ *    a fuzzy table match is not the provider answering (PR #493 review C).
+ * 2. The SDK's own value, authoritative on direct Anthropic (`[1m]` and
+ *    similar) and the best available on a proxy with nothing discovered.
+ * 3. The general lookup (discovered → bundled table → Claude family regex),
+ *    for the case where the SDK reported nothing at all.
+ */
+function resolveResultContextWindow(params: {
+  readonly isDirect: boolean;
+  readonly discoveredContextWindow: number;
+  readonly sdkContextWindow: number;
+  readonly knownContextWindow: number;
+}): number {
+  if (!params.isDirect && params.discoveredContextWindow > 0) {
+    return params.discoveredContextWindow;
+  }
+  if (params.sdkContextWindow > 0) return params.sdkContextWindow;
+  return params.knownContextWindow;
+}
 
 /**
  * Model usage data from SDK result message
@@ -454,15 +481,22 @@ export class StreamTransformer {
                     const trackedContext = lastTurnContextByModel.get(model);
                     // On a proxy the CLI cannot know a non-Claude model's
                     // window and reports its generic 200000 fallback, so a
-                    // known window (e.g. discovered from the provider
-                    // catalogue) wins there. Direct Anthropic keeps the SDK
-                    // value, which is authoritative for `[1m]` and similar.
-                    const contextWindow =
-                      !isDirect && knownContextWindow > 0
-                        ? knownContextWindow
-                        : usage.contextWindow > 0
-                          ? usage.contextWindow
-                          : knownContextWindow;
+                    // window the PROVIDER ITSELF reported for this exact id
+                    // wins there. It must be the EXACT discovered value, never
+                    // `getModelContextWindow`: that falls through to the
+                    // bundled pricing table's partial matching, so an
+                    // undiscovered `gpt-4o-ultra` resolved to `gpt-4o`'s
+                    // 128000 and overrode the SDK for a model nobody
+                    // registered (PR #493 review C). Direct Anthropic keeps
+                    // the SDK value, authoritative for `[1m]` and similar.
+                    const discoveredContextWindow =
+                      getDiscoveredContextWindow(resolvedModel);
+                    const contextWindow = resolveResultContextWindow({
+                      isDirect,
+                      discoveredContextWindow,
+                      sdkContextWindow: usage.contextWindow,
+                      knownContextWindow,
+                    });
                     modelUsageList.push({
                       model: resolvedModel,
                       inputTokens: usage.inputTokens,

--- a/libs/backend/agent-sdk/src/lib/helpers/stream-transformer.ts
+++ b/libs/backend/agent-sdk/src/lib/helpers/stream-transformer.ts
@@ -452,14 +452,22 @@ export class StreamTransformer {
                     const knownContextWindow =
                       getModelContextWindow(resolvedModel);
                     const trackedContext = lastTurnContextByModel.get(model);
+                    // On a proxy the CLI cannot know a non-Claude model's
+                    // window and reports its generic 200000 fallback, so a
+                    // known window (e.g. discovered from the provider
+                    // catalogue) wins there. Direct Anthropic keeps the SDK
+                    // value, which is authoritative for `[1m]` and similar.
+                    const contextWindow =
+                      !isDirect && knownContextWindow > 0
+                        ? knownContextWindow
+                        : usage.contextWindow > 0
+                          ? usage.contextWindow
+                          : knownContextWindow;
                     modelUsageList.push({
                       model: resolvedModel,
                       inputTokens: usage.inputTokens,
                       outputTokens: usage.outputTokens,
-                      contextWindow:
-                        usage.contextWindow > 0
-                          ? usage.contextWindow
-                          : knownContextWindow,
+                      contextWindow,
                       costUSD,
                       cacheReadInputTokens: usage.cacheReadInputTokens ?? 0,
                       lastTurnContextTokens: trackedContext

--- a/libs/backend/agent-sdk/src/lib/message-transform/artifact-parity.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/message-transform/artifact-parity.spec.ts
@@ -13,7 +13,10 @@ import { AgentCorrelationService } from '../helpers/history/agent-correlation.se
 import { HistoryEventFactory } from '../helpers/history/history-event-factory';
 import type { SessionHistoryMessage } from '../helpers/history/history.types';
 import { SessionReplayService } from '../helpers/history/session-replay.service';
+import type { JsonlReaderService } from '../helpers/history/jsonl-reader.service';
+import type { IPricingProvider } from '../pricing.port';
 import { SdkMessageTransformer } from '../sdk-message-transformer';
+import { SessionHistoryReaderService } from '../session-history-reader.service';
 
 const SESSION_ID = 'artifact-parity-session';
 
@@ -67,6 +70,46 @@ function createReplayService(): SessionReplayService {
     {
       resolveForPricing: (model: string) => model || 'unknown',
     } as unknown as IModelResolver,
+  );
+}
+
+/**
+ * The reader over a fixed transcript, wired to the REAL replay service — the
+ * two outputs under comparison must come from one parse of one corpus.
+ */
+function createReader(
+  records: SessionHistoryMessage[],
+  replay: SessionReplayService,
+): SessionHistoryReaderService {
+  const jsonlReader = {
+    findSessionsDirectory: jest.fn().mockResolvedValue('/sessions'),
+    readJsonlMessages: jest.fn().mockResolvedValue(records),
+    loadAgentSessions: jest.fn().mockResolvedValue([]),
+  } as unknown as JsonlReaderService;
+  const modelResolver = {
+    resolveForPricing: (model: string) => model || 'unknown',
+    resolveForCost: (model: string) => ({
+      modelId: model || 'unknown',
+      pricing: findModelPricing(model || 'unknown'),
+      subscriptionCovered: false,
+    }),
+    isSubscriptionCovered: () => false,
+  } as unknown as IModelResolver;
+  const pricingProvider = {
+    getPricing: jest.fn().mockResolvedValue(null),
+    ensureHydrated: jest.fn().mockResolvedValue(true),
+  } as unknown as IPricingProvider;
+
+  return new SessionHistoryReaderService(
+    createLogger(),
+    jsonlReader,
+    replay,
+    new HistoryEventFactory(),
+    modelResolver,
+    {} as AuthEnv,
+    pricingProvider,
+    new LiveUsageTracker(),
+    new CompactionBoundaryGenerationRegistry(),
   );
 }
 
@@ -187,6 +230,40 @@ describe('artifact replay/live visible-text parity (TASK_2026_414)', () => {
     );
 
     expect(visibleText(replay)).toEqual(visibleText(live));
+  });
+
+  /**
+   * `readSessionHistory` returns events and messages from ONE parse, and
+   * `chat:resume` renders the messages. So the projection must hide exactly
+   * what replay hides: the first fix suppressed `isSynthetic` only, leaving an
+   * `isMeta` record visible in a resumed transcript that the event stream
+   * omits (round-2 verification, Moderate-2). Both sides now ask the one
+   * `isHiddenTranscriptRecord` predicate.
+   */
+  it('hides isMeta AND isSynthetic records from the projected messages and the replayed events alike', async () => {
+    const records: SessionHistoryMessage[] = [
+      replayUser('ordinary prompt', { uuid: 'u-ordinary' }),
+      replayUser('meta bookkeeping turn', { uuid: 'u-meta', isMeta: true }),
+      replayUser('synthetic cue', { uuid: 'u-synthetic', isSynthetic: true }),
+      replayAssistant([{ type: 'text', text: 'ordinary answer' }]),
+    ];
+
+    const snapshot = await createReader(
+      records,
+      createReplayService(),
+    ).readSessionHistory(SESSION_ID, '/workspace');
+    const events = createReplayService().replayToStreamEvents(
+      SESSION_ID,
+      records,
+      [],
+    );
+
+    const projected = snapshot.messages.map((message) => message.content);
+    expect(projected).toEqual(['ordinary prompt', 'ordinary answer']);
+    expect(visibleText(events)).toEqual(projected);
+    expect(snapshot.messages.map((message) => message.id)).not.toContain(
+      'u-meta',
+    );
   });
 
   it('keeps local-command output visible where replay has an assistant-text representation', () => {

--- a/libs/backend/agent-sdk/src/lib/message-transform/artifact-parity.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/message-transform/artifact-parity.spec.ts
@@ -1,0 +1,211 @@
+import 'reflect-metadata';
+
+import type { AuthEnv, FlatStreamEventUnion } from '@ptah-extension/shared';
+import { findModelPricing } from '@ptah-extension/shared';
+import type { Logger, SubagentRegistryService } from '@ptah-extension/vscode-core';
+
+import type { IModelResolver } from '../auth-env.port';
+import { CompactionBoundaryGenerationRegistry } from '../helpers/compaction-boundary-generation-registry';
+import { LiveUsageTracker } from '../helpers/live-usage-tracker';
+import type { SessionLifecycleManager } from '../helpers/session-lifecycle-manager';
+import { SessionTurnStateRegistry } from '../helpers/session-turn-state.registry';
+import { AgentCorrelationService } from '../helpers/history/agent-correlation.service';
+import { HistoryEventFactory } from '../helpers/history/history-event-factory';
+import type { SessionHistoryMessage } from '../helpers/history/history.types';
+import { SessionReplayService } from '../helpers/history/session-replay.service';
+import { SdkMessageTransformer } from '../sdk-message-transformer';
+
+const SESSION_ID = 'artifact-parity-session';
+
+function createLogger(): jest.Mocked<Logger> {
+  return {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as jest.Mocked<Logger>;
+}
+
+function createLiveTransformer(): SdkMessageTransformer {
+  const logger = createLogger();
+  const subagentRegistry = {
+    pruneSession: jest.fn(),
+    markPendingBackground: jest.fn(),
+    setTaskId: jest.fn(),
+  } as unknown as SubagentRegistryService;
+  const modelResolver = {
+    resolveForPricing: jest.fn((model: string) => model),
+    resolveForCost: jest.fn((model: string) => ({
+      modelId: model,
+      pricing: findModelPricing(model),
+      subscriptionCovered: false,
+    })),
+    isSubscriptionCovered: jest.fn(() => false),
+  } as unknown as IModelResolver;
+  const lifecycle = {
+    getActiveSessionIds: jest.fn(() => [SESSION_ID]),
+  } as unknown as SessionLifecycleManager;
+
+  return new SdkMessageTransformer(
+    logger,
+    { provider: 'anthropic' } as unknown as AuthEnv,
+    subagentRegistry,
+    modelResolver,
+    lifecycle,
+    new LiveUsageTracker(),
+    new SessionTurnStateRegistry(),
+    new CompactionBoundaryGenerationRegistry(),
+  );
+}
+
+function createReplayService(): SessionReplayService {
+  const logger = createLogger();
+  return new SessionReplayService(
+    logger,
+    new AgentCorrelationService(logger),
+    new HistoryEventFactory(),
+    {
+      resolveForPricing: (model: string) => model || 'unknown',
+    } as unknown as IModelResolver,
+  );
+}
+
+function visibleText(events: FlatStreamEventUnion[]): string[] {
+  return events
+    .filter(
+      (event): event is Extract<FlatStreamEventUnion, { eventType: 'text_delta' }> =>
+        event.eventType === 'text_delta',
+    )
+    .map((event) => event.delta);
+}
+
+function replayUser(content: unknown, extra: Record<string, unknown> = {}): SessionHistoryMessage {
+  return {
+    type: 'user',
+    uuid: 'replay-user',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    message: { role: 'user', content: content as string },
+    ...extra,
+  } as SessionHistoryMessage;
+}
+
+function replayAssistant(content: unknown): SessionHistoryMessage {
+  return {
+    type: 'assistant',
+    uuid: 'replay-assistant',
+    timestamp: '2026-01-01T00:00:01.000Z',
+    message: { role: 'assistant', content: content as string },
+  } as SessionHistoryMessage;
+}
+
+function liveUser(content: unknown, extra: Record<string, unknown> = {}): unknown {
+  return {
+    type: 'user',
+    uuid: 'live-user',
+    session_id: SESSION_ID,
+    message: { role: 'user', content },
+    ...extra,
+  };
+}
+
+function liveAssistant(content: unknown): unknown {
+  return {
+    type: 'assistant',
+    uuid: 'live-assistant',
+    session_id: SESSION_ID,
+    message: { id: 'live-assistant', role: 'assistant', content },
+  };
+}
+
+describe('artifact replay/live visible-text parity (TASK_2026_414)', () => {
+  /**
+   * The replay path previously emitted visible text for the command and skill
+   * artifacts below while the live transformer rejected them with
+   * isSkillOrMetaContent. This corpus pins their shared hidden status without
+   * comparing protocol-only events, timestamps, or event ordering.
+   */
+  it.each([
+    ['synthetic user payload', 'synthetic payload', { isSynthetic: true }, { isSynthetic: true }],
+    ['sourceToolUseID payload', 'tool-owned payload', { sourceToolUseID: 'tool-1' }, { sourceToolUseID: 'tool-1' }],
+    [
+      'task notification',
+      '<task-notification>done</task-notification>',
+      { isSynthetic: true },
+      {},
+    ],
+    ['interrupt sentinel', '<interrupt>interrupted</interrupt>', {}, {}],
+    ['skill format marker', '<skill-format>true</skill-format>skill body', {}, {}],
+    ['command message marker', '<command-message>orchestrate</command-message>', {}, {}],
+    ['command name marker', '<command-name>/orchestrate</command-name>', {}, {}],
+    ['skill base directory', 'Base directory for this skill: C:/skills', {}, {}],
+    ['invoked skills summary', 'The following skills were invoked in this session: audit', {}, {}],
+    ['plan file reference', 'A plan file exists from plan mode at: C:/plan.md', {}, {}],
+    ['skill frontmatter', '---\nname: audit\ndescription: audit a project\n---', {}, {}],
+    ['ordinary user content', 'Explain the current project.', {}, {}],
+    ['No response requested probe', 'No response requested.', {}, {}],
+  ])('%s has the same visible user text', (_name, content, liveExtra, replayExtra) => {
+    const live = createLiveTransformer().transform(
+      liveUser(content, liveExtra) as never,
+      SESSION_ID as never,
+    );
+    const replay = createReplayService().replayToStreamEvents(
+      SESSION_ID,
+      [replayUser(content, replayExtra)],
+      [],
+    );
+
+    expect(visibleText(replay)).toEqual(visibleText(live));
+  });
+
+  it('keeps tool-result-only user messages out of normalized visible text', () => {
+    const toolResult = [
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'tool output' },
+    ];
+    const live = createLiveTransformer().transform(
+      liveUser(toolResult) as never,
+      SESSION_ID as never,
+    );
+    const replay = createReplayService().replayToStreamEvents(
+      SESSION_ID,
+      [replayUser(toolResult)],
+      [],
+    );
+
+    expect(visibleText(replay)).toEqual(visibleText(live));
+  });
+
+  it('keeps genuine assistant text visible in both representations', () => {
+    const content = [{ type: 'text', text: 'Here is the answer.' }];
+    const live = createLiveTransformer().transform(
+      liveAssistant(content) as never,
+      SESSION_ID as never,
+    );
+    const replay = createReplayService().replayToStreamEvents(
+      SESSION_ID,
+      [replayAssistant(content)],
+      [],
+    );
+
+    expect(visibleText(replay)).toEqual(visibleText(live));
+  });
+
+  it('keeps local-command output visible where replay has an assistant-text representation', () => {
+    const content = 'Command completed successfully.';
+    const live = createLiveTransformer().transform(
+      {
+        type: 'system',
+        subtype: 'local_command_output',
+        session_id: SESSION_ID,
+        content,
+      } as never,
+      SESSION_ID as never,
+    );
+    const replay = createReplayService().replayToStreamEvents(
+      SESSION_ID,
+      [replayAssistant([{ type: 'text', text: content }])],
+      [],
+    );
+
+    expect(visibleText(replay)).toEqual(visibleText(live));
+  });
+});

--- a/libs/backend/agent-sdk/src/lib/message-transform/index.ts
+++ b/libs/backend/agent-sdk/src/lib/message-transform/index.ts
@@ -1,5 +1,6 @@
 export {
   generateEventId,
+  isHiddenTranscriptRecord,
   isSkillOrMetaContent,
   userMessageHasToolResult,
 } from './message-transform-helpers';

--- a/libs/backend/agent-sdk/src/lib/message-transform/message-transform-helpers.ts
+++ b/libs/backend/agent-sdk/src/lib/message-transform/message-transform-helpers.ts
@@ -18,6 +18,26 @@ export function generateEventId(): string {
 }
 
 /**
+ * The ONE rule for "this transcript record is bookkeeping, not conversation":
+ * the SDK's own `isMeta` / `isSynthetic` flags.
+ *
+ * Both readers of a JSONL transcript must ask this same question — the replay
+ * that produces the live-shaped event stream (`session-replay.service.ts`) and
+ * the projection that produces the one-read resume snapshot
+ * (`SessionHistoryReaderService.projectHistoryMessages`). When they disagree,
+ * `chat:resume` shows a record the replayed event stream hides, which is the
+ * event/message parity break PR #493 review C set out to close and closed only
+ * for `isSynthetic`. Shared rather than duplicated so a third flag cannot be
+ * added to one side alone.
+ */
+export function isHiddenTranscriptRecord(record: {
+  readonly isMeta?: boolean;
+  readonly isSynthetic?: boolean;
+}): boolean {
+  return record.isMeta === true || record.isSynthetic === true;
+}
+
+/**
  * Detect SDK meta/skill content in a user message.
  *
  * The SDK wraps some internal messages (skill .md content, command metadata,

--- a/libs/backend/agent-sdk/src/lib/message-transform/system-message.transformer.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/message-transform/system-message.transformer.spec.ts
@@ -73,6 +73,9 @@ function makeHelpers(
       applySnapshot: jest.fn().mockReturnValue(null),
       get: jest.fn().mockReturnValue(undefined),
     },
+    compactionBoundaryRegistry: {
+      recordExpectedBoundary: jest.fn(),
+    },
   } as unknown as jest.Mocked<TransformerHelpers>;
 }
 

--- a/libs/backend/agent-sdk/src/lib/message-transform/system-message.transformer.ts
+++ b/libs/backend/agent-sdk/src/lib/message-transform/system-message.transformer.ts
@@ -79,6 +79,10 @@ export class SystemMessageTransformer {
 
     helpers.subagentRegistry.pruneSession(resolvedSessionId);
     helpers.usageTracker.clearSessionTokenSnapshot(resolvedSessionId);
+    helpers.compactionBoundaryRegistry.recordExpectedBoundary(
+      resolvedSessionId,
+      (sdkMessage as SDKMessage & { uuid?: string }).uuid,
+    );
 
     const compactionCompleteEvent: CompactionCompleteEvent = {
       id: generateEventId(),

--- a/libs/backend/agent-sdk/src/lib/message-transform/transformer-helpers.ts
+++ b/libs/backend/agent-sdk/src/lib/message-transform/transformer-helpers.ts
@@ -6,6 +6,7 @@ import type { IModelResolver } from '../auth-env.port';
 import type { SessionLifecycleManager } from '../helpers/session-lifecycle-manager';
 import type { LiveUsageTracker } from '../helpers/live-usage-tracker';
 import type { SessionTurnStateRegistry } from '../helpers/session-turn-state.registry';
+import type { CompactionBoundaryGenerationRegistry } from '../helpers/compaction-boundary-generation-registry';
 
 export interface TransformerHelpers {
   readonly logger: Logger;
@@ -15,4 +16,6 @@ export interface TransformerHelpers {
   readonly usageTracker: LiveUsageTracker;
   /** Per-session turn state; producers emit `turn_state` events from it. */
   readonly turnState: SessionTurnStateRegistry;
+  /** Tracks observed/expected compact-boundary counts for immutable resume verification. */
+  readonly compactionBoundaryRegistry: CompactionBoundaryGenerationRegistry;
 }

--- a/libs/backend/agent-sdk/src/lib/sdk-message-transformer.replay.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/sdk-message-transformer.replay.spec.ts
@@ -28,6 +28,7 @@ import type { SessionLifecycleManager } from './helpers/session-lifecycle-manage
 import { SdkMessageTransformer } from './sdk-message-transformer';
 import { LiveUsageTracker } from './helpers/live-usage-tracker';
 import { SessionTurnStateRegistry } from './helpers/session-turn-state.registry';
+import { CompactionBoundaryGenerationRegistry } from './helpers/compaction-boundary-generation-registry';
 
 const SESSION_ID = 'b5399ba8-e06d-417c-bac4-aba5add0555c';
 
@@ -73,6 +74,7 @@ function build(): {
       lifecycle,
       new LiveUsageTracker(),
       new SessionTurnStateRegistry(),
+      new CompactionBoundaryGenerationRegistry(),
     ),
   };
 }

--- a/libs/backend/agent-sdk/src/lib/sdk-message-transformer.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/sdk-message-transformer.spec.ts
@@ -28,6 +28,7 @@ import type { SessionLifecycleManager } from './helpers/session-lifecycle-manage
 import { SdkMessageTransformer } from './sdk-message-transformer';
 import { LiveUsageTracker } from './helpers/live-usage-tracker';
 import { SessionTurnStateRegistry } from './helpers/session-turn-state.registry';
+import { CompactionBoundaryGenerationRegistry } from './helpers/compaction-boundary-generation-registry';
 
 // ---------------------------------------------------------------------------
 // Typed mock helpers
@@ -130,6 +131,7 @@ describe('SdkMessageTransformer — compact_boundary (TASK_2026_109)', () => {
       lifecycle as unknown as SessionLifecycleManager,
       new LiveUsageTracker(),
       new SessionTurnStateRegistry(),
+      new CompactionBoundaryGenerationRegistry(),
     );
   }
 
@@ -206,6 +208,34 @@ describe('SdkMessageTransformer — compact_boundary (TASK_2026_109)', () => {
       expect.any(Object),
     );
   });
+
+  it('records the expected boundary generation only after resolving a session id', () => {
+    const boundaryRegistry = new CompactionBoundaryGenerationRegistry();
+    const localLifecycle = makeSessionLifecycle(['resolved-sess']);
+    const localTransformer = new SdkMessageTransformer(
+      makeLogger(),
+      makeAuthEnv(),
+      makeSubagentRegistry() as unknown as SubagentRegistryService,
+      makeModelResolver() as unknown as IModelResolver,
+      localLifecycle as unknown as SessionLifecycleManager,
+      new LiveUsageTracker(),
+      new SessionTurnStateRegistry(),
+      boundaryRegistry,
+    );
+
+    const events = localTransformer.transform(
+      makeCompactBoundary({ trigger: 'manual', preTokens: 1000 }) as never,
+      undefined,
+    );
+
+    expect(events).toHaveLength(1);
+    expect(
+      (events[0] as { eventType: string }).eventType,
+    ).toBe('compaction_complete');
+    expect(
+      boundaryRegistry.capturePendingExpectation('resolved-sess'),
+    ).toEqual({ kind: 'unverified' });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -249,6 +279,7 @@ describe('SdkMessageTransformer — task_started (Fix 1 + Fix 2)', () => {
       lifecycle as unknown as SessionLifecycleManager,
       new LiveUsageTracker(),
       new SessionTurnStateRegistry(),
+      new CompactionBoundaryGenerationRegistry(),
     );
   }
 
@@ -423,6 +454,7 @@ describe('SdkMessageTransformer — workflow run correlation', () => {
       makeSessionLifecycle([]) as unknown as SessionLifecycleManager,
       new LiveUsageTracker(),
       new SessionTurnStateRegistry(),
+      new CompactionBoundaryGenerationRegistry(),
     );
   }
 
@@ -543,6 +575,7 @@ describe('SdkMessageTransformer — session id falls back to the SDK payload (TA
       makeSessionLifecycle(activeIds) as unknown as SessionLifecycleManager,
       new LiveUsageTracker(),
       new SessionTurnStateRegistry(),
+      new CompactionBoundaryGenerationRegistry(),
     );
   }
 
@@ -617,6 +650,7 @@ describe('SdkMessageTransformer — per-session isolation (TASK_2026_370)', () =
       makeSessionLifecycle([]) as unknown as SessionLifecycleManager,
       new LiveUsageTracker(),
       new SessionTurnStateRegistry(),
+      new CompactionBoundaryGenerationRegistry(),
     );
   }
 

--- a/libs/backend/agent-sdk/src/lib/sdk-message-transformer.ts
+++ b/libs/backend/agent-sdk/src/lib/sdk-message-transformer.ts
@@ -17,6 +17,7 @@ import type { IModelResolver } from './auth-env.port';
 import type { SessionLifecycleManager } from './helpers/session-lifecycle-manager';
 import type { LiveUsageTracker } from './helpers/live-usage-tracker';
 import type { SessionTurnStateRegistry } from './helpers/session-turn-state.registry';
+import type { CompactionBoundaryGenerationRegistry } from './helpers/compaction-boundary-generation-registry';
 import {
   SDKMessage,
   isResultMessage,
@@ -86,6 +87,8 @@ export class SdkMessageTransformer implements TransformerState {
     private readonly usageTracker: LiveUsageTracker,
     @inject(SDK_TOKENS.SDK_SESSION_TURN_STATE_REGISTRY)
     private readonly turnState: SessionTurnStateRegistry,
+    @inject(SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY)
+    private readonly compactionBoundaryRegistry: CompactionBoundaryGenerationRegistry,
   ) {
     this.helpers = {
       logger: this.logger,
@@ -94,6 +97,7 @@ export class SdkMessageTransformer implements TransformerState {
       sessionLifecycle: this.sessionLifecycle,
       usageTracker: this.usageTracker,
       turnState: this.turnState,
+      compactionBoundaryRegistry: this.compactionBoundaryRegistry,
     };
     this.assistantTransformer = new AssistantMessageTransformer();
     this.userTransformer = new UserMessageTransformer();
@@ -111,6 +115,7 @@ export class SdkMessageTransformer implements TransformerState {
       this.sessionLifecycle,
       this.usageTracker,
       this.turnState,
+      this.compactionBoundaryRegistry,
     );
   }
 

--- a/libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts
@@ -741,6 +741,93 @@ describe('SessionHistoryReaderService', () => {
       ).toBeUndefined();
     });
 
+    it('two distinct recorded boundaries: a transcript with only one new boundary stays stale', async () => {
+      // PR #493 review B: both boundaries used to write expectedCount =
+      // observedCount + 1, so a transcript holding just the first new
+      // boundary wrongly verified the second expectation.
+      const stubs = makeStubs();
+      stubs.compactionBoundaryRegistry.observeBoundaryCount('valid', 1);
+      stubs.compactionBoundaryRegistry.recordExpectedBoundary(
+        'valid',
+        'b-new-1',
+      );
+      stubs.compactionBoundaryRegistry.recordExpectedBoundary(
+        'valid',
+        'b-new-2',
+      );
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue('/sessions/dir');
+      stubs.jsonlReader.readJsonlMessages.mockResolvedValue([
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b1',
+        } as SessionHistoryMessage,
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b2',
+        } as SessionHistoryMessage,
+      ]);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      stubs.replayService.replayToStreamEvents.mockReturnValue([]);
+
+      const service = makeService(stubs);
+      const result = await service.readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+
+      // Expected 3, observed 2 — the transcript holds only one of the two
+      // promised new boundaries, so the snapshot must read as stale.
+      expect(result.staleSnapshot).toBe(true);
+      expect(
+        stubs.compactionBoundaryRegistry.capturePendingExpectation('valid'),
+      ).toBeUndefined();
+    });
+
+    it('two distinct recorded boundaries: a transcript with both new boundaries verifies', async () => {
+      const stubs = makeStubs();
+      stubs.compactionBoundaryRegistry.observeBoundaryCount('valid', 1);
+      stubs.compactionBoundaryRegistry.recordExpectedBoundary(
+        'valid',
+        'b-new-1',
+      );
+      stubs.compactionBoundaryRegistry.recordExpectedBoundary(
+        'valid',
+        'b-new-2',
+      );
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue('/sessions/dir');
+      stubs.jsonlReader.readJsonlMessages.mockResolvedValue([
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b1',
+        } as SessionHistoryMessage,
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b2',
+        } as SessionHistoryMessage,
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b3',
+        } as SessionHistoryMessage,
+      ]);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      stubs.replayService.replayToStreamEvents.mockReturnValue([]);
+
+      const service = makeService(stubs);
+      const result = await service.readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+
+      expect(result.staleSnapshot).toBeUndefined();
+      expect(stubs.jsonlReader.readJsonlMessages).toHaveBeenCalledTimes(1);
+      expect(
+        stubs.compactionBoundaryRegistry.capturePendingExpectation('valid'),
+      ).toBeUndefined();
+    });
+
     it('compaction-read exhausts retries and returns staleSnapshot: true when expectation is unmet', async () => {
       const stubs = makeStubs();
       stubs.compactionBoundaryRegistry.observeBoundaryCount('valid', 1);

--- a/libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts
@@ -39,7 +39,10 @@ import { CompactionBoundaryGenerationRegistry } from './helpers/compaction-bound
 import type { IModelResolver } from './auth-env.port';
 import type { IPricingProvider } from './pricing.port';
 import type { AuthEnv, ModelPricing } from '@ptah-extension/shared';
-import { findModelPricing } from '@ptah-extension/shared';
+import {
+  findModelPricing,
+  registerModelContextWindows,
+} from '@ptah-extension/shared';
 import {
   createMockLogger,
   type MockLogger,
@@ -407,6 +410,86 @@ describe('SessionHistoryReaderService', () => {
       expect(stats?.tokens.output).toBe(20);
       // Model was detected from the pre-compact init (metadata, not usage).
       expect(stats?.model).toBe('claude-sonnet-4-20250514');
+    });
+
+    it('contextSnapshot and modelUsageList carry contextWindow for a registered unpriced model', async () => {
+      const model = 'gpt-ctx-reader-registered-414';
+      registerModelContextWindows([{ id: model, contextLength: 400_000 }]);
+      const stubs = makeStubs();
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue(
+        '/sessions/dir',
+      );
+      stubs.jsonlReader.readJsonlMessages.mockResolvedValue([
+        { type: 'system', subtype: 'init', model, uuid: 'init' },
+        {
+          type: 'assistant',
+          uuid: 'a1',
+          message: {
+            role: 'assistant',
+            model,
+            content: [{ type: 'text', text: 'reply' }],
+          },
+          usage: {
+            input_tokens: 30_000,
+            output_tokens: 500,
+            cache_read_input_tokens: 10_000,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      ] as SessionHistoryMessage[]);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+
+      const service = makeService(stubs);
+      const { stats } = await service.readSessionHistory(
+        'valid-session',
+        '/workspace',
+      );
+
+      expect(stats?.contextSnapshot).toEqual({
+        model,
+        contextTokens: 40_000,
+        contextWindow: 400_000,
+      });
+      expect(stats?.modelUsageList?.[0]).toMatchObject({
+        model,
+        contextWindow: 400_000,
+      });
+    });
+
+    it('omits contextWindow when the window is unknown', async () => {
+      const model = 'mystery-ctx-reader-unknown-414';
+      const stubs = makeStubs();
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue(
+        '/sessions/dir',
+      );
+      stubs.jsonlReader.readJsonlMessages.mockResolvedValue([
+        { type: 'system', subtype: 'init', model, uuid: 'init' },
+        {
+          type: 'assistant',
+          uuid: 'a1',
+          message: {
+            role: 'assistant',
+            model,
+            content: [{ type: 'text', text: 'reply' }],
+          },
+          usage: {
+            input_tokens: 100,
+            output_tokens: 10,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      ] as SessionHistoryMessage[]);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+
+      const service = makeService(stubs);
+      const { stats } = await service.readSessionHistory(
+        'valid-session',
+        '/workspace',
+      );
+
+      expect(stats?.contextSnapshot).toEqual({ model, contextTokens: 100 });
+      expect(stats?.modelUsageList?.[0]).not.toHaveProperty('contextWindow');
     });
 
     it('uses the globally latest main-session model for the context snapshot regardless of aggregate cost', async () => {

--- a/libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts
@@ -196,12 +196,16 @@ describe('SessionHistoryReaderService', () => {
       );
     });
 
+    // A VERIFIED expectation survives a stale read for a bounded recovery
+    // budget — the next reload of the same transcript must still be checked
+    // against it (PR #493 review C). An UNVERIFIED one can never be satisfied,
+    // so a stale read gives up on it immediately.
     it.each([
-      ['verified', true],
-      ['unverified', false],
+      ['verified', true, { kind: 'verified', expectedCount: 2 }],
+      ['unverified', false, undefined],
     ])(
       'consumes a %s pending compaction expectation and returns stale when sessions directory is missing',
-      async (_kind, hasBaseline) => {
+      async (_kind, hasBaseline, expectedAfterRead) => {
         const stubs = makeStubs();
         if (hasBaseline) {
           stubs.compactionBoundaryRegistry.observeBoundaryCount('valid-session-id', 1);
@@ -226,7 +230,7 @@ describe('SessionHistoryReaderService', () => {
           stubs.compactionBoundaryRegistry.capturePendingExpectation(
             'valid-session-id',
           ),
-        ).toBeUndefined();
+        ).toEqual(expectedAfterRead);
       },
     );
 
@@ -862,9 +866,42 @@ describe('SessionHistoryReaderService', () => {
       // Expected 3, observed 2 — the transcript holds only one of the two
       // promised new boundaries, so the snapshot must read as stale.
       expect(result.staleSnapshot).toBe(true);
+      // The expectation is RETAINED across the stale read (PR #493 review C):
+      // clearing it here made the next read of the same incomplete transcript
+      // return an incomplete snapshot with no `staleSnapshot` flag.
       expect(
         stubs.compactionBoundaryRegistry.capturePendingExpectation('valid'),
-      ).toBeUndefined();
+      ).toEqual({ kind: 'verified', expectedCount: 3 });
+    });
+
+    it('a second read of the still-incomplete transcript is still reported stale', async () => {
+      // PR #493 review C: the reload that follows a stale snapshot must not
+      // silently become a clean read just because the first one consumed the
+      // expectation.
+      const stubs = makeStubs();
+      stubs.compactionBoundaryRegistry.observeBoundaryCount('valid', 1);
+      stubs.compactionBoundaryRegistry.recordExpectedBoundary('valid', 'b-new');
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue('/sessions/dir');
+      stubs.jsonlReader.readJsonlMessages.mockResolvedValue([
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b1',
+        } as SessionHistoryMessage,
+      ]);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      stubs.replayService.replayToStreamEvents.mockReturnValue([]);
+
+      const service = makeService(stubs);
+      const first = await service.readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+      const second = await service.readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+
+      expect(first.staleSnapshot).toBe(true);
+      expect(second.staleSnapshot).toBe(true);
     });
 
     it('Post-only reload: PreCompact expectation with the boundary not yet on disk returns staleSnapshot true and keeps it for the retry', async () => {
@@ -1060,9 +1097,10 @@ describe('SessionHistoryReaderService', () => {
       });
 
       expect(result.staleSnapshot).toBe(true);
+      // Retained for the next read, not cleared (PR #493 review C).
       expect(
         stubs.compactionBoundaryRegistry.capturePendingExpectation('valid'),
-      ).toBeUndefined();
+      ).toEqual({ kind: 'verified', expectedCount: 2 });
       expect(stubs.jsonlReader.readJsonlMessages).toHaveBeenCalledTimes(6);
     });
 

--- a/libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts
@@ -22,12 +22,20 @@
  */
 
 import 'reflect-metadata';
+import { Readable } from 'node:stream';
+
+jest.mock('fs/promises', () => ({ stat: jest.fn() }));
+jest.mock('node:fs', () => ({ createReadStream: jest.fn() }));
+
+import * as fs from 'fs/promises';
+import { createReadStream } from 'node:fs';
 import { SessionHistoryReaderService } from './session-history-reader.service';
-import type { JsonlReaderService } from './helpers/history/jsonl-reader.service';
+import { JsonlReaderService } from './helpers/history/jsonl-reader.service';
 import type { SessionReplayService } from './helpers/history/session-replay.service';
 import { HistoryEventFactory } from './helpers/history/history-event-factory';
 import type { SessionHistoryMessage } from './helpers/history/history.types';
 import { LiveUsageTracker } from './helpers/live-usage-tracker';
+import { CompactionBoundaryGenerationRegistry } from './helpers/compaction-boundary-generation-registry';
 import type { IModelResolver } from './auth-env.port';
 import type { IPricingProvider } from './pricing.port';
 import type { AuthEnv, ModelPricing } from '@ptah-extension/shared';
@@ -40,6 +48,26 @@ import type { Logger } from '@ptah-extension/vscode-core';
 
 function asLogger(mock: MockLogger): Logger {
   return mock as unknown as Logger;
+}
+
+const mockedStat = fs.stat as jest.MockedFunction<typeof fs.stat>;
+const mockedCreateReadStream = createReadStream as jest.MockedFunction<
+  typeof createReadStream
+>;
+
+function transcriptStats(
+  size: number,
+  mtimeMs: number,
+): Awaited<ReturnType<typeof fs.stat>> {
+  return { size, mtimeMs } as Awaited<ReturnType<typeof fs.stat>>;
+}
+
+function transcriptStream(
+  content: string,
+): ReturnType<typeof createReadStream> {
+  return Readable.from([Buffer.from(content, 'utf8')]) as ReturnType<
+    typeof createReadStream
+  >;
 }
 
 /**
@@ -67,6 +95,8 @@ interface Stubs {
   logger: MockLogger;
   /** Real, not stubbed — the seed and the read are the behaviour under test. */
   usageTracker: LiveUsageTracker;
+  /** Real singleton; compaction-read behaviour is tested through it. */
+  compactionBoundaryRegistry: CompactionBoundaryGenerationRegistry;
 }
 
 function makeStubs(): Stubs {
@@ -95,6 +125,7 @@ function makeStubs(): Stubs {
     authEnv: {} as AuthEnv,
     logger: createMockLogger(),
     usageTracker: new LiveUsageTracker(),
+    compactionBoundaryRegistry: new CompactionBoundaryGenerationRegistry(),
   };
 }
 
@@ -109,6 +140,7 @@ function makeService(stubs: Stubs): SessionHistoryReaderService {
     stubs.authEnv,
     stubs.pricingProvider,
     stubs.usageTracker,
+    stubs.compactionBoundaryRegistry,
   );
 }
 
@@ -127,7 +159,7 @@ describe('SessionHistoryReaderService', () => {
         '/workspace',
       );
 
-      expect(result).toEqual({ events: [], stats: null });
+      expect(result).toEqual({ events: [], messages: [], stats: null });
       // Traversal rejected pre-filesystem — reader must never be called.
       expect(stubs.jsonlReader.findSessionsDirectory).not.toHaveBeenCalled();
       // The facade catches the SdkError internally and logs via `error`.
@@ -138,7 +170,7 @@ describe('SessionHistoryReaderService', () => {
       const stubs = makeStubs();
       const service = makeService(stubs);
       const result = await service.readSessionHistory('', '/workspace');
-      expect(result).toEqual({ events: [], stats: null });
+      expect(result).toEqual({ events: [], messages: [], stats: null });
     });
 
     // -----------------------------------------------------------------------
@@ -155,10 +187,58 @@ describe('SessionHistoryReaderService', () => {
         '/workspace',
       );
 
-      expect(result).toEqual({ events: [], stats: null });
+      expect(result).toEqual({ events: [], messages: [], stats: null });
       expect(stubs.logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('Sessions directory not found'),
       );
+    });
+
+    it.each([
+      ['verified', true],
+      ['unverified', false],
+    ])(
+      'consumes a %s pending compaction expectation and returns stale when sessions directory is missing',
+      async (_kind, hasBaseline) => {
+        const stubs = makeStubs();
+        if (hasBaseline) {
+          stubs.compactionBoundaryRegistry.observeBoundaryCount('valid-session-id', 1);
+        }
+        stubs.compactionBoundaryRegistry.recordExpectedBoundary('valid-session-id');
+        stubs.jsonlReader.findSessionsDirectory.mockResolvedValue(null);
+
+        const service = makeService(stubs);
+        const result = await service.readSessionHistory(
+          'valid-session-id',
+          '/workspace',
+          { checkCompactionBoundary: true },
+        );
+
+        expect(result).toEqual({
+          events: [],
+          messages: [],
+          stats: null,
+          staleSnapshot: true,
+        });
+        expect(
+          stubs.compactionBoundaryRegistry.capturePendingExpectation(
+            'valid-session-id',
+          ),
+        ).toBeUndefined();
+      },
+    );
+
+    it('leaves staleSnapshot absent when a compaction check has no expectation and sessions directory is missing', async () => {
+      const stubs = makeStubs();
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue(null);
+
+      const service = makeService(stubs);
+      const result = await service.readSessionHistory(
+        'valid-session-id',
+        '/workspace',
+        { checkCompactionBoundary: true },
+      );
+
+      expect(result).toEqual({ events: [], messages: [], stats: null });
     });
 
     // -----------------------------------------------------------------------
@@ -180,7 +260,7 @@ describe('SessionHistoryReaderService', () => {
         '/workspace',
       );
 
-      expect(result).toEqual({ events: [], stats: null });
+      expect(result).toEqual({ events: [], messages: [], stats: null });
       expect(stubs.logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('Session file not found'),
         expect.objectContaining({ sessionId: 'valid-session' }),
@@ -577,6 +657,290 @@ describe('SessionHistoryReaderService', () => {
       const service = makeService(stubs);
       const { stats } = await service.readSessionHistory('valid', '/workspace');
       expect(stats).toBeNull();
+    });
+
+    it('ordinary read records observed boundary count and has no staleSnapshot', async () => {
+      const stubs = makeStubs();
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue('/sessions/dir');
+      stubs.jsonlReader.readJsonlMessages.mockResolvedValue([
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b1',
+        } as SessionHistoryMessage,
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b2',
+        } as SessionHistoryMessage,
+      ]);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      stubs.replayService.replayToStreamEvents.mockReturnValue([]);
+
+      const service = makeService(stubs);
+      const result = await service.readSessionHistory('valid', '/workspace');
+
+      expect(result.staleSnapshot).toBeUndefined();
+      expect(stubs.compactionBoundaryRegistry.inspect('valid')).toEqual({
+        baselineObserved: true,
+        observedCount: 2,
+        pendingExpectation: null,
+      });
+    });
+
+    it('compaction-read without a pending expectation leaves staleSnapshot absent', async () => {
+      const stubs = makeStubs();
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue('/sessions/dir');
+      stubs.jsonlReader.readJsonlMessages.mockResolvedValue([
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b1',
+        } as SessionHistoryMessage,
+      ]);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      stubs.replayService.replayToStreamEvents.mockReturnValue([]);
+
+      const service = makeService(stubs);
+      const result = await service.readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+
+      expect(result.staleSnapshot).toBeUndefined();
+      expect(stubs.jsonlReader.readJsonlMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it('compaction-read meets the expected count and clears staleSnapshot', async () => {
+      const stubs = makeStubs();
+      stubs.compactionBoundaryRegistry.observeBoundaryCount('valid', 1);
+      stubs.compactionBoundaryRegistry.recordExpectedBoundary('valid');
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue('/sessions/dir');
+      stubs.jsonlReader.readJsonlMessages.mockResolvedValue([
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b1',
+        } as SessionHistoryMessage,
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b2',
+        } as SessionHistoryMessage,
+      ]);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      stubs.replayService.replayToStreamEvents.mockReturnValue([]);
+
+      const service = makeService(stubs);
+      const result = await service.readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+
+      expect(result.staleSnapshot).toBeUndefined();
+      expect(
+        stubs.compactionBoundaryRegistry.capturePendingExpectation('valid'),
+      ).toBeUndefined();
+    });
+
+    it('compaction-read exhausts retries and returns staleSnapshot: true when expectation is unmet', async () => {
+      const stubs = makeStubs();
+      stubs.compactionBoundaryRegistry.observeBoundaryCount('valid', 1);
+      stubs.compactionBoundaryRegistry.recordExpectedBoundary('valid');
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue('/sessions/dir');
+      stubs.jsonlReader.readJsonlMessages.mockResolvedValue([
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b1',
+        } as SessionHistoryMessage,
+      ]);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      stubs.replayService.replayToStreamEvents.mockReturnValue([]);
+
+      const service = makeService(stubs);
+      const result = await service.readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+
+      expect(result.staleSnapshot).toBe(true);
+      expect(
+        stubs.compactionBoundaryRegistry.capturePendingExpectation('valid'),
+      ).toBeUndefined();
+      expect(stubs.jsonlReader.readJsonlMessages).toHaveBeenCalledTimes(6);
+    });
+
+    it('treats a baseline-absent expectation as stale even when the transcript already has boundaries', async () => {
+      const stubs = makeStubs();
+      // Baseline is never observed before the expectation is recorded.
+      stubs.compactionBoundaryRegistry.recordExpectedBoundary('valid');
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue('/sessions/dir');
+      stubs.jsonlReader.readJsonlMessages.mockResolvedValue([
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b1',
+        } as SessionHistoryMessage,
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b2',
+        } as SessionHistoryMessage,
+      ]);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      stubs.replayService.replayToStreamEvents.mockReturnValue([]);
+
+      const service = makeService(stubs);
+      const result = await service.readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+
+      expect(result.staleSnapshot).toBe(true);
+      expect(
+        stubs.compactionBoundaryRegistry.capturePendingExpectation('valid'),
+      ).toBeUndefined();
+      expect(stubs.jsonlReader.readJsonlMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries through unchanged short parses until a later changed transcript contains the expected boundary', async () => {
+      const stubs = makeStubs();
+      stubs.compactionBoundaryRegistry.observeBoundaryCount('valid', 1);
+      stubs.compactionBoundaryRegistry.recordExpectedBoundary('valid');
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue('/sessions/dir');
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      stubs.replayService.replayToStreamEvents.mockReturnValue([]);
+
+      const unchanged = [
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b1',
+        } as SessionHistoryMessage,
+      ];
+      const changed = [
+        unchanged[0],
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b2',
+        } as SessionHistoryMessage,
+      ];
+      stubs.jsonlReader.readJsonlMessages
+        .mockResolvedValueOnce(unchanged)
+        .mockResolvedValueOnce(unchanged)
+        .mockResolvedValueOnce(changed);
+
+      const service = makeService(stubs);
+      const result = await service.readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+
+      expect(result.staleSnapshot).toBeUndefined();
+      expect(stubs.jsonlReader.readJsonlMessages).toHaveBeenCalledTimes(3);
+      expect(
+        stubs.compactionBoundaryRegistry.capturePendingExpectation('valid'),
+      ).toBeUndefined();
+    });
+
+    it('retries through the real JSONL cache until a changed size/mtime exposes the expected boundary', async () => {
+      const stubs = makeStubs();
+      const registry = stubs.compactionBoundaryRegistry;
+      registry.observeBoundaryCount('valid', 1);
+      registry.recordExpectedBoundary('valid');
+
+      const jsonlReader = new JsonlReaderService(asLogger(stubs.logger));
+      jest
+        .spyOn(jsonlReader, 'findSessionsDirectory')
+        .mockResolvedValue('/sessions/dir');
+      jest.spyOn(jsonlReader, 'loadAgentSessions').mockResolvedValue([]);
+      const oldTranscript =
+        '{"type":"system","subtype":"compact_boundary","uuid":"b1"}\n';
+      const changedTranscript =
+        oldTranscript +
+        '{"type":"system","subtype":"compact_boundary","uuid":"b2"}\n';
+      mockedStat
+        .mockResolvedValueOnce(transcriptStats(oldTranscript.length, 1))
+        .mockResolvedValueOnce(transcriptStats(oldTranscript.length, 1))
+        .mockResolvedValueOnce(
+          transcriptStats(changedTranscript.length, 2),
+        );
+      mockedCreateReadStream
+        .mockReturnValueOnce(transcriptStream(oldTranscript))
+        .mockReturnValueOnce(transcriptStream(changedTranscript));
+
+      const factory = new HistoryEventFactory();
+      const service = new SessionHistoryReaderService(
+        asLogger(stubs.logger),
+        jsonlReader,
+        stubs.replayService as unknown as SessionReplayService,
+        factory,
+        stubs.modelResolver as unknown as IModelResolver,
+        stubs.authEnv,
+        stubs.pricingProvider,
+        stubs.usageTracker,
+        registry,
+      );
+
+      const result = await service.readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+
+      expect(result.staleSnapshot).toBeUndefined();
+      expect(mockedStat).toHaveBeenCalledTimes(3);
+      // The second observation reused the cached old parse; only the changed
+      // validity token streamed and parsed again.
+      expect(mockedCreateReadStream).toHaveBeenCalledTimes(2);
+      expect(
+        registry.capturePendingExpectation('valid'),
+      ).toBeUndefined();
+    });
+
+    it('single parse supplies events and messages from the same boundary snapshot', async () => {
+      const stubs = makeStubs();
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue('/sessions/dir');
+
+      const mainMessages: SessionHistoryMessage[] = [
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'boundary',
+        } as SessionHistoryMessage,
+        {
+          type: 'user',
+          uuid: 'u1',
+          timestamp: '2026-01-01T00:00:00.000Z',
+          message: { role: 'user', content: 'hello' },
+        } as SessionHistoryMessage,
+        {
+          type: 'assistant',
+          uuid: 'a1',
+          timestamp: '2026-01-01T00:00:01.000Z',
+          message: {
+            role: 'assistant',
+            content: [{ type: 'text', text: 'hi' }],
+          },
+        } as SessionHistoryMessage,
+      ];
+      stubs.jsonlReader.readJsonlMessages.mockResolvedValue(mainMessages);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      stubs.replayService.replayToStreamEvents.mockImplementation(
+        (_sessionId, messages) =>
+          messages.map((m) => ({
+            id: m.uuid,
+            eventType: 'message_start',
+            role: m.message?.role,
+          })) as never,
+      );
+
+      const service = makeService(stubs);
+      const result = await service.readSessionHistory('valid', '/workspace');
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[0].id).toBe('u1');
+      expect(result.messages[1].id).toBe('a1');
+      expect(stubs.replayService.replayToStreamEvents).toHaveBeenCalledWith(
+        'valid',
+        mainMessages,
+        [],
+      );
     });
   });
 

--- a/libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts
+++ b/libs/backend/agent-sdk/src/lib/session-history-reader.service.spec.ts
@@ -867,6 +867,134 @@ describe('SessionHistoryReaderService', () => {
       ).toBeUndefined();
     });
 
+    it('Post-only reload: PreCompact expectation with the boundary not yet on disk returns staleSnapshot true and keeps it for the retry', async () => {
+      const stubs = makeStubs();
+      stubs.compactionBoundaryRegistry.observeBoundaryCount('valid', 1);
+      stubs.compactionBoundaryRegistry.recordPreCompact('valid');
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue('/sessions/dir');
+      stubs.jsonlReader.readJsonlMessages.mockResolvedValue([
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b1',
+        } as SessionHistoryMessage,
+      ]);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      stubs.replayService.replayToStreamEvents.mockReturnValue([]);
+
+      const service = makeService(stubs);
+      const result = await service.readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+
+      expect(result.staleSnapshot).toBe(true);
+      // Still verified for the renderer's single retry.
+      expect(
+        stubs.compactionBoundaryRegistry.capturePendingExpectation('valid'),
+      ).toEqual({ kind: 'verified', expectedCount: 2 });
+    });
+
+    it('Post-only reload: the boundary persisted on a yield returns a verified snapshot, and the late live boundary adds nothing', async () => {
+      const stubs = makeStubs();
+      stubs.compactionBoundaryRegistry.observeBoundaryCount('valid', 1);
+      stubs.compactionBoundaryRegistry.recordPreCompact('valid');
+      stubs.jsonlReader.findSessionsDirectory.mockResolvedValue('/sessions/dir');
+      const before = [
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b1',
+        } as SessionHistoryMessage,
+      ];
+      const after = [
+        before[0],
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b2',
+        } as SessionHistoryMessage,
+      ];
+      stubs.jsonlReader.readJsonlMessages
+        .mockResolvedValueOnce(before)
+        .mockResolvedValueOnce(after);
+      stubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      stubs.replayService.replayToStreamEvents.mockReturnValue([]);
+
+      const service = makeService(stubs);
+      const result = await service.readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+
+      expect(result.staleSnapshot).toBeUndefined();
+      expect(
+        stubs.compactionBoundaryRegistry.capturePendingExpectation('valid'),
+      ).toBeUndefined();
+      stubs.compactionBoundaryRegistry.recordExpectedBoundary('valid', 'b2');
+      expect(
+        stubs.compactionBoundaryRegistry.capturePendingExpectation('valid'),
+      ).toBeUndefined();
+    });
+
+    it('consumes with outcome satisfied / stale / none per path', async () => {
+      const boundaryOnly = [
+        {
+          type: 'system',
+          subtype: 'compact_boundary',
+          uuid: 'b1',
+        } as SessionHistoryMessage,
+      ];
+
+      // stale: sessions directory missing with an expectation pending
+      const staleStubs = makeStubs();
+      staleStubs.compactionBoundaryRegistry.observeBoundaryCount('valid', 0);
+      staleStubs.compactionBoundaryRegistry.recordExpectedBoundary('valid');
+      const staleSpy = jest.spyOn(
+        staleStubs.compactionBoundaryRegistry,
+        'consumeExpectation',
+      );
+      staleStubs.jsonlReader.findSessionsDirectory.mockResolvedValue(null);
+      await makeService(staleStubs).readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+      expect(staleSpy).toHaveBeenCalledWith('valid', 'stale');
+
+      // satisfied: the transcript holds the expected boundary
+      const okStubs = makeStubs();
+      okStubs.compactionBoundaryRegistry.observeBoundaryCount('valid', 0);
+      okStubs.compactionBoundaryRegistry.recordExpectedBoundary('valid');
+      const okSpy = jest.spyOn(
+        okStubs.compactionBoundaryRegistry,
+        'consumeExpectation',
+      );
+      okStubs.jsonlReader.findSessionsDirectory.mockResolvedValue(
+        '/sessions/dir',
+      );
+      okStubs.jsonlReader.readJsonlMessages.mockResolvedValue(boundaryOnly);
+      okStubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      okStubs.replayService.replayToStreamEvents.mockReturnValue([]);
+      await makeService(okStubs).readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+      expect(okSpy).toHaveBeenCalledWith('valid', 'satisfied');
+
+      // none: nothing was expected
+      const noneStubs = makeStubs();
+      const noneSpy = jest.spyOn(
+        noneStubs.compactionBoundaryRegistry,
+        'consumeExpectation',
+      );
+      noneStubs.jsonlReader.findSessionsDirectory.mockResolvedValue(
+        '/sessions/dir',
+      );
+      noneStubs.jsonlReader.readJsonlMessages.mockResolvedValue(boundaryOnly);
+      noneStubs.jsonlReader.loadAgentSessions.mockResolvedValue([]);
+      noneStubs.replayService.replayToStreamEvents.mockReturnValue([]);
+      await makeService(noneStubs).readSessionHistory('valid', '/workspace', {
+        checkCompactionBoundary: true,
+      });
+      expect(noneSpy).toHaveBeenCalledWith('valid', 'none');
+    });
+
     it('two distinct recorded boundaries: a transcript with both new boundaries verifies', async () => {
       const stubs = makeStubs();
       stubs.compactionBoundaryRegistry.observeBoundaryCount('valid', 1);

--- a/libs/backend/agent-sdk/src/lib/session-history-reader.service.ts
+++ b/libs/backend/agent-sdk/src/lib/session-history-reader.service.ts
@@ -43,6 +43,10 @@ import { SdkError } from './errors';
 import type { IModelResolver } from './auth-env.port';
 import type { IPricingProvider } from './pricing.port';
 import type { LiveUsageTracker } from './helpers/live-usage-tracker';
+import type {
+  CompactionBoundaryGenerationRegistry,
+  PendingExpectation,
+} from './helpers/compaction-boundary-generation-registry';
 import type { JsonlReaderService } from './helpers/history/jsonl-reader.service';
 import type { SessionReplayService } from './helpers/history/session-replay.service';
 import type { HistoryEventFactory } from './helpers/history/history-event-factory';
@@ -50,6 +54,12 @@ import type {
   SessionHistoryMessage,
   AgentSessionData,
 } from './helpers/history/history.types';
+
+const MAX_COMPACTION_RETRIES = 5;
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
 
 /**
  * Phrase used in the SdkError thrown by resolveNativeMessageId() when
@@ -101,6 +111,8 @@ export class SessionHistoryReaderService {
     private readonly pricingProvider: IPricingProvider,
     @inject(SDK_TOKENS.SDK_LIVE_USAGE_TRACKER)
     private readonly usageTracker: LiveUsageTracker,
+    @inject(SDK_TOKENS.SDK_COMPACTION_BOUNDARY_GENERATION_REGISTRY)
+    private readonly compactionBoundaryRegistry: CompactionBoundaryGenerationRegistry,
   ) {}
 
   /**
@@ -124,19 +136,31 @@ export class SessionHistoryReaderService {
   }
 
   /**
-   * Read session history and convert to FlatStreamEventUnion events with stats
+   * Read session history and convert to FlatStreamEventUnion events with stats.
    *
-   * Returns both events for UI rendering and aggregated usage stats from JSONL.
+   * Returns a single immutable snapshot containing events, messages, and
+   * aggregated usage stats from one JSONL parse. When `options.checkCompactionBoundary`
+   * is true the reader verifies the expected compact-boundary generation with a
+   * small bounded number of event-loop yields; if the expected count is not
+   * observed the snapshot carries `staleSnapshot: true`.
    *
    * @param sessionId - Session identifier
    * @param workspacePath - Workspace path for locating session files
-   * @returns Object with events and aggregated stats
+   * @param options - Optional read controls
+   * @returns Object with events, messages, aggregated stats, and optional stale flag
    */
   async readSessionHistory(
     sessionId: string,
     workspacePath: string,
+    options?: { checkCompactionBoundary?: boolean },
   ): Promise<{
     events: FlatStreamEventUnion[];
+    messages: {
+      id: string;
+      role: 'user' | 'assistant';
+      content: string;
+      timestamp: number;
+    }[];
     stats: {
       totalCost: number | null;
       tokens: {
@@ -161,25 +185,61 @@ export class SessionHistoryReaderService {
         costUSD: number | null;
       }>;
     } | null;
+    staleSnapshot?: true;
   }> {
+    const checkCompactionBoundary = options?.checkCompactionBoundary ?? false;
+    let expectation: PendingExpectation | undefined;
+    let staleSnapshot: true | undefined;
+
     try {
       this.validateSessionId(sessionId);
+      if (checkCompactionBoundary) {
+        expectation =
+          this.compactionBoundaryRegistry.capturePendingExpectation(sessionId);
+      }
       const sessionsDir =
         await this.jsonlReader.findSessionsDirectory(workspacePath);
       if (!sessionsDir) {
         this.logger.warn('[SessionHistoryReader] Sessions directory not found');
-        return { events: [], stats: null };
+        this.consumeCompactionExpectation(sessionId, checkCompactionBoundary);
+        return {
+          events: [],
+          messages: [],
+          stats: null,
+          staleSnapshot:
+            checkCompactionBoundary && expectation !== undefined
+              ? true
+              : undefined,
+        };
       }
       const sessionPath = path.join(sessionsDir, `${sessionId}.jsonl`);
+
       let mainMessages: SessionHistoryMessage[];
       try {
-        mainMessages = await this.jsonlReader.readJsonlMessages(sessionPath);
+        const mainMessagesResult =
+          await this.readMainMessagesWithOptionalCompactionCheck(
+            sessionId,
+            sessionPath,
+            expectation,
+          );
+        staleSnapshot = mainMessagesResult.staleSnapshot;
+        mainMessages = mainMessagesResult.messages;
       } catch {
         this.logger.warn('[SessionHistoryReader] Session file not found', {
           sessionId,
         });
-        return { events: [], stats: null };
+        this.consumeCompactionExpectation(sessionId, checkCompactionBoundary);
+        return {
+          events: [],
+          messages: [],
+          stats: null,
+          staleSnapshot:
+            checkCompactionBoundary && expectation !== undefined
+              ? true
+              : undefined,
+        };
       }
+
       const agentSessions = await this.jsonlReader.loadAgentSessions(
         sessionsDir,
         sessionId,
@@ -194,23 +254,184 @@ export class SessionHistoryReaderService {
       }
       const stats = this.aggregateUsageStats(mainMessages, agentSessions);
       this.seedLiveUsageBaseline(sessionId, mainMessages);
+      const messages = this.projectHistoryMessages(mainMessages, (content) =>
+        this.eventFactory.extractTextContent(content),
+      );
+
+      this.consumeCompactionExpectation(sessionId, checkCompactionBoundary);
 
       this.logger.info('[SessionHistoryReader] Loaded session with stats', {
         sessionId,
         eventCount: events.length,
+        messageCount: messages.length,
         hasStats: !!stats,
         totalCost: stats?.totalCost,
         totalTokens: (stats?.tokens?.input ?? 0) + (stats?.tokens?.output ?? 0),
+        staleSnapshot,
       });
 
-      return { events, stats };
+      return { events, messages, stats, staleSnapshot };
     } catch (error) {
+      this.consumeCompactionExpectation(sessionId, checkCompactionBoundary);
       this.logger.error(
         '[SessionHistoryReader] Failed to read session history',
         error instanceof Error ? error : new Error(String(error)),
       );
-      return { events: [], stats: null };
+      return {
+        events: [],
+        messages: [],
+        stats: null,
+        staleSnapshot:
+          checkCompactionBoundary && expectation !== undefined
+            ? (staleSnapshot ?? true)
+            : undefined,
+      };
     }
+  }
+
+  /**
+   * Read the main transcript, optionally verifying that the expected
+   * compact-boundary generation is present. Captures the pending expectation
+   * before observing the count, records the observed count on every parse,
+   * and yields to the event loop a bounded number of times when the expectation
+   * is unmet.
+   */
+  private async readMainMessagesWithOptionalCompactionCheck(
+    sessionId: string,
+    sessionPath: string,
+    expectation: PendingExpectation | undefined,
+  ): Promise<{
+    messages: SessionHistoryMessage[];
+    staleSnapshot: true | undefined;
+  }> {
+    let mainMessages = await this.jsonlReader.readJsonlMessages(sessionPath);
+    let observedBoundaryCount = this.countCompactBoundaries(mainMessages);
+    this.compactionBoundaryRegistry.observeBoundaryCount(
+      sessionId,
+      observedBoundaryCount,
+      this.latestCompactBoundaryId(mainMessages),
+    );
+
+    if (expectation === undefined) {
+      return { messages: mainMessages, staleSnapshot: undefined };
+    }
+
+    if (expectation.kind === 'unverified') {
+      // A baseline-absent expectation can never be satisfied by the current
+      // parse: we do not know what the next boundary count should be.
+      return { messages: mainMessages, staleSnapshot: true };
+    }
+
+    if (observedBoundaryCount >= expectation.expectedCount) {
+      return { messages: mainMessages, staleSnapshot: undefined };
+    }
+
+    for (let attempt = 1; attempt <= MAX_COMPACTION_RETRIES; attempt++) {
+      await yieldToEventLoop();
+      mainMessages = await this.jsonlReader.readJsonlMessages(sessionPath);
+      observedBoundaryCount = this.countCompactBoundaries(mainMessages);
+      this.compactionBoundaryRegistry.observeBoundaryCount(
+        sessionId,
+        observedBoundaryCount,
+        this.latestCompactBoundaryId(mainMessages),
+      );
+      if (observedBoundaryCount >= expectation.expectedCount) {
+        return { messages: mainMessages, staleSnapshot: undefined };
+      }
+    }
+
+    return { messages: mainMessages, staleSnapshot: true };
+  }
+
+  private countCompactBoundaries(
+    mainMessages: readonly SessionHistoryMessage[],
+  ): number {
+    return mainMessages.filter(
+      (m) => m.type === 'system' && m.subtype === 'compact_boundary',
+    ).length;
+  }
+
+  private latestCompactBoundaryId(
+    mainMessages: readonly SessionHistoryMessage[],
+  ): string | undefined {
+    for (let index = mainMessages.length - 1; index >= 0; index--) {
+      const message = mainMessages[index];
+      if (
+        message.type === 'system' &&
+        message.subtype === 'compact_boundary' &&
+        message.uuid
+      ) {
+        return message.uuid;
+      }
+    }
+    return undefined;
+  }
+
+  private consumeCompactionExpectation(
+    sessionId: string,
+    checkCompactionBoundary: boolean,
+  ): void {
+    if (checkCompactionBoundary) {
+      this.compactionBoundaryRegistry.consumeExpectation(sessionId);
+    }
+  }
+
+  /**
+   * Project raw JSONL messages to the simple `{ id, role, content, timestamp }`
+   * shape shared by `chat:resume` and the legacy text/curation readers.
+   * Drops everything before the last `compact_boundary` and skips non-user/
+   * non-assistant roles, empty content, and task-notification content.
+   */
+  private projectHistoryMessages(
+    rawMessages: readonly SessionHistoryMessage[],
+    extractContent: (content: unknown) => string,
+  ): {
+    id: string;
+    role: 'user' | 'assistant';
+    content: string;
+    timestamp: number;
+  }[] {
+    let startIndex = 0;
+    for (let i = rawMessages.length - 1; i >= 0; i--) {
+      if (
+        rawMessages[i].type === 'system' &&
+        rawMessages[i].subtype === 'compact_boundary'
+      ) {
+        startIndex = i + 1;
+        break;
+      }
+    }
+    const effectiveMessages =
+      startIndex > 0 ? rawMessages.slice(startIndex) : rawMessages;
+    const messages: {
+      id: string;
+      role: 'user' | 'assistant';
+      content: string;
+      timestamp: number;
+    }[] = [];
+
+    for (const msg of effectiveMessages) {
+      if (!msg.message?.role) continue;
+
+      const role = msg.message.role;
+      if (role !== 'user' && role !== 'assistant') continue;
+      const content = extractContent(msg.message.content);
+      if (!content) continue;
+      if (content.trimStart().startsWith('<task-notification>')) continue;
+
+      const timestamp = msg.timestamp
+        ? new Date(msg.timestamp).getTime()
+        : Date.now();
+
+      messages.push({
+        id: msg.uuid || this.eventFactory.generateId(),
+        role: role as 'user' | 'assistant',
+        content,
+        timestamp,
+      });
+    }
+
+    return messages;
   }
 
   /**
@@ -376,50 +597,8 @@ export class SessionHistoryReaderService {
           : await this.jsonlReader.readJsonlMessages(sessionFile, {
               signal: options?.signal,
             });
-      let startIndex = 0;
-      for (let i = rawMessages.length - 1; i >= 0; i--) {
-        if (
-          rawMessages[i].type === 'system' &&
-          rawMessages[i].subtype === 'compact_boundary'
-        ) {
-          startIndex = i + 1;
-          this.logger.info(
-            `[SessionHistoryReader] Found compact_boundary at index ${i}, skipping pre-compaction messages`,
-          );
-          break;
-        }
-      }
-      const effectiveMessages =
-        startIndex > 0 ? rawMessages.slice(startIndex) : rawMessages;
-      const messages: {
-        id: string;
-        role: 'user' | 'assistant';
-        content: string;
-        timestamp: number;
-      }[] = [];
 
-      for (const msg of effectiveMessages) {
-        if (!msg.message?.role) continue;
-
-        const role = msg.message.role;
-        if (role !== 'user' && role !== 'assistant') continue;
-        const content = extractContent(msg.message.content);
-        if (!content) continue;
-        if (content.trimStart().startsWith('<task-notification>')) continue;
-
-        const timestamp = msg.timestamp
-          ? new Date(msg.timestamp).getTime()
-          : Date.now();
-
-        messages.push({
-          id: msg.uuid || this.eventFactory.generateId(),
-          role: role as 'user' | 'assistant',
-          content,
-          timestamp,
-        });
-      }
-
-      return messages;
+      return this.projectHistoryMessages(rawMessages, extractContent);
     } catch (error) {
       this.logger.error(
         '[SessionHistoryReader] Failed to read history as messages',

--- a/libs/backend/agent-sdk/src/lib/session-history-reader.service.ts
+++ b/libs/backend/agent-sdk/src/lib/session-history-reader.service.ts
@@ -432,6 +432,11 @@ export class SessionHistoryReaderService {
     }[] = [];
 
     for (const msg of effectiveMessages) {
+      // Synthetic records are an internal cue, not conversation. Replay already
+      // suppresses them (`session-replay.service.ts`), so projecting them here
+      // broke event/message parity: the one-read resume snapshot showed
+      // artifacts replay hides (PR #493 review C).
+      if (msg.isSynthetic === true) continue;
       if (!msg.message?.role) continue;
 
       const role = msg.message.role;

--- a/libs/backend/agent-sdk/src/lib/session-history-reader.service.ts
+++ b/libs/backend/agent-sdk/src/lib/session-history-reader.service.ts
@@ -46,6 +46,7 @@ import type { IPricingProvider } from './pricing.port';
 import type { LiveUsageTracker } from './helpers/live-usage-tracker';
 import type {
   CompactionBoundaryGenerationRegistry,
+  ExpectationOutcome,
   PendingExpectation,
 } from './helpers/compaction-boundary-generation-registry';
 import type { JsonlReaderService } from './helpers/history/jsonl-reader.service';
@@ -204,7 +205,11 @@ export class SessionHistoryReaderService {
         await this.jsonlReader.findSessionsDirectory(workspacePath);
       if (!sessionsDir) {
         this.logger.warn('[SessionHistoryReader] Sessions directory not found');
-        this.consumeCompactionExpectation(sessionId, checkCompactionBoundary);
+        this.consumeCompactionExpectation(
+          sessionId,
+          checkCompactionBoundary,
+          expectation ? 'stale' : 'none',
+        );
         return {
           events: [],
           messages: [],
@@ -231,7 +236,11 @@ export class SessionHistoryReaderService {
         this.logger.warn('[SessionHistoryReader] Session file not found', {
           sessionId,
         });
-        this.consumeCompactionExpectation(sessionId, checkCompactionBoundary);
+        this.consumeCompactionExpectation(
+          sessionId,
+          checkCompactionBoundary,
+          expectation ? 'stale' : 'none',
+        );
         return {
           events: [],
           messages: [],
@@ -261,7 +270,11 @@ export class SessionHistoryReaderService {
         this.eventFactory.extractTextContent(content),
       );
 
-      this.consumeCompactionExpectation(sessionId, checkCompactionBoundary);
+      this.consumeCompactionExpectation(
+        sessionId,
+        checkCompactionBoundary,
+        staleSnapshot ? 'stale' : expectation ? 'satisfied' : 'none',
+      );
 
       this.logger.info('[SessionHistoryReader] Loaded session with stats', {
         sessionId,
@@ -275,7 +288,11 @@ export class SessionHistoryReaderService {
 
       return { events, messages, stats, staleSnapshot };
     } catch (error) {
-      this.consumeCompactionExpectation(sessionId, checkCompactionBoundary);
+      this.consumeCompactionExpectation(
+        sessionId,
+        checkCompactionBoundary,
+        expectation ? 'stale' : 'none',
+      );
       this.logger.error(
         '[SessionHistoryReader] Failed to read session history',
         error instanceof Error ? error : new Error(String(error)),
@@ -373,9 +390,10 @@ export class SessionHistoryReaderService {
   private consumeCompactionExpectation(
     sessionId: string,
     checkCompactionBoundary: boolean,
+    outcome: ExpectationOutcome,
   ): void {
     if (checkCompactionBoundary) {
-      this.compactionBoundaryRegistry.consumeExpectation(sessionId);
+      this.compactionBoundaryRegistry.consumeExpectation(sessionId, outcome);
     }
   }
 

--- a/libs/backend/agent-sdk/src/lib/session-history-reader.service.ts
+++ b/libs/backend/agent-sdk/src/lib/session-history-reader.service.ts
@@ -39,6 +39,7 @@ import {
   type ModelUsageEntry,
 } from '@ptah-extension/shared';
 import { SDK_TOKENS } from './di/tokens';
+import { isHiddenTranscriptRecord } from './message-transform/message-transform-helpers';
 import { AUTH_PROVIDERS_TOKENS } from '@ptah-extension/auth-providers-tokens';
 import { SdkError } from './errors';
 import type { IModelResolver } from './auth-env.port';
@@ -432,11 +433,12 @@ export class SessionHistoryReaderService {
     }[] = [];
 
     for (const msg of effectiveMessages) {
-      // Synthetic records are an internal cue, not conversation. Replay already
-      // suppresses them (`session-replay.service.ts`), so projecting them here
-      // broke event/message parity: the one-read resume snapshot showed
-      // artifacts replay hides (PR #493 review C).
-      if (msg.isSynthetic === true) continue;
+      // Meta and synthetic records are an internal cue, not conversation.
+      // Replay suppresses both through the SAME predicate, so projecting either
+      // here broke event/message parity: the one-read resume snapshot showed
+      // artifacts replay hides (PR #493 review C; the `isMeta` half was left
+      // open by the first fix and is round-2 verification Moderate-2).
+      if (isHiddenTranscriptRecord(msg)) continue;
       if (!msg.message?.role) continue;
 
       const role = msg.message.role;

--- a/libs/backend/agent-sdk/src/lib/session-history-reader.service.ts
+++ b/libs/backend/agent-sdk/src/lib/session-history-reader.service.ts
@@ -31,6 +31,7 @@ import { TOKENS } from '@ptah-extension/vscode-core';
 import { extractTokenUsage } from './helpers/usage-extraction.utils';
 import {
   calculateMessageCost,
+  getModelContextWindow,
   pickPrimaryModel,
   isDirectAnthropic,
   registerProviderPricing,
@@ -174,6 +175,7 @@ export class SessionHistoryReaderService {
       contextSnapshot?: {
         model: string;
         contextTokens: number;
+        contextWindow?: number;
       };
       /** Number of agent/subagent JSONL files found for this session */
       agentSessionCount?: number;
@@ -183,6 +185,7 @@ export class SessionHistoryReaderService {
         inputTokens: number;
         outputTokens: number;
         costUSD: number | null;
+        contextWindow?: number;
       }>;
     } | null;
     staleSnapshot?: true;
@@ -853,6 +856,7 @@ export class SessionHistoryReaderService {
     contextSnapshot?: {
       model: string;
       contextTokens: number;
+      contextWindow?: number;
     };
     agentSessionCount?: number;
     modelUsageList?: Array<{
@@ -860,6 +864,7 @@ export class SessionHistoryReaderService {
       inputTokens: number;
       outputTokens: number;
       costUSD: number | null;
+      contextWindow?: number;
     }>;
   } | null {
     let totalInput = 0;
@@ -882,8 +887,15 @@ export class SessionHistoryReaderService {
       | {
           model: string;
           contextTokens: number;
+          contextWindow?: number;
         }
       | undefined;
+    // Carry the window on the wire so the renderer never reverse-resolves it
+    // from a name its bundled table cannot know (discovered proxy models).
+    const knownWindow = (model: string): { contextWindow?: number } => {
+      const contextWindow = getModelContextWindow(model);
+      return contextWindow > 0 ? { contextWindow } : {};
+    };
 
     const accumulatePerModel = (
       rawModel: string,
@@ -971,6 +983,7 @@ export class SessionHistoryReaderService {
                   tokens.input +
                   (tokens.cacheRead ?? 0) +
                   (tokens.cacheCreation ?? 0),
+                ...knownWindow(modelKey),
               };
             }
           }
@@ -1016,12 +1029,14 @@ export class SessionHistoryReaderService {
       inputTokens: number;
       outputTokens: number;
       costUSD: number | null;
+      contextWindow?: number;
     }> = Array.from(perModelUsage.entries())
       .map(([model, usage]) => ({
         model,
         inputTokens: usage.input,
         outputTokens: usage.output,
         costUSD: usage.hasCostContribution ? usage.cost : null,
+        ...knownWindow(model),
       }))
       .sort((a, b) => (b.costUSD ?? -1) - (a.costUSD ?? -1));
     const primaryModelEntries: ModelUsageEntry[] = modelUsageList.map((m) => ({

--- a/libs/backend/auth-providers/src/lib/provider-models.prefetch-context-windows.spec.ts
+++ b/libs/backend/auth-providers/src/lib/provider-models.prefetch-context-windows.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * `prefetchPricing()` is the FIRST model fetch on a cold start — it runs before
+ * the user has configured any API key — and the OpenRouter payload it parses
+ * carries `context_length` for every model. Both of its branches used to call
+ * only `feedPricingMap()`, which stores prices and not windows, so every
+ * provider-reported context window was discarded until some other fetch path
+ * happened to run (PR #493 review C).
+ */
+
+import 'reflect-metadata';
+
+import axios from 'axios';
+import {
+  createMockConfigManager,
+  type MockConfigManager,
+} from '@ptah-extension/vscode-core/testing';
+import { createMockLogger } from '@ptah-extension/shared/testing';
+import { getModelContextWindow, type AuthEnv } from '@ptah-extension/shared';
+import type { ConfigManager, Logger } from '@ptah-extension/vscode-core';
+import type { WorkspaceScopeResolver } from '@ptah-extension/settings-core';
+
+import { ProviderModelsService } from './provider-models.service';
+import { ActiveProviderResolver } from './auth/active-provider-resolver';
+
+jest.mock('axios');
+
+const mockedGet = axios.get as unknown as jest.Mock;
+
+function makeService(): {
+  service: ProviderModelsService;
+  config: MockConfigManager;
+} {
+  const logger = createMockLogger();
+  const config = createMockConfigManager({ values: {} });
+  const authEnv: AuthEnv = {};
+  const scope = {
+    read: <T>(): T | undefined => undefined,
+  } as unknown as WorkspaceScopeResolver;
+  const service = new ProviderModelsService(
+    logger as unknown as Logger,
+    config as unknown as ConfigManager,
+    authEnv,
+    new ActiveProviderResolver(scope),
+  );
+  return { service, config };
+}
+
+/** One OpenRouter catalogue row: a real window, deliberately no price. */
+function unpricedRow(id: string, contextLength: number) {
+  return {
+    id,
+    name: id,
+    description: '',
+    context_length: contextLength,
+    supported_parameters: ['tools'],
+    pricing: {},
+  };
+}
+
+async function runPrefetch(service: ProviderModelsService): Promise<number> {
+  // The implementation waits 3 s before its first attempt so a cold start does
+  // not race extension activation.
+  const pending = service.prefetchPricing();
+  await jest.advanceTimersByTimeAsync(3000);
+  return pending;
+}
+
+describe('ProviderModelsService.prefetchPricing — discovered context windows', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockedGet.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('registers provider-reported windows from a fresh fetch, even with no pricing', async () => {
+    const modelId = 'gpt-ctx-prefetch-fresh-493';
+    mockedGet.mockResolvedValue({
+      data: { data: [unpricedRow(modelId, 333_000)] },
+    });
+    const { service } = makeService();
+    expect(getModelContextWindow(modelId)).toBe(0);
+
+    await runPrefetch(service);
+
+    expect(getModelContextWindow(modelId)).toBe(333_000);
+  });
+
+  it('registers windows again on the cached branch', async () => {
+    const modelId = 'gpt-ctx-prefetch-cached-493';
+    mockedGet.mockResolvedValue({
+      data: { data: [unpricedRow(modelId, 444_000)] },
+    });
+    const { service } = makeService();
+    await runPrefetch(service);
+
+    const recordSpy = jest.spyOn(
+      service as unknown as {
+        recordContextWindows: (models: readonly unknown[]) => void;
+      },
+      'recordContextWindows',
+    );
+    mockedGet.mockClear();
+
+    await runPrefetch(service);
+
+    // Served entirely from the prefetch cache — and it still feeds the window
+    // registry, so a process that only ever takes this branch is not left
+    // without any provider-reported window.
+    expect(mockedGet).not.toHaveBeenCalled();
+    expect(recordSpy).toHaveBeenCalledTimes(1);
+    expect(recordSpy.mock.calls[0][0]).toEqual([
+      expect.objectContaining({ id: modelId, contextLength: 444_000 }),
+    ]);
+  });
+});

--- a/libs/backend/auth-providers/src/lib/provider-models.service.spec.ts
+++ b/libs/backend/auth-providers/src/lib/provider-models.service.spec.ts
@@ -39,7 +39,11 @@ import {
   type MockConfigManager,
 } from '@ptah-extension/vscode-core/testing';
 import { createMockLogger } from '@ptah-extension/shared/testing';
-import { getAnthropicProvider, type AuthEnv } from '@ptah-extension/shared';
+import {
+  getAnthropicProvider,
+  getModelContextWindow,
+  type AuthEnv,
+} from '@ptah-extension/shared';
 import type { Logger } from '@ptah-extension/vscode-core';
 
 import { ProviderModelsService } from './provider-models.service';
@@ -113,6 +117,55 @@ afterEach(() => {
       process.env[key] = val;
     }
   }
+});
+
+// ---------------------------------------------------------------------------
+// Discovered context windows (no pricing required)
+// ---------------------------------------------------------------------------
+
+describe('ProviderModelsService — discovered context windows', () => {
+  it('a dynamic fetcher result with contextLength and no pricing registers the window', async () => {
+    const { service } = makeService({});
+    const modelId = 'gpt-ctx-dynamic-fetch-414';
+    expect(getModelContextWindow(modelId)).toBe(0);
+    service.registerDynamicFetcher('codex', async () => [
+      {
+        id: modelId,
+        name: 'Discovered',
+        description: '',
+        contextLength: 400_000,
+        supportsToolUse: true,
+      },
+    ]);
+
+    await service.fetchModels('codex', null);
+
+    expect(getModelContextWindow(modelId)).toBe(400_000);
+  });
+
+  it('a persisted catalog read registers windows', () => {
+    const modelId = 'gpt-ctx-persisted-catalog-414';
+    const { service } = makeService({
+      configValues: {
+        'provider.codex.modelCatalog': {
+          models: [
+            {
+              id: modelId,
+              name: 'Persisted',
+              description: '',
+              contextLength: 272_000,
+              supportsToolUse: true,
+            },
+          ],
+        },
+      },
+    });
+    expect(getModelContextWindow(modelId)).toBe(0);
+
+    service.getLiveDerivedTiers('codex');
+
+    expect(getModelContextWindow(modelId)).toBe(272_000);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/libs/backend/auth-providers/src/lib/provider-models.service.ts
+++ b/libs/backend/auth-providers/src/lib/provider-models.service.ts
@@ -25,7 +25,10 @@ import type {
   ProviderTierScope,
   ModelPricing,
 } from '@ptah-extension/shared';
-import { updatePricingMap } from '@ptah-extension/shared';
+import {
+  registerModelContextWindows,
+  updatePricingMap,
+} from '@ptah-extension/shared';
 import {
   SdkError,
   TIER_ENV_VAR_MAP,
@@ -188,7 +191,23 @@ export class ProviderModelsService {
         typeof (m as ProviderModelInfo).id === 'string' &&
         typeof (m as ProviderModelInfo).name === 'string',
     );
-    return valid.length > 0 ? valid : null;
+    if (valid.length === 0) return null;
+    this.recordContextWindows(valid);
+    return valid;
+  }
+
+  /**
+   * Feed discovered context windows into the shared exact-match registry.
+   * Unlike {@link feedPricingMap} this does not require a price: a provider
+   * that reports `context_window` for an unpriced model (every Codex
+   * subscription model) is still the authority on that model's window. Never
+   * called for `staticModels` — those are release-time literals, not the
+   * provider's own answer.
+   */
+  private recordContextWindows(models: readonly ProviderModelInfo[]): void {
+    registerModelContextWindows(
+      models.map((m) => ({ id: m.id, contextLength: m.contextLength })),
+    );
   }
 
   /**
@@ -245,6 +264,7 @@ export class ProviderModelsService {
         const models = await dynamicFetcher();
         if (models.length > 0) {
           this.modelCache.set(providerId, { models, timestamp: now });
+          this.recordContextWindows(models);
           void this.persistCatalog(providerId, models);
 
           const filtered = toolUseOnly
@@ -408,6 +428,7 @@ export class ProviderModelsService {
       }
       const models = this.transformApiModels(data.data);
       this.feedPricingMap(models);
+      this.recordContextWindows(models);
       this.modelCache.set(providerId, { models, timestamp: now });
 
       this.logger.info(

--- a/libs/backend/auth-providers/src/lib/provider-models.service.ts
+++ b/libs/backend/auth-providers/src/lib/provider-models.service.ts
@@ -998,6 +998,11 @@ export class ProviderModelsService {
       Date.now() - cached.timestamp < this.CACHE_TTL_MS
     ) {
       this.feedPricingMap(cached.models);
+      // The prefetch is the FIRST model fetch on a cold start, and its models
+      // carry `contextLength`. Feeding only the pricing map discarded every
+      // provider-reported window until some other fetch path happened to run
+      // (PR #493 review C).
+      this.recordContextWindows(cached.models);
       return cached.models.filter((m) => m.inputCostPerToken !== undefined)
         .length;
     }
@@ -1031,6 +1036,7 @@ export class ProviderModelsService {
         });
 
         const pricedCount = this.feedPricingMap(models);
+        this.recordContextWindows(models);
 
         this.logger.info(
           '[ProviderModelsService] Pre-fetched pricing from OpenRouter',

--- a/libs/backend/cli-agent-runtime/src/lib/ptah-cli/helpers/ptah-cli-spawn-options.service.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/ptah-cli/helpers/ptah-cli-spawn-options.service.ts
@@ -30,6 +30,8 @@ import {
   CompactionConfigProvider,
   assembleSystemPrompt,
   getActiveProviderId,
+  resolveAutoCompactControl,
+  type AutoCompactSettings,
   type HookEvent,
   type HookCallbackMatcher,
   type McpHttpServerConfig,
@@ -52,9 +54,11 @@ export interface PtahSpawnAssembly {
   readonly systemPromptContent: string | undefined;
   readonly mcpServers: Record<string, McpHttpServerConfig>;
   readonly hooks: Partial<Record<HookEvent, HookCallbackMatcher[]>> | undefined;
-  readonly compactionControl:
-    | { enabled: boolean; contextTokenThreshold: number }
-    | undefined;
+  /**
+   * Flag-tier auto-compaction keys from `resolveAutoCompactControl`, merged by
+   * the caller through `buildFlagSettings`. `{}` when Ptah has no opinion.
+   */
+  readonly autoCompact: AutoCompactSettings;
   /**
    * Output-style name for the FLAG tier (TASK_2026_197), or `undefined` when
    * no style is active.
@@ -219,12 +223,12 @@ export class PtahCliSpawnOptions {
       }
     }
     const compactionConfig = this.compactionConfigProvider?.getConfig();
-    const compactionControl = compactionConfig?.enabled
-      ? {
-          enabled: true,
-          contextTokenThreshold: compactionConfig.contextTokenThreshold,
-        }
-      : undefined;
+    const autoCompact: AutoCompactSettings = compactionConfig
+      ? resolveAutoCompactControl({
+          enabled: compactionConfig.enabled,
+          windowTokens: compactionConfig.contextTokenThreshold ?? null,
+        })
+      : {};
 
     this.logger.info('[PtahCliSpawnOptions] Assembled spawn options', {
       cwd,
@@ -232,7 +236,8 @@ export class PtahCliSpawnOptions {
       mcpEnabled: Object.keys(mcpServers).length > 0,
       hasEnhancedPrompts: !!enhancedPromptsContent,
       hasHooks: !!hooks,
-      compactionEnabled: compactionConfig?.enabled ?? false,
+      compactionEnabled: compactionConfig?.enabled ?? true,
+      autoCompact,
       hasIdentityPrompt: !!activeProviderId,
       outputStyleName: outputStyle.outputStyleName ?? null,
       parentSessionId: parentSessionId ?? null,
@@ -244,7 +249,7 @@ export class PtahCliSpawnOptions {
       systemPromptContent: fullSystemPromptContent,
       mcpServers,
       hooks,
-      compactionControl,
+      autoCompact,
       outputStyleName: outputStyle.outputStyleName,
     };
   }

--- a/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-auto-compact-argv.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-auto-compact-argv.spec.ts
@@ -15,7 +15,8 @@
 import 'reflect-metadata';
 
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
 
@@ -77,8 +78,14 @@ import type { ISdkProcessSpawner } from '../spawn/sdk-process-spawner.port';
 
 const PINNED_SDK_VERSION = '0.3.150';
 
+// The probe payload (system prompts across 7 cases routinely exceed 100 KB
+// combined) is read from stdin, never argv or env — both are capped by the
+// OS (Linux MAX_ARG_STRLEN is 131072 bytes per string; spawnSync fails with
+// E2BIG once argv+environ crosses ARG_MAX). See assertWithinArgLimit below.
 const PROBE_SCRIPT = `
-const { sdkUrl, runs } = JSON.parse(process.env.PTAH_SDK_ARGV_PROBE);
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+const { sdkUrl, runs } = JSON.parse(Buffer.concat(chunks).toString('utf8'));
 const { query } = await import(sdkUrl);
 const { PassThrough } = await import('node:stream');
 const { EventEmitter } = await import('node:events');
@@ -129,31 +136,68 @@ function findPinnedSdk(): { entry: string; version: string } {
   }
 }
 
+// Linux caps a single argv/env string at MAX_ARG_STRLEN (131072 bytes) and
+// the whole argv+environ block at ARG_MAX; exceeding either fails spawnSync
+// with E2BIG (`child.status === null`, `child.error.code === 'E2BIG'`).
+// Windows enforces no such limit, so a regression here passes locally and
+// only fails in CI. Guarding argv/env directly — rather than only moving the
+// known-large payload off them — makes a future regression fail everywhere.
+const MAX_ARG_BYTES = 100_000;
+
+function assertWithinArgLimit(label: string, value: string): void {
+  const bytes = Buffer.byteLength(value, 'utf8');
+  if (bytes >= MAX_ARG_BYTES) {
+    throw new Error(
+      `${label} is ${bytes} bytes, at/over the ${MAX_ARG_BYTES}-byte guard ` +
+        '(Linux argv/env strings are capped at 131072 bytes and spawnSync ' +
+        'fails with E2BIG well before that on the full argv+env block). ' +
+        'Send this payload over stdin or a temp file instead.',
+    );
+  }
+}
+
 function runProbe(
   sdkEntry: string,
   runs: ReadonlyArray<Record<string, unknown>>,
 ): ProbeResult[] {
-  const child = spawnSync(
-    process.execPath,
-    ['--input-type=module', '-e', PROBE_SCRIPT],
-    {
+  const scriptPath = path.join(
+    os.tmpdir(),
+    `ptah-sdk-argv-probe-${process.pid}-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}.mjs`,
+  );
+  writeFileSync(scriptPath, PROBE_SCRIPT, 'utf8');
+  try {
+    const args = [scriptPath];
+    for (const arg of args) assertWithinArgLimit(`argv "${arg}"`, arg);
+    for (const [key, value] of Object.entries(process.env)) {
+      if (typeof value === 'string') {
+        assertWithinArgLimit(`env[${key}]`, value);
+      }
+    }
+    const payload = JSON.stringify({
+      sdkUrl: pathToFileURL(sdkEntry).href,
+      runs,
+    });
+    const child = spawnSync(process.execPath, args, {
       encoding: 'utf8',
       timeout: 120_000,
-      env: {
-        ...process.env,
-        PTAH_SDK_ARGV_PROBE: JSON.stringify({
-          sdkUrl: pathToFileURL(sdkEntry).href,
-          runs,
-        }),
-      },
-    },
-  );
-  if (child.status !== 0) {
-    throw new Error(
-      `SDK probe failed (${child.status}): ${child.stderr || child.error}`,
-    );
+      input: payload,
+      env: process.env,
+    });
+    if (child.status !== 0) {
+      throw new Error(
+        `SDK probe failed (${child.status}): ${child.stderr || child.error}`,
+      );
+    }
+    return JSON.parse(child.stdout) as ProbeResult[];
+  } finally {
+    try {
+      unlinkSync(scriptPath);
+    } catch {
+      // best-effort cleanup; a leftover temp file is not worth failing the test over
+    }
   }
-  return JSON.parse(child.stdout) as ProbeResult[];
 }
 
 function flagValue(args: readonly string[], flag: string): string | undefined {

--- a/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-auto-compact-argv.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-auto-compact-argv.spec.ts
@@ -108,8 +108,10 @@ for (const options of runs) {
   }
   results.push({ args: captured ? captured.args : null, stdinText });
 }
-process.stdout.write(JSON.stringify(results));
-process.exit(0);
+// Exit only once the payload has actually left the process. stdout is a PIPE
+// here, so process.stdout.write() buffers and an immediate process.exit(0)
+// truncates a large JSON result — the parent then fails at JSON.parse.
+process.stdout.write(JSON.stringify(results), () => process.exit(0));
 `;
 
 interface ProbeResult {

--- a/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-auto-compact-argv.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-auto-compact-argv.spec.ts
@@ -1,0 +1,442 @@
+/**
+ * Effective compaction settings on the PTAH-CLI spawn path, proven through the
+ * real pinned `@anthropic-ai/claude-agent-sdk` (TASK_2026_414 / 411 B8).
+ *
+ * `PtahCliRegistry.spawnAgent` builds the options with the REAL
+ * `PtahCliSpawnOptions` and the REAL `CompactionConfigProvider`; the captured
+ * options are then handed to the pinned SDK's `query()` in a child Node
+ * process (the SDK is ESM-only) with a FAKE `spawnClaudeCodeProcess` that
+ * records argv and the `initialize` request. Nothing is launched.
+ *
+ * This path used to send `compactionControl`, which is not an SDK option and
+ * was silently ignored.
+ */
+
+import 'reflect-metadata';
+
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+
+import { createMockLogger } from '@ptah-extension/shared/testing';
+import type {
+  ConfigManager,
+  IAuthSecretsService,
+  Logger,
+} from '@ptah-extension/vscode-core';
+import type {
+  Options,
+  SdkMessageTransformer,
+  SdkModuleLoader,
+  SdkPermissionHandler,
+} from '@ptah-extension/agent-sdk';
+import { CompactionConfigProvider } from '@ptah-extension/agent-sdk';
+import type { ProviderModelsService } from '@ptah-extension/auth-providers';
+import type { PtahCliConfig } from '@ptah-extension/shared';
+import type { SpawnedProcess } from '@anthropic-ai/claude-agent-sdk';
+
+// The `agent-generation` barrel reaches tree-sitter's `import.meta.url`, which
+// this Jest transform cannot parse. Only the DI token is needed.
+jest.mock('@ptah-extension/agent-generation', () => ({
+  AGENT_GENERATION_TOKENS: {
+    ENHANCED_PROMPTS_SERVICE: Symbol.for('EnhancedPromptsService'),
+  },
+}));
+
+jest.mock('@ptah-extension/agent-sdk', () => {
+  const actual = jest.requireActual('@ptah-extension/agent-sdk');
+  return {
+    ...actual,
+    getAnthropicProvider: jest.fn(() => ({
+      id: 'moonshot',
+      name: 'Moonshot (Kimi)',
+      baseUrl: 'https://api.moonshot.ai/anthropic/',
+      authEnvVar: 'ANTHROPIC_AUTH_TOKEN',
+      keyPrefix: '',
+      helpUrl: '',
+      description: '',
+      keyPlaceholder: '',
+      maskedKeyDisplay: '',
+      staticModels: [{ id: 'kimi-k2', name: 'Kimi K2' }],
+      defaultTiers: {
+        sonnet: 'kimi-tier-sonnet',
+        opus: 'kimi-tier-opus',
+        haiku: 'kimi-tier-haiku',
+      },
+    })),
+    getProviderAuthEnvVar: jest.fn(() => 'ANTHROPIC_AUTH_TOKEN'),
+    seedStaticModelPricing: jest.fn(),
+    buildSafeEnv: jest.fn((env: unknown) => env),
+  };
+});
+
+import { PtahCliRegistry } from './ptah-cli-registry';
+import { PtahCliSpawnOptions } from './helpers/ptah-cli-spawn-options.service';
+import type { ISdkProcessSpawner } from '../spawn/sdk-process-spawner.port';
+
+const PINNED_SDK_VERSION = '0.3.150';
+
+const PROBE_SCRIPT = `
+const { sdkUrl, runs } = JSON.parse(process.env.PTAH_SDK_ARGV_PROBE);
+const { query } = await import(sdkUrl);
+const { PassThrough } = await import('node:stream');
+const { EventEmitter } = await import('node:events');
+const results = [];
+for (const options of runs) {
+  let captured = null;
+  let stdinText = '';
+  const q = query({ prompt: 'probe', options: { ...options, cwd: process.cwd(), pathToClaudeCodeExecutable: process.execPath, spawnClaudeCodeProcess: (spawnOptions) => {
+    captured = { args: spawnOptions.args };
+    const stdin = new PassThrough();
+    stdin.on('data', (chunk) => { stdinText += String(chunk); });
+    const stdout = new PassThrough();
+    const events = new EventEmitter();
+    return { stdin, stdout, killed: false, exitCode: null, kill: () => true, on: events.on.bind(events), once: events.once.bind(events), off: events.off.bind(events) };
+  } } });
+  q[Symbol.asyncIterator]().next().catch(() => undefined);
+  const deadline = Date.now() + 10000;
+  while ((!captured || !stdinText.includes('"initialize"')) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  results.push({ args: captured ? captured.args : null, stdinText });
+}
+process.stdout.write(JSON.stringify(results));
+process.exit(0);
+`;
+
+interface ProbeResult {
+  readonly args: string[] | null;
+  readonly stdinText: string;
+}
+
+function findPinnedSdk(): { entry: string; version: string } {
+  let dir = __dirname;
+  for (;;) {
+    const root = path.join(dir, 'node_modules', '@anthropic-ai', 'claude-agent-sdk');
+    const entry = path.join(root, 'sdk.mjs');
+    if (existsSync(entry)) {
+      const pkg = JSON.parse(
+        readFileSync(path.join(root, 'package.json'), 'utf8'),
+      ) as { version: string };
+      return { entry, version: pkg.version };
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error('@anthropic-ai/claude-agent-sdk is not installed');
+    }
+    dir = parent;
+  }
+}
+
+function runProbe(
+  sdkEntry: string,
+  runs: ReadonlyArray<Record<string, unknown>>,
+): ProbeResult[] {
+  const child = spawnSync(
+    process.execPath,
+    ['--input-type=module', '-e', PROBE_SCRIPT],
+    {
+      encoding: 'utf8',
+      timeout: 120_000,
+      env: {
+        ...process.env,
+        PTAH_SDK_ARGV_PROBE: JSON.stringify({
+          sdkUrl: pathToFileURL(sdkEntry).href,
+          runs,
+        }),
+      },
+    },
+  );
+  if (child.status !== 0) {
+    throw new Error(
+      `SDK probe failed (${child.status}): ${child.stderr || child.error}`,
+    );
+  }
+  return JSON.parse(child.stdout) as ProbeResult[];
+}
+
+function flagValue(args: readonly string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index >= 0) return args[index + 1];
+  const joined = args.find((arg) => arg.startsWith(`${flag}=`));
+  return joined?.slice(flag.length + 1);
+}
+
+function settingsFromArgv(args: readonly string[]): Record<string, unknown> {
+  const raw = flagValue(args, '--settings');
+  if (raw === undefined) throw new Error('no --settings on argv');
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+function initializeRequest(stdinText: string): Record<string, unknown> {
+  for (const line of stdinText.split('\n')) {
+    if (!line.trim()) continue;
+    const message = JSON.parse(line) as {
+      type?: string;
+      request?: Record<string, unknown>;
+    };
+    if (
+      message.type === 'control_request' &&
+      message.request?.['subtype'] === 'initialize'
+    ) {
+      return message.request;
+    }
+  }
+  throw new Error('no initialize request was written');
+}
+
+const BASE_CONFIG: PtahCliConfig = {
+  id: 'pc-auto-compact-001',
+  name: 'Auto Compact Agent',
+  providerId: 'moonshot',
+  enabled: true,
+  tierMappings: undefined,
+  updatedAt: 0,
+};
+
+async function* emptyStream(): AsyncGenerator<never, void, unknown> {
+  // No messages — the stream loop resolves with exit code 0.
+}
+
+async function captureSpawnOptions(
+  values: Record<string, unknown>,
+  outputStyleName: string | undefined,
+): Promise<{
+  options: Options;
+  logger: ReturnType<typeof createMockLogger>;
+}> {
+  const logger = createMockLogger();
+  let captured: Options | undefined;
+  const queryFn = jest.fn((args: { options?: Options }) => {
+    captured = args.options;
+    return emptyStream();
+  });
+  const config = {
+    get: jest.fn((key: string) => values[key]),
+  } as unknown as ConfigManager;
+  const compactionConfigProvider = new CompactionConfigProvider(
+    config,
+    logger as unknown as Logger,
+  );
+  const spawnOptions = new PtahCliSpawnOptions(
+    logger as unknown as Logger,
+    { createHooks: jest.fn().mockReturnValue({}) } as never,
+    { createHooks: jest.fn().mockReturnValue({}) } as never,
+    compactionConfigProvider,
+    {
+      getProjectGuidanceContent: jest.fn().mockResolvedValue(undefined),
+    } as never,
+    undefined,
+    {
+      resolveSessionFields: jest
+        .fn()
+        .mockResolvedValue(outputStyleName ? { outputStyleName } : {}),
+    } as never,
+  );
+  const dummyProcess: SpawnedProcess = {
+    stdin: {} as never,
+    stdout: {} as never,
+    killed: false,
+    exitCode: null,
+    kill: jest.fn().mockReturnValue(true),
+    on: jest.fn(),
+    once: jest.fn(),
+    off: jest.fn(),
+  };
+  const spawner: ISdkProcessSpawner = {
+    spawn: jest.fn().mockReturnValue(dummyProcess),
+  };
+  const registry = new PtahCliRegistry(
+    logger as unknown as Logger,
+    {
+      getProviderKey: jest.fn().mockResolvedValue('sk-test-key'),
+    } as unknown as IAuthSecretsService,
+    {
+      getQueryFunction: jest.fn().mockResolvedValue(queryFn),
+      getCliJsPath: jest.fn().mockResolvedValue(undefined),
+    } as unknown as SdkModuleLoader,
+    {
+      createIsolated: jest.fn().mockReturnValue({
+        transform: jest.fn().mockReturnValue([]),
+      }),
+    } as unknown as SdkMessageTransformer,
+    {
+      getPermissionLevel: jest.fn().mockReturnValue('yolo'),
+      createCallback: jest.fn(),
+    } as unknown as SdkPermissionHandler,
+    null as never, // subagentHookHandler
+    null as never, // compactionHookHandler
+    compactionConfigProvider,
+    {
+      getModelTiers: jest
+        .fn()
+        .mockReturnValue({ sonnet: null, opus: null, haiku: null }),
+    } as unknown as ProviderModelsService,
+    { loadConfigs: jest.fn().mockReturnValue([BASE_CONFIG]) } as never,
+    spawnOptions,
+    null as never, // modelResolver
+    { get: jest.fn(() => undefined) } as unknown as never, // configManager
+    spawner,
+  );
+  await registry.spawnAgent(BASE_CONFIG.id, 'do work');
+  if (!captured) throw new Error('spawnAgent did not call query()');
+  return { options: captured, logger };
+}
+
+type CaseName =
+  | 'enabled-unset'
+  | 'disabled'
+  | 'min'
+  | 'max'
+  | 'invalid-low'
+  | 'invalid-high'
+  | 'style-and-window';
+
+const CASES: ReadonlyArray<{
+  readonly name: CaseName;
+  readonly values: Record<string, unknown>;
+  readonly outputStyleName?: string;
+}> = [
+  { name: 'enabled-unset', values: {} },
+  {
+    name: 'disabled',
+    values: { 'compaction.enabled': false, 'compaction.threshold': 300_000 },
+  },
+  { name: 'min', values: { 'compaction.threshold': 100_000 } },
+  { name: 'max', values: { 'compaction.threshold': 1_000_000 } },
+  { name: 'invalid-low', values: { 'compaction.threshold': 50_000 } },
+  { name: 'invalid-high', values: { 'compaction.threshold': 1_000_001 } },
+  {
+    name: 'style-and-window',
+    values: { 'compaction.threshold': 400_000 },
+    outputStyleName: 'Terse',
+  },
+];
+
+describe('ptah-cli spawn path — compaction settings on the real SDK argv', () => {
+  const results = new Map<
+    CaseName,
+    {
+      probe: ProbeResult;
+      options: Options;
+      logger: ReturnType<typeof createMockLogger>;
+    }
+  >();
+  let sdkVersion = '';
+
+  beforeAll(async () => {
+    const sdk = findPinnedSdk();
+    sdkVersion = sdk.version;
+    const captured: Array<{
+      name: CaseName;
+      options: Options;
+      logger: ReturnType<typeof createMockLogger>;
+    }> = [];
+    for (const testCase of CASES) {
+      const { options, logger } = await captureSpawnOptions(
+        testCase.values,
+        testCase.outputStyleName,
+      );
+      captured.push({ name: testCase.name, options, logger });
+    }
+    const probes = runProbe(
+      sdk.entry,
+      captured.map(({ options }) => ({
+        model: options.model,
+        settings: options.settings,
+        systemPrompt: options.systemPrompt,
+        settingSources: options.settingSources,
+      })),
+    );
+    captured.forEach((entry, index) => {
+      results.set(entry.name, {
+        probe: probes[index],
+        options: entry.options,
+        logger: entry.logger,
+      });
+    });
+  }, 180_000);
+
+  function argvSettings(name: CaseName): Record<string, unknown> {
+    const args = results.get(name)?.probe.args;
+    if (!args) throw new Error(`no argv captured for ${name}`);
+    return settingsFromArgv(args);
+  }
+
+  it('runs against the pinned SDK version', () => {
+    expect(sdkVersion).toBe(PINNED_SDK_VERSION);
+  });
+
+  it('no longer sends the non-existent compactionControl option', () => {
+    for (const { options } of results.values()) {
+      expect('compactionControl' in options).toBe(false);
+    }
+  });
+
+  it('enabled + unset threshold → no autoCompactWindow and no autoCompactEnabled', () => {
+    expect(argvSettings('enabled-unset')).toEqual({
+      autoMemoryEnabled: false,
+      autoDreamEnabled: false,
+    });
+  });
+
+  it('disabled → autoCompactEnabled false (auto compact off, no window)', () => {
+    expect(argvSettings('disabled')).toEqual({
+      autoMemoryEnabled: false,
+      autoDreamEnabled: false,
+      autoCompactEnabled: false,
+    });
+  });
+
+  it('min threshold → autoCompactWindow 100000 on argv', () => {
+    expect(argvSettings('min')).toMatchObject({ autoCompactWindow: 100_000 });
+  });
+
+  it('max threshold → autoCompactWindow 1000000 on argv', () => {
+    expect(argvSettings('max')).toMatchObject({
+      autoCompactWindow: 1_000_000,
+    });
+  });
+
+  it.each(['invalid-low', 'invalid-high'] as const)(
+    'invalid persisted threshold (%s) → warn + treated as unset',
+    (name) => {
+      expect(argvSettings(name)).toEqual({
+        autoMemoryEnabled: false,
+        autoDreamEnabled: false,
+      });
+      expect(results.get(name)?.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid compaction threshold'),
+        expect.anything(),
+      );
+    },
+  );
+
+  it('output style and window coexist on the flag tier', () => {
+    expect(argvSettings('style-and-window')).toEqual({
+      autoMemoryEnabled: false,
+      autoDreamEnabled: false,
+      outputStyle: 'Terse',
+      autoCompactWindow: 400_000,
+    });
+  });
+
+  it('preserves model, setting sources and the system prompt in every case', () => {
+    for (const [name, { probe, options }] of results) {
+      const args = probe.args;
+      if (!args) throw new Error(`no argv captured for ${name}`);
+      expect(flagValue(args, '--model')).toBe(options.model);
+      expect(flagValue(args, '--setting-sources')).toBe(
+        (options.settingSources ?? []).join(','),
+      );
+      const init = initializeRequest(probe.stdinText);
+      const systemPrompt = options.systemPrompt;
+      if (typeof systemPrompt === 'string') {
+        expect(init['systemPrompt']).toBe(systemPrompt);
+      } else if (systemPrompt && 'append' in systemPrompt) {
+        expect(init['appendSystemPrompt']).toBe(systemPrompt.append);
+      }
+    }
+  });
+});

--- a/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-harness-preflight.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-harness-preflight.spec.ts
@@ -78,7 +78,7 @@ function buildHarness(ensure: jest.Mock | null): Harness {
   const assembleSpawnOptions = jest.fn().mockResolvedValue({
     mcpServers: {},
     hooks: undefined,
-    compactionControl: undefined,
+    autoCompact: {},
     systemPromptMode: 'append',
     systemPromptContent: undefined,
     outputStyleName: undefined,

--- a/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-lmstudio-proxy.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-lmstudio-proxy.spec.ts
@@ -148,7 +148,7 @@ function buildHarness(config: PtahCliConfig): SpawnHarness {
     assembleSpawnOptions: jest.fn().mockResolvedValue({
       mcpServers: {},
       hooks: undefined,
-      compactionControl: undefined,
+      autoCompact: {},
       systemPromptMode: 'append',
       systemPromptContent: undefined,
     }),

--- a/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-off-thread-spawn.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-off-thread-spawn.spec.ts
@@ -113,7 +113,7 @@ function buildHarness(config: PtahCliConfig): SpawnHarness {
     assembleSpawnOptions: jest.fn().mockResolvedValue({
       mcpServers: {},
       hooks: undefined,
-      compactionControl: undefined,
+      autoCompact: {},
       systemPromptMode: 'append',
       systemPromptContent: undefined,
     }),

--- a/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-output-style.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-output-style.spec.ts
@@ -119,7 +119,7 @@ function buildHarness(outputStyleName: string | undefined): {
       assembleSpawnOptions: jest.fn().mockResolvedValue({
         mcpServers: {},
         hooks: undefined,
-        compactionControl: undefined,
+        autoCompact: {},
         systemPromptMode: 'append',
         systemPromptContent: undefined,
         outputStyleName,

--- a/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-permission-routing.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-permission-routing.spec.ts
@@ -120,7 +120,7 @@ function buildHarness(): {
       assembleSpawnOptions: jest.fn().mockResolvedValue({
         mcpServers: {},
         hooks: undefined,
-        compactionControl: undefined,
+        autoCompact: {},
         systemPromptMode: 'append',
         systemPromptContent: undefined,
         outputStyleName: undefined,

--- a/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-sakana-proxy.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-sakana-proxy.spec.ts
@@ -146,7 +146,7 @@ function buildHarness(config: PtahCliConfig): SpawnHarness {
     assembleSpawnOptions: jest.fn().mockResolvedValue({
       mcpServers: {},
       hooks: undefined,
-      compactionControl: undefined,
+      autoCompact: {},
       systemPromptMode: 'append',
       systemPromptContent: undefined,
     }),

--- a/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-spawn-model.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry-spawn-model.spec.ts
@@ -122,7 +122,7 @@ function buildHarness(config: PtahCliConfig): SpawnHarness {
     assembleSpawnOptions: jest.fn().mockResolvedValue({
       mcpServers: {},
       hooks: undefined,
-      compactionControl: undefined,
+      autoCompact: {},
       systemPromptMode: 'append',
       systemPromptContent: undefined,
     }),

--- a/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/ptah-cli/ptah-cli-registry.ts
@@ -727,9 +727,14 @@ export class PtahCliRegistry {
         // send before. That is deliberate: Ptah runs its own memory curator,
         // and a spawned agent writing SDK auto-memory was an inconsistency
         // with every other session Ptah starts.
-        settings: buildFlagSettings({
-          outputStyleName: assembly.outputStyleName,
-        }),
+        //
+        // Auto-compaction keys ride the same builder: the pinned runtime reads
+        // `autoCompactEnabled` / `autoCompactWindow` from this flag tier, and
+        // there is no `Options.compactionControl` (see auto-compact-control.ts).
+        settings: buildFlagSettings(
+          { outputStyleName: assembly.outputStyleName },
+          assembly.autoCompact,
+        ),
         ...this.resolvePermissionOptions(
           blankToUndefined(options?.resumeSessionId) ??
             blankToUndefined(options?.parentSessionId) ??
@@ -747,7 +752,6 @@ export class PtahCliRegistry {
             onStderr: handleChildStderr,
           }),
         hooks: assembly.hooks,
-        compactionControl: assembly.compactionControl,
         pathToClaudeCodeExecutable:
           (await this.moduleLoader.getCliJsPath()) ?? undefined,
       } as Options,

--- a/libs/backend/rpc-handlers/src/lib/chat/session/chat-session-resume-activate.spec.ts
+++ b/libs/backend/rpc-handlers/src/lib/chat/session/chat-session-resume-activate.spec.ts
@@ -78,6 +78,10 @@ function makeService(params: {
   resumeSession?: jest.Mock;
   isStreaming?: jest.Mock;
   mcpServerRunning?: boolean;
+  historyReader?: {
+    readSessionHistory?: jest.Mock;
+    readHistoryAsMessages?: jest.Mock;
+  };
 }): ChatSessionService {
   const noop = jest.fn();
   const stub = { then: undefined } as unknown;
@@ -93,10 +97,12 @@ function makeService(params: {
   } as unknown as IAgentAdapter;
 
   const historyReader = {
-    readSessionHistory: jest
-      .fn()
-      .mockResolvedValue({ events: [], stats: null }),
-    readHistoryAsMessages: jest.fn().mockResolvedValue([]),
+    readSessionHistory:
+      params.historyReader?.readSessionHistory ??
+      jest.fn().mockResolvedValue({ events: [], messages: [], stats: null }),
+    readHistoryAsMessages:
+      params.historyReader?.readHistoryAsMessages ??
+      jest.fn().mockResolvedValue([]),
   };
   const subagentRegistry = {
     registerFromHistoryEvents: jest.fn().mockReturnValue(0),
@@ -280,5 +286,73 @@ describe('ChatSessionService — resumeSession activate:true (TS-04)', () => {
     expect(result.activated).toBe(false);
     expect(result.activationError).toBeUndefined();
     expect(result.activationErrorCode).toBeUndefined();
+  });
+
+  it('forwards staleSnapshot:true from the immutable resume read onto ChatResumeResult', async () => {
+    const svc = makeService({
+      isSessionActive: jest.fn().mockReturnValue(false),
+      historyReader: {
+        readSessionHistory: jest.fn().mockResolvedValue({
+          events: [],
+          messages: [],
+          stats: null,
+          staleSnapshot: true,
+        }),
+      },
+    });
+
+    const params: ChatResumeParams = {
+      sessionId: SESSION_ID,
+      tabId: TAB_ID,
+      workspacePath: OPEN_FOLDER,
+    };
+
+    const result = (await svc.resumeSession(params)) as ChatResumeResult;
+    expect(result.success).toBe(true);
+    expect(result.staleSnapshot).toBe(true);
+  });
+
+  it('uses a single readSessionHistory parse and never calls readHistoryAsMessages', async () => {
+    const readSessionHistory = jest.fn().mockResolvedValue({
+      events: [{ id: 'ev1', eventType: 'message_start' } as never],
+      messages: [
+        {
+          id: 'msg-1',
+          role: 'user' as const,
+          content: 'hello',
+          timestamp: 1,
+        },
+      ],
+      stats: null,
+    });
+    const readHistoryAsMessages = jest.fn().mockResolvedValue([]);
+
+    const svc = makeService({
+      isSessionActive: jest.fn().mockReturnValue(false),
+      historyReader: {
+        readSessionHistory,
+        readHistoryAsMessages,
+      },
+    });
+
+    const params: ChatResumeParams = {
+      sessionId: SESSION_ID,
+      tabId: TAB_ID,
+      workspacePath: OPEN_FOLDER,
+    };
+
+    const result = (await svc.resumeSession(params)) as ChatResumeResult;
+    expect(result.success).toBe(true);
+    expect(readSessionHistory).toHaveBeenCalledTimes(1);
+    expect(readSessionHistory).toHaveBeenCalledWith(
+      SESSION_ID,
+      OPEN_FOLDER,
+      { checkCompactionBoundary: true },
+    );
+    expect(readHistoryAsMessages).not.toHaveBeenCalled();
+    expect(result.messages).toEqual([
+      { id: 'msg-1', role: 'user', content: 'hello', timestamp: 1 },
+    ]);
+    expect(result.events).toEqual([{ id: 'ev1', eventType: 'message_start' }]);
   });
 });

--- a/libs/backend/rpc-handlers/src/lib/chat/session/chat-session.service.ts
+++ b/libs/backend/rpc-handlers/src/lib/chat/session/chat-session.service.ts
@@ -798,14 +798,13 @@ export class ChatSessionService {
       const result = await this.historyReader.readSessionHistory(
         sessionId,
         resolvedWorkspacePath,
+        { checkCompactionBoundary: true },
       );
       const events = result.events;
+      const messages = result.messages;
       const stats = result.stats;
+      const staleSnapshot = result.staleSnapshot;
 
-      const messages = await this.historyReader.readHistoryAsMessages(
-        sessionId,
-        resolvedWorkspacePath,
-      );
       const registeredFromHistory =
         this.subagentRegistry.registerFromHistoryEvents(events, sessionId);
 
@@ -900,6 +899,7 @@ export class ChatSessionService {
         resumableSubagents,
         cliSessions,
         activated,
+        ...(staleSnapshot ? { staleSnapshot } : {}),
         ...(activationError ? { activationError } : {}),
         ...(activationErrorCode ? { activationErrorCode } : {}),
       };

--- a/libs/backend/rpc-handlers/src/lib/handlers/session-lifecycle-notifier.spec.ts
+++ b/libs/backend/rpc-handlers/src/lib/handlers/session-lifecycle-notifier.spec.ts
@@ -150,6 +150,10 @@ describe('SessionLifecycleNotifier', () => {
     expect(calls[0].type).toBe(MESSAGE_TYPES.SESSION_COMPACTION_COMPLETE);
     const payload = calls[0].payload as SdkCompactionCompletePayload;
     expect(payload).toEqual(event);
+    expect(logger.info).toHaveBeenCalledWith(
+      '[SessionLifecycleNotifier] Broadcasting PostCompact advisory',
+      { sessionId: event.sessionId, trigger: event.trigger },
+    );
   });
 
   it('drops a malformed payload (Zod validation) and logs a warning', () => {

--- a/libs/backend/rpc-handlers/src/lib/handlers/session-lifecycle-notifier.ts
+++ b/libs/backend/rpc-handlers/src/lib/handlers/session-lifecycle-notifier.ts
@@ -99,6 +99,10 @@ export class SessionLifecycleNotifier {
       return;
     }
     const payload: SdkCompactionCompletePayload = parsed.data;
+    this.logger.info('[SessionLifecycleNotifier] Broadcasting PostCompact advisory', {
+      sessionId: payload.sessionId,
+      trigger: payload.trigger,
+    });
     this.webviewManager
       .broadcastMessage(MESSAGE_TYPES.SESSION_COMPACTION_COMPLETE, payload)
       .catch((err: unknown) => {

--- a/libs/frontend/chat-state/src/lib/tab-manager.intent-mutators.spec.ts
+++ b/libs/frontend/chat-state/src/lib/tab-manager.intent-mutators.spec.ts
@@ -701,21 +701,11 @@ describe('TabManagerService — intent-named mutators', () => {
   });
 
   describe('compaction', () => {
-    it('markCompactionStart/clearCompactingFlag toggle isCompacting', () => {
-      const id = service.createTab('compact');
-      service.markCompactionStart(id);
-      expect(service.tabs().find((t) => t.id === id)?.isCompacting).toBe(true);
-      service.clearCompactingFlag(id);
-      expect(service.tabs().find((t) => t.id === id)?.isCompacting).toBe(false);
-    });
-
     it('applyCompactionTimeoutReset clears state machine', () => {
       const id = service.createTab('timeout');
-      service.markCompactionStart(id);
       service.setStreamingState(id, createEmptyStreamingState());
       service.applyCompactionTimeoutReset(id);
       const tab = service.tabs().find((t) => t.id === id);
-      expect(tab?.isCompacting).toBe(false);
       expect(tab?.streamingState).toBeNull();
       expect(tab?.status).toBe('loaded');
     });

--- a/libs/frontend/chat-state/src/lib/tab-manager.lifecycle.spec.ts
+++ b/libs/frontend/chat-state/src/lib/tab-manager.lifecycle.spec.ts
@@ -84,7 +84,6 @@ describe('TabManagerService — tab lifecycle + selectors', () => {
       expect(service.activeTabPreloadedStats()).toBeNull();
       expect(service.activeTabLiveModelStats()).toBeNull();
       expect(service.activeTabModelUsageList()).toBeNull();
-      expect(service.activeTabIsCompacting()).toBe(false);
       expect(service.activeTabCompactionCount()).toBe(0);
       expect(service.activeTabViewMode()).toBe('full');
       expect(service.activeTabQueuedContent()).toBeNull();
@@ -99,10 +98,8 @@ describe('TabManagerService — tab lifecycle + selectors', () => {
         contextPercent: 50,
       });
       service.setQueuedContent(id, 'queued');
-      service.markCompactionStart(id);
       expect(service.activeTabLiveModelStats()?.model).toBe('m');
       expect(service.activeTabQueuedContent()).toBe('queued');
-      expect(service.activeTabIsCompacting()).toBe(true);
     });
   });
 
@@ -168,7 +165,6 @@ describe('TabManagerService — tab lifecycle + selectors', () => {
         contextPercent: 50,
       });
       service.setQueuedContent(id, 'queued');
-      service.markCompactionStart(id);
 
       service.resetTabToFresh(id);
 
@@ -182,7 +178,6 @@ describe('TabManagerService — tab lifecycle + selectors', () => {
       expect(tab?.liveModelStats ?? null).toBeNull();
       expect(service.isTabStreaming(id)).toBe(false);
       expect(service.activeTabQueuedContent()).toBeNull();
-      expect(service.activeTabIsCompacting()).toBe(false);
       expect(partition.unregisterSession).toHaveBeenCalledWith(SESS_X);
 
       const evt = service.closedTab();

--- a/libs/frontend/chat-state/src/lib/tab-manager.service.spec.ts
+++ b/libs/frontend/chat-state/src/lib/tab-manager.service.spec.ts
@@ -131,14 +131,14 @@ describe('TabManagerService — abort streaming on tab close (Wave E2)', () => {
       service.setLiveModelStatsAndUsageList(
         tabId,
         {
-          model: 'opus',
+          model: 'claude-sonnet-4-5',
           contextUsed: 1234,
           contextWindow: 200000,
           contextPercent: 0.6,
         },
         [
           {
-            model: 'opus',
+            model: 'claude-sonnet-4-5',
             inputTokens: 100,
             outputTokens: 50,
             contextWindow: 200000,
@@ -165,6 +165,194 @@ describe('TabManagerService — abort streaming on tab close (Wave E2)', () => {
       expect(after?.liveModelStats).toBeNull();
       expect(after?.modelUsageList).toEqual([]);
     });
+
+    it('seeds post-compaction context only for a tab with a known model', () => {
+      const tabId = service.createTab('compacting tab');
+      service.setLiveModelStats(tabId, {
+        model: 'claude-sonnet-4-5',
+        contextUsed: 1234,
+        contextWindow: 200000,
+        contextPercent: 0.6,
+      });
+
+      service.applyCompactionComplete(tabId, {
+        preloadedStats: null,
+        compactionCount: 1,
+        postCompactionContextTokens: 1200,
+      });
+
+      expect(service.tabs().find((tab) => tab.id === tabId)?.liveModelStats).toEqual({
+        model: 'claude-sonnet-4-5',
+        contextUsed: 1200,
+        contextWindow: 200000,
+        contextPercent: 0.6,
+      });
+    });
+
+    it.each([undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+      'does not synthesize context for an invalid post-compaction token value: %p',
+      (postCompactionContextTokens) => {
+        const tabId = service.createTab('compacting tab');
+        service.setLiveModelStats(tabId, {
+          model: 'claude-sonnet-4-5',
+          contextUsed: 1234,
+          contextWindow: 200000,
+          contextPercent: 0.6,
+        });
+
+        service.applyCompactionComplete(tabId, {
+          preloadedStats: null,
+          compactionCount: 1,
+          postCompactionContextTokens,
+        });
+
+        expect(
+          service.tabs().find((tab) => tab.id === tabId)?.liveModelStats,
+        ).toBeNull();
+      },
+    );
+
+    it('does not seed context for an unrecognized model with no usable window', () => {
+      const tabId = service.createTab('compacting tab');
+      service.setLiveModelStats(tabId, {
+        model: 'unrecognized-model',
+        contextUsed: 1234,
+        contextWindow: 200000,
+        contextPercent: 0.6,
+      });
+
+      service.applyCompactionComplete(tabId, {
+        preloadedStats: null,
+        compactionCount: 1,
+        postCompactionContextTokens: 1200,
+      });
+
+      expect(service.tabs().find((tab) => tab.id === tabId)?.liveModelStats).toBeNull();
+    });
+
+    it('does not seed context when the tab has no existing model', () => {
+      const tabId = service.createTab('compacting tab');
+
+      service.applyCompactionComplete(tabId, {
+        preloadedStats: null,
+        compactionCount: 1,
+        postCompactionContextTokens: 1200,
+      });
+
+      expect(service.tabs().find((tab) => tab.id === tabId)?.liveModelStats).toBeNull();
+    });
+
+    it('preserves cumulative preloaded stats while seeding only context', () => {
+      const tabId = service.createTab('compacting tab');
+      const preloadedStats = {
+        totalCost: 1.5,
+        tokens: { input: 100, output: 50, cacheRead: 25, cacheCreation: 10 },
+        messageCount: 3,
+      };
+      service.setLiveModelStats(tabId, {
+        model: 'claude-sonnet-4-5',
+        contextUsed: 1234,
+        contextWindow: 200000,
+        contextPercent: 0.6,
+      });
+
+      service.applyCompactionComplete(tabId, {
+        preloadedStats,
+        compactionCount: 1,
+        postCompactionContextTokens: 1200,
+      });
+
+      const tab = service.tabs().find((candidate) => candidate.id === tabId);
+      expect(tab?.preloadedStats).toEqual(preloadedStats);
+      expect(tab?.liveModelStats?.contextUsed).toBe(1200);
+    });
+
+    it('keeps context seeds isolated to the completed tab and lets live usage replace it', () => {
+      const compactedTabId = service.createTab('compacted tab');
+      const otherTabId = service.createTab('other tab');
+      service.setLiveModelStats(compactedTabId, {
+        model: 'claude-sonnet-4-5',
+        contextUsed: 1234,
+        contextWindow: 200000,
+        contextPercent: 0.6,
+      });
+      service.setLiveModelStats(otherTabId, {
+        model: 'claude-sonnet-4-5',
+        contextUsed: 5678,
+        contextWindow: 200000,
+        contextPercent: 2.8,
+      });
+
+      service.applyCompactionComplete(compactedTabId, {
+        preloadedStats: null,
+        compactionCount: 1,
+        postCompactionContextTokens: 1200,
+      });
+      service.setLiveModelStats(compactedTabId, {
+        model: 'claude-sonnet-4-5',
+        contextUsed: 1400,
+        contextWindow: 200000,
+        contextPercent: 0.7,
+      });
+
+      expect(
+        service.tabs().find((tab) => tab.id === compactedTabId)?.liveModelStats,
+      ).toEqual({
+        model: 'claude-sonnet-4-5',
+        contextUsed: 1400,
+        contextWindow: 200000,
+        contextPercent: 0.7,
+      });
+      expect(service.tabs().find((tab) => tab.id === otherTabId)?.liveModelStats)
+        .toEqual({
+          model: 'claude-sonnet-4-5',
+          contextUsed: 5678,
+          contextWindow: 200000,
+          contextPercent: 2.8,
+        });
+    });
+
+    it('seeds verified late boundary context without resetting messages or compaction count', () => {
+      const tabId = service.createTab('compacted tab');
+      service.setLiveModelStats(tabId, {
+        model: 'claude-sonnet-4-5',
+        contextUsed: 1234,
+        contextWindow: 200000,
+        contextPercent: 0.6,
+      });
+      const messagesBefore = service.tabs().find(
+        (candidate) => candidate.id === tabId,
+      )?.messages;
+
+      service.seedPostCompactionContext(tabId, 1600);
+
+      const tab = service.tabs().find((candidate) => candidate.id === tabId);
+      expect(tab?.messages).toBe(messagesBefore);
+      expect(tab?.compactionCount).toBeUndefined();
+      expect(tab?.liveModelStats).toEqual({
+        model: 'claude-sonnet-4-5',
+        contextUsed: 1600,
+        contextWindow: 200000,
+        contextPercent: 0.8,
+      });
+    });
+
+    it.each([undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+      'does not seed late boundary context for invalid token value: %p',
+      (postTokens) => {
+        const tabId = service.createTab('compacted tab');
+        service.setLiveModelStats(tabId, {
+          model: 'claude-sonnet-4-5',
+          contextUsed: 1234,
+          contextWindow: 200000,
+          contextPercent: 0.6,
+        });
+
+        service.seedPostCompactionContext(tabId, postTokens);
+
+        expect(service.tabs().find((tab) => tab.id === tabId)?.liveModelStats).toBeNull();
+      },
+    );
 
     it('B3 — stamps lastCompactionAt at completion time', () => {
       const tabId = service.createTab('compacting tab');

--- a/libs/frontend/chat-state/src/lib/tab-manager.service.spec.ts
+++ b/libs/frontend/chat-state/src/lib/tab-manager.service.spec.ts
@@ -212,13 +212,41 @@ describe('TabManagerService — abort streaming on tab close (Wave E2)', () => {
       },
     );
 
-    it('does not seed context for an unrecognized model with no usable window', () => {
+    it('retains the prior finite positive context window for an unrecognized model', () => {
+      // PR #493 review C: a proxied Codex model id (gpt-5.6-sol) is not in the
+      // pricing registry, so getModelContextWindow returns 0 — the tab's own
+      // prior window must keep the gauge alive instead of clearing it.
+      const tabId = service.createTab('compacting tab');
+      service.setLiveModelStats(tabId, {
+        model: 'gpt-5.6-sol',
+        contextUsed: 1234,
+        contextWindow: 200000,
+        contextPercent: 0.6,
+      });
+
+      service.applyCompactionComplete(tabId, {
+        preloadedStats: null,
+        compactionCount: 1,
+        postCompactionContextTokens: 1200,
+      });
+
+      expect(
+        service.tabs().find((tab) => tab.id === tabId)?.liveModelStats,
+      ).toEqual({
+        model: 'gpt-5.6-sol',
+        contextUsed: 1200,
+        contextWindow: 200000,
+        contextPercent: 0.6,
+      });
+    });
+
+    it('does not seed context when neither the prior window nor the model registry provides one', () => {
       const tabId = service.createTab('compacting tab');
       service.setLiveModelStats(tabId, {
         model: 'unrecognized-model',
         contextUsed: 1234,
-        contextWindow: 200000,
-        contextPercent: 0.6,
+        contextWindow: 0,
+        contextPercent: 0,
       });
 
       service.applyCompactionComplete(tabId, {

--- a/libs/frontend/chat-state/src/lib/tab-manager.service.ts
+++ b/libs/frontend/chat-state/src/lib/tab-manager.service.ts
@@ -347,14 +347,6 @@ export class TabManagerService {
     { equal: (a, b) => a === b },
   );
 
-  /** Whether compaction is in progress for the active tab. */
-  readonly activeTabIsCompacting = computed(
-    () =>
-      this._tabs().find((t) => t.id === this._activeTabId())?.isCompacting ??
-      false,
-    { equal: (a, b) => a === b },
-  );
-
   /** Compaction count. Rarely changes. */
   readonly activeTabCompactionCount = computed(
     () =>
@@ -984,7 +976,6 @@ export class TabManagerService {
       liveModelStats: null,
       modelUsageList: undefined,
       hasLiveSession: false,
-      isCompacting: false,
       compactionCount: 0,
       lastCompactionAt: null,
       lastTerminalReason: undefined,
@@ -1750,24 +1741,13 @@ export class TabManagerService {
 
   // ----- Compaction -----
 
-  /** Mark compaction in progress for the tab. */
-  markCompactionStart(tabId: string): void {
-    this.updateTabInternal(tabId, { isCompacting: true });
-  }
-
-  /** Clear the per-tab `isCompacting` flag (no other state touched). */
-  clearCompactingFlag(tabId: string): void {
-    this.updateTabInternal(tabId, { isCompacting: false });
-  }
-
   /**
-   * Apply the compaction-safety-timeout reset: clear isCompacting and reset
-   * the streaming state machine so a stuck compaction banner doesn't leave
-   * the tab in a non-recoverable state.
+   * Apply the compaction-safety-timeout reset: reset the streaming state
+   * machine so a stuck compaction doesn't leave the tab in a non-recoverable
+   * state. Compaction in-flight state itself lives in `ConversationRegistry`.
    */
   applyCompactionTimeoutReset(tabId: string): void {
     this.updateTabInternal(tabId, {
-      isCompacting: false,
       status: 'loaded',
       streamingState: null,
       currentMessageId: null,
@@ -2020,7 +2000,6 @@ export class TabManagerService {
       preloadedStats: null,
       liveModelStats: null,
       modelUsageList: [],
-      isCompacting: false,
       compactionCount: 0,
     });
 

--- a/libs/frontend/chat-state/src/lib/tab-manager.service.ts
+++ b/libs/frontend/chat-state/src/lib/tab-manager.service.ts
@@ -1775,6 +1775,17 @@ export class TabManagerService {
   }
 
   /**
+   * Seed a verified post-compaction context usage value without touching
+   * transcript, reload, compaction count, or any other tab state.
+   */
+  seedPostCompactionContext(tabId: string, postTokens: number | undefined): void {
+    const tab = this.tabs().find((candidate) => candidate.id === tabId);
+    this.updateTabInternal(tabId, {
+      liveModelStats: this.postCompactionContextStats(tab?.liveModelStats, postTokens),
+    });
+  }
+
+  /**
    * Apply the post-compaction reload state: clear messages, install the
    * snapshot preloadedStats, increment compactionCount, reset streaming
    * state machine, and drop any queued message so the next user input is
@@ -1785,8 +1796,15 @@ export class TabManagerService {
     payload: {
       preloadedStats: PreloadedStatsPayload | null | undefined;
       compactionCount: number;
+      postCompactionContextTokens?: number;
     },
   ): void {
+    const tab = this.tabs().find((candidate) => candidate.id === tabId);
+    const liveModelStats = this.postCompactionContextStats(
+      tab?.liveModelStats,
+      payload.postCompactionContextTokens,
+    );
+
     this.updateTabInternal(tabId, {
       messages: [],
       preloadedStats: payload.preloadedStats,
@@ -1800,9 +1818,35 @@ export class TabManagerService {
       currentMessageId: null,
       queuedContent: null,
       queuedOptions: null,
-      liveModelStats: null,
+      liveModelStats,
       modelUsageList: [],
     });
+  }
+
+  private postCompactionContextStats(
+    priorLiveStats: LiveModelStatsPayload | null | undefined,
+    postTokens: number | undefined,
+  ): LiveModelStatsPayload | null {
+    const contextWindow = priorLiveStats
+      ? getModelContextWindow(priorLiveStats.model)
+      : 0;
+    if (
+      typeof postTokens !== 'number' ||
+      !Number.isFinite(postTokens) ||
+      postTokens <= 0 ||
+      priorLiveStats == null ||
+      priorLiveStats.model.length === 0 ||
+      !Number.isFinite(contextWindow) ||
+      contextWindow <= 0
+    ) {
+      return null;
+    }
+    return {
+      model: priorLiveStats.model,
+      contextUsed: postTokens,
+      contextWindow,
+      contextPercent: Math.round((postTokens / contextWindow) * 1000) / 10,
+    };
   }
 
   /**

--- a/libs/frontend/chat-state/src/lib/tab-manager.service.ts
+++ b/libs/frontend/chat-state/src/lib/tab-manager.service.ts
@@ -1827,18 +1827,25 @@ export class TabManagerService {
     priorLiveStats: LiveModelStatsPayload | null | undefined,
     postTokens: number | undefined,
   ): LiveModelStatsPayload | null {
-    const contextWindow = priorLiveStats
-      ? getModelContextWindow(priorLiveStats.model)
-      : 0;
     if (
       typeof postTokens !== 'number' ||
       !Number.isFinite(postTokens) ||
       postTokens <= 0 ||
       priorLiveStats == null ||
-      priorLiveStats.model.length === 0 ||
-      !Number.isFinite(contextWindow) ||
-      contextWindow <= 0
+      priorLiveStats.model.length === 0
     ) {
+      return null;
+    }
+    // The prior finite positive window wins over the pricing lookup: for a
+    // model the registry does not recognize (proxied Codex ids such as
+    // gpt-5.6-sol), falling back to getModelContextWindow would return 0 and
+    // clear the context gauge even though the tab carried a usable window.
+    const priorWindow = priorLiveStats.contextWindow;
+    const contextWindow =
+      Number.isFinite(priorWindow) && priorWindow > 0
+        ? priorWindow
+        : getModelContextWindow(priorLiveStats.model);
+    if (!Number.isFinite(contextWindow) || contextWindow <= 0) {
       return null;
     }
     return {

--- a/libs/frontend/chat-types/src/lib/chat-types.ts
+++ b/libs/frontend/chat-types/src/lib/chat-types.ts
@@ -639,12 +639,6 @@ export interface TabState {
   viewMode?: TabViewMode;
 
   /**
-   * Whether context compaction is currently in progress for this tab.
-   * Set to true on compaction_start, cleared on compaction_complete or error.
-   */
-  isCompacting?: boolean;
-
-  /**
    * Number of context compactions that occurred during this session.
    * Incremented on each compaction_complete event.
    */

--- a/libs/frontend/chat-ui/src/lib/molecules/notifications/compaction-marker.component.spec.ts
+++ b/libs/frontend/chat-ui/src/lib/molecules/notifications/compaction-marker.component.spec.ts
@@ -65,17 +65,26 @@ describe('CompactionMarkerComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('Context compacted');
   });
 
-  it('renders the token-reduction line only when both counts are present', () => {
+  it('uses "shrank" only when context tokens decrease', () => {
     const fixture = setup({ preTokens: 5000, postTokens: 1200 });
     const text = fixture.nativeElement.textContent as string;
-    expect(text).toContain('shrank');
-    expect(text).toContain('5,000');
-    expect(text).toContain('1,200');
+    expect(text).toContain('shrank 5,000 → 1,200 tokens');
   });
 
-  it('omits the token line when only one count is present', () => {
+  it.each([
+    [1200, 1200],
+    [1200, 5000],
+  ])('uses neutral wording for non-shrinking values: %i → %i', (pre, post) => {
+    const fixture = setup({ preTokens: pre, postTokens: post });
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain(`${pre.toLocaleString()} → ${post.toLocaleString()} tokens`);
+    expect(text).not.toContain('shrank');
+  });
+
+  it('omits the token line when either endpoint is null', () => {
     const fixture = setup({ preTokens: 5000, postTokens: null });
     expect(fixture.nativeElement.textContent).not.toContain('shrank');
+    expect(fixture.nativeElement.textContent).not.toContain('5,000 →');
   });
 
   it('appends duration only when durationMs is present', () => {

--- a/libs/frontend/chat-ui/src/lib/molecules/notifications/compaction-marker.component.ts
+++ b/libs/frontend/chat-ui/src/lib/molecules/notifications/compaction-marker.component.ts
@@ -98,7 +98,8 @@ export class CompactionMarkerComponent {
     const pre = this.preTokens();
     const post = this.postTokens();
     if (pre === null || post === null) return null;
-    const base = `shrank ${this.format(pre)} → ${this.format(post)} tokens`;
+    const prefix = pre > post ? 'shrank ' : '';
+    const base = `${prefix}${this.format(pre)} → ${this.format(post)} tokens`;
     const ms = this.durationMs();
     if (ms === null) return base;
     return `${base} in ${this.formatDuration(ms)}`;

--- a/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.spec.ts
+++ b/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.spec.ts
@@ -66,6 +66,18 @@ import {
 } from '@ptah-extension/core';
 import { VoiceInputService } from '../../../services/voice-input.service';
 import type { AtTriggerEvent } from '../../../directives/at-trigger.directive';
+import { SESSION_CONTEXT } from '../../../tokens/session-context.token';
+import { CompactionLifecycleService } from '../../../services/chat-store/compaction-lifecycle.service';
+import { SessionLoaderService } from '../../../services/chat-store/session-loader.service';
+import {
+  ConversationRegistry,
+  TabSessionBinding,
+} from '@ptah-extension/chat-state';
+import {
+  ExecutionTreeBuilderService,
+  SessionManager,
+} from '@ptah-extension/chat-streaming';
+import { SessionId, TabId as SharedTabId } from '@ptah-extension/shared';
 
 describe('ChatInputComponent', () => {
   let component: ChatInputComponent;
@@ -79,6 +91,9 @@ describe('ChatInputComponent', () => {
     sendOrQueueMessage: jest.fn().mockResolvedValue(undefined),
     abortCurrentMessage: jest.fn().mockResolvedValue(undefined),
     abortWithConfirmation: jest.fn().mockResolvedValue(true),
+    isCompactingForTab: jest.fn(
+      (_tabId: string | null | undefined): boolean => false,
+    ),
   };
 
   const tabsSignal = signal<
@@ -153,7 +168,13 @@ describe('ChatInputComponent', () => {
     cancelRecording: jest.fn(),
   };
 
-  function createComponent(opts: { isElectron?: boolean } = {}): void {
+  function createComponent(
+    opts: {
+      isElectron?: boolean;
+      /** Tile tab id for SESSION_CONTEXT; `undefined` = token not provided. */
+      sessionContextTabId?: string | null;
+    } = {},
+  ): void {
     mockIsElectron = opts.isElectron ?? false;
     tabsSignal.set([]);
     activeTabIdSignal.set(null);
@@ -168,6 +189,16 @@ describe('ChatInputComponent', () => {
         { provide: ClaudeRpcService, useValue: mockRpcService },
         { provide: VSCodeService, useValue: mockVSCodeService },
         { provide: VoiceInputService, useValue: mockVoiceInput },
+        ...(opts.sessionContextTabId === undefined
+          ? []
+          : [
+              {
+                provide: SESSION_CONTEXT,
+                useValue: signal<string | null>(
+                  opts.sessionContextTabId,
+                ).asReadonly(),
+              },
+            ]),
       ],
     });
 
@@ -188,6 +219,183 @@ describe('ChatInputComponent', () => {
 
   it('should be created', () => {
     expect(component).toBeTruthy();
+  });
+
+  // ============================================================================
+  // COMPACTION OVERLAY — one registry derivation shared with the chat-view banner
+  // ============================================================================
+
+  describe('compaction overlay (registry-derived)', () => {
+    afterEach(() => {
+      mockChatStore.isCompactingForTab.mockImplementation(() => false);
+    });
+
+    it('uses chatStore.isCompactingForTab with the SESSION_CONTEXT tab id', () => {
+      createComponent({ sessionContextTabId: 'tile-A' });
+      activeTabIdSignal.set('tab-global');
+      mockChatStore.isCompactingForTab.mockImplementation(
+        (id) => id === 'tile-A',
+      );
+      expect(component.resolvedIsCompacting()).toBe(true);
+      expect(mockChatStore.isCompactingForTab).toHaveBeenCalledWith('tile-A');
+    });
+
+    it('uses the active tab id without SESSION_CONTEXT', () => {
+      createComponent();
+      activeTabIdSignal.set('tab-global');
+      mockChatStore.isCompactingForTab.mockImplementation(
+        (id) => id === 'tab-global',
+      );
+      expect(component.resolvedIsCompacting()).toBe(true);
+      expect(mockChatStore.isCompactingForTab).toHaveBeenCalledWith(
+        'tab-global',
+      );
+    });
+
+    it('returns false when SESSION_CONTEXT resolves null', () => {
+      createComponent({ sessionContextTabId: null });
+      activeTabIdSignal.set('tab-global');
+      mockChatStore.isCompactingForTab.mockImplementation((id) => id != null);
+      expect(component.resolvedIsCompacting()).toBe(false);
+      expect(mockChatStore.isCompactingForTab).toHaveBeenCalledWith(null);
+    });
+
+    it('ignores a stale tab.isCompacting=true when the registry says not in flight', () => {
+      createComponent();
+      tabsSignal.set([
+        { id: 'tab-global', status: 'loaded', isCompacting: true } as {
+          id: string;
+          status: string;
+        },
+      ]);
+      activeTabIdSignal.set('tab-global');
+      mockChatStore.isCompactingForTab.mockReturnValue(false);
+      expect(component.resolvedIsCompacting()).toBe(false);
+    });
+  });
+
+  describe('compaction overlay and banner agree (real registries)', () => {
+    const TAB = SharedTabId.create();
+    const SESS = SessionId.create();
+    let lifecycle: CompactionLifecycleService;
+    let switchSession: jest.Mock;
+    const activeTab = signal<string | null>(TAB);
+
+    /** chat-view's banner reads exactly this (see chat-view spec delegation). */
+    const banner = (): boolean =>
+      TestBed.inject(ChatStore).isCompactingForTab(activeTab());
+
+    async function flushMicrotasks(): Promise<void> {
+      for (let i = 0; i < 10; i += 1) await Promise.resolve();
+    }
+
+    let consoleSpies: jest.SpyInstance[] = [];
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      consoleSpies = [
+        jest.spyOn(console, 'info').mockImplementation(),
+        jest.spyOn(console, 'warn').mockImplementation(),
+      ];
+      const tabs = [
+        { id: TAB, status: 'loaded', claudeSessionId: SESS, messages: [] },
+      ];
+      switchSession = jest.fn().mockResolvedValue(undefined);
+      const tabManager = {
+        ...mockTabManager,
+        activeTabId: activeTab,
+        tabs: () => tabs,
+        findTabsBySessionId: (sessionId: string) =>
+          tabs.filter((t) => t.claudeSessionId === sessionId),
+        applyCompactionComplete: jest.fn(),
+        applyCompactionTimeoutReset: jest.fn(),
+        seedPostCompactionContext: jest.fn(),
+        markTabIdle: jest.fn(),
+      };
+      const chatStore = {
+        ...mockChatStore,
+        isCompactingForTab: (id: string | null | undefined) =>
+          TestBed.inject(CompactionLifecycleService).isCompactingForTab(id),
+      };
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: ChatStore, useValue: chatStore },
+          { provide: TabManagerService, useValue: tabManager },
+          { provide: AutopilotStateService, useValue: mockAutopilotState },
+          { provide: FilePickerService, useValue: mockFilePicker },
+          { provide: CommandDiscoveryFacade, useValue: mockCommandDiscovery },
+          { provide: ClaudeRpcService, useValue: mockRpcService },
+          { provide: VSCodeService, useValue: mockVSCodeService },
+          { provide: VoiceInputService, useValue: mockVoiceInput },
+          CompactionLifecycleService,
+          ConversationRegistry,
+          TabSessionBinding,
+          {
+            provide: SessionManager,
+            useValue: { setStatus: jest.fn(), getCurrentSessionId: () => null },
+          },
+          {
+            provide: ExecutionTreeBuilderService,
+            useValue: { clearCache: jest.fn() },
+          },
+          { provide: SessionLoaderService, useValue: { switchSession } },
+        ],
+      });
+      lifecycle = TestBed.inject(CompactionLifecycleService);
+      component = TestBed.runInInjectionContext(() => new ChatInputComponent());
+    });
+
+    afterEach(() => {
+      lifecycle.clearCompactionState();
+      jest.useRealTimers();
+      for (const spy of consoleSpies) spy.mockRestore();
+    });
+
+    it('agree through start and authoritative completion', async () => {
+      expect(component.resolvedIsCompacting()).toBe(false);
+      expect(banner()).toBe(false);
+
+      lifecycle.handleCompactionStart(SESS);
+      expect(component.resolvedIsCompacting()).toBe(true);
+      expect(banner()).toBe(true);
+
+      lifecycle.handleCompactionComplete({
+        tabId: TAB,
+        compactionSessionId: SESS,
+        postTokens: 500,
+      });
+      await flushMicrotasks();
+      expect(component.resolvedIsCompacting()).toBe(false);
+      expect(banner()).toBe(false);
+    });
+
+    it('agree through the PostCompact advisory fallback', async () => {
+      lifecycle.handleCompactionStart(SESS);
+      expect(component.resolvedIsCompacting()).toBe(banner());
+      lifecycle.handleCompactionCompleteNotification({
+        sessionId: SESS,
+        cwd: '/workspace',
+        trigger: 'auto',
+        compactSummary: 'recap',
+        timestamp: 1_700_000_000_000,
+      });
+      expect(component.resolvedIsCompacting()).toBe(banner());
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks();
+      expect(switchSession).toHaveBeenCalledTimes(1);
+      expect(component.resolvedIsCompacting()).toBe(false);
+      expect(banner()).toBe(false);
+    });
+
+    it('agree through the safety timeout', () => {
+      lifecycle.handleCompactionStart(SESS);
+      expect(component.resolvedIsCompacting()).toBe(true);
+      expect(banner()).toBe(true);
+      jest.advanceTimersByTime(600000);
+      expect(component.resolvedIsCompacting()).toBe(false);
+      expect(banner()).toBe(false);
+    });
   });
 
   // ============================================================================

--- a/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.ts
+++ b/libs/frontend/chat/src/lib/components/molecules/chat-input/chat-input.component.ts
@@ -506,21 +506,18 @@ export class ChatInputComponent implements OnInit {
   readonly attachedReadOnly = computed(() => this.attachedBinding() != null);
 
   /**
-   * Per-tab compaction state. In canvas mode, scoped to this tile's tab.
-   * Prevents compaction overlay from showing on ALL tiles.
+   * Per-tab compaction state. In canvas mode, scoped to this tile's tab
+   * (a tile whose SESSION_CONTEXT resolves null shows no overlay); otherwise
+   * the global active tab. Reads the SAME registry derivation as the
+   * chat-view banner, so the overlay and banner always agree.
    */
-  readonly resolvedIsCompacting = computed(() => {
-    const ctx = this._sessionContext;
-    if (ctx) {
-      const tabId = ctx();
-      if (!tabId) return false;
-      return (
-        this.tabManager.tabs().find((t) => t.id === tabId)?.isCompacting ??
-        false
-      );
-    }
-    return this.chatStore.isCompacting();
-  });
+  readonly resolvedIsCompacting = computed(() =>
+    this.chatStore.isCompactingForTab(
+      this._sessionContext
+        ? this._sessionContext()
+        : this.tabManager.activeTabId(),
+    ),
+  );
   private readonly textareaRef =
     viewChild<ElementRef<HTMLTextAreaElement>>('inputElement');
 

--- a/libs/frontend/chat/src/lib/components/templates/chat-view.component.spec.ts
+++ b/libs/frontend/chat/src/lib/components/templates/chat-view.component.spec.ts
@@ -173,7 +173,11 @@ function makeHarness(
   const switchSessionMock = jest.fn().mockResolvedValue(undefined);
   const upsertSessionSummaryMock = jest.fn();
   const removeSessionFromListMock = jest.fn();
+  const isCompactingForTabMock = jest.fn(
+    (_tabId: string | null | undefined): boolean => false,
+  );
   const chatStoreStub = {
+    isCompactingForTab: isCompactingForTabMock,
     currentSessionId: sessionIdSig.asReadonly(),
     sessionIsActive: sessionIsActiveSig.asReadonly(),
     // Other signals required by computed() inside the component
@@ -399,8 +403,29 @@ function makeHarness(
     activeTabIdSig,
     sessionVisibleSig,
     resumableSubagentsSig,
+    isCompactingForTabMock,
   };
 }
+
+describe('ChatViewComponent — compaction banner source', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    jest.clearAllMocks();
+  });
+
+  it('resolvedIsCompacting delegates to chatStore.isCompactingForTab with the resolved tab id', () => {
+    const h = makeHarness();
+    h.isCompactingForTabMock.mockImplementation((id) => id === 'tab-abc');
+    expect(h.component.resolvedIsCompacting()).toBe(true);
+    expect(h.isCompactingForTabMock).toHaveBeenCalledWith('tab-abc');
+  });
+
+  it('reports no banner when the shared derivation says the tab is not compacting', () => {
+    const h = makeHarness();
+    h.isCompactingForTabMock.mockReturnValue(false);
+    expect(h.component.resolvedIsCompacting()).toBe(false);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Test suite

--- a/libs/frontend/chat/src/lib/components/templates/chat-view.component.spec.ts
+++ b/libs/frontend/chat/src/lib/components/templates/chat-view.component.spec.ts
@@ -425,6 +425,20 @@ describe('ChatViewComponent — compaction banner source', () => {
     h.isCompactingForTabMock.mockReturnValue(false);
     expect(h.component.resolvedIsCompacting()).toBe(false);
   });
+
+  it('a tile whose SESSION_CONTEXT tab id is absent from tabs() asks about ITS id, not the active tab', () => {
+    // PR #493 review C: the banner derived its id from `resolvedTab()`, which
+    // is null for a context tab id missing from `tabs()` — a tile still
+    // resolving, or one whose tab just closed — and fell back to the GLOBAL
+    // active tab. ChatInputComponent reads the context id, so the banner and
+    // the input overlay could report different compaction states.
+    const h = makeHarness({ sessionContextTabId: 'tile-unknown' });
+    h.isCompactingForTabMock.mockImplementation((id) => id === 'tab-abc');
+
+    expect(h.component.resolvedIsCompacting()).toBe(false);
+    expect(h.isCompactingForTabMock).toHaveBeenCalledWith('tile-unknown');
+    expect(h.isCompactingForTabMock).not.toHaveBeenCalledWith('tab-abc');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/libs/frontend/chat/src/lib/components/templates/chat-view.component.ts
+++ b/libs/frontend/chat/src/lib/components/templates/chat-view.component.ts
@@ -665,16 +665,22 @@ export class ChatViewComponent implements OnDestroy {
    * overlay uses, so banner and overlay cannot disagree. Unresolved
    * conversations simply render no banner, which is the correct state for an
    * unrouted tab.
+   *
+   * Scoped by `resolvedTabId()`, the same derivation
+   * `ChatInputComponent.resolvedIsCompacting` uses. Deriving the id from
+   * `resolvedTab()` instead fell back to the GLOBAL active tab whenever
+   * SESSION_CONTEXT held a tab id absent from `tabs()` — a tile still
+   * resolving, or one whose tab had just closed — so the banner reported the
+   * active tab's compaction while the overlay reported the tile's
+   * (PR #493 review C).
    */
   readonly resolvedIsCompacting = computed(() =>
-    this.chatStore.isCompactingForTab(
-      this.resolvedTab()?.id ?? this._tabManager.activeTabId(),
-    ),
+    this.chatStore.isCompactingForTab(this.resolvedTabId()),
   );
 
+  /** Same tab scope as the banner above — the two must never disagree. */
   readonly resolvedCompactionMarker = computed(() => {
-    const tab = this.resolvedTab();
-    const rawTabId = tab?.id ?? this._tabManager.activeTabId();
+    const rawTabId = this.resolvedTabId();
     if (!rawTabId) return null;
     const tabId = TabId.safeParse(rawTabId);
     if (!tabId) return null;

--- a/libs/frontend/chat/src/lib/components/templates/chat-view.component.ts
+++ b/libs/frontend/chat/src/lib/components/templates/chat-view.component.ts
@@ -660,27 +660,17 @@ export class ChatViewComponent implements OnDestroy {
    * is conversation-scoped, so every tab bound to the conversation sees the
    * banner together (canvas-grid).
    *
-   * Reads ONLY from the conversation registry. The previous fallback to
-   * `tab.isCompacting` / `chatStore.isCompacting()` created a second source
-   * of truth: when StreamRouter had not yet registered the conversation by
-   * `compaction_complete` time, the registry stayed `inFlight=true` while
-   * the tab cleared (or vice versa) and the banner stuck on the 120s safety
-   * timeout. The lifecycle service now writes through the registry on every
-   * transition, so unresolved conversations simply render no banner — which
-   * is the correct state for an unrouted tab.
+   * Reads ONLY from the conversation registry, through
+   * `ChatStore.isCompactingForTab` — the same derivation the chat-input
+   * overlay uses, so banner and overlay cannot disagree. Unresolved
+   * conversations simply render no banner, which is the correct state for an
+   * unrouted tab.
    */
-  readonly resolvedIsCompacting = computed(() => {
-    const tab = this.resolvedTab();
-    const rawTabId = tab?.id ?? this._tabManager.activeTabId();
-    if (!rawTabId) return false;
-    const tabId = TabId.safeParse(rawTabId);
-    if (!tabId) return false;
-    const convId = this._tabSessionBinding.conversationFor(tabId);
-    if (!convId) return false;
-    return (
-      this._conversationRegistry.compactionStateFor(convId)?.inFlight ?? false
-    );
-  });
+  readonly resolvedIsCompacting = computed(() =>
+    this.chatStore.isCompactingForTab(
+      this.resolvedTab()?.id ?? this._tabManager.activeTabId(),
+    ),
+  );
 
   readonly resolvedCompactionMarker = computed(() => {
     const tab = this.resolvedTab();

--- a/libs/frontend/chat/src/lib/components/templates/electron-shell.activity-toast.spec.ts
+++ b/libs/frontend/chat/src/lib/components/templates/electron-shell.activity-toast.spec.ts
@@ -177,7 +177,7 @@ describe('ElectronShellComponent — activity toast', () => {
     const classes = layer()?.getAttribute('class') ?? '';
 
     expect(classes).toContain('fixed');
-    expect(classes).toContain('top-6');
+    expect(classes).toContain('top-11');
     expect(classes).toContain('right-3');
     expect(classes).toContain('z-50');
   });

--- a/libs/frontend/chat/src/lib/components/templates/electron-shell.activity-toast.spec.ts
+++ b/libs/frontend/chat/src/lib/components/templates/electron-shell.activity-toast.spec.ts
@@ -177,7 +177,7 @@ describe('ElectronShellComponent — activity toast', () => {
     const classes = layer()?.getAttribute('class') ?? '';
 
     expect(classes).toContain('fixed');
-    expect(classes).toContain('top-11');
+    expect(classes).toContain('top-6');
     expect(classes).toContain('right-3');
     expect(classes).toContain('z-50');
   });

--- a/libs/frontend/chat/src/lib/services/chat-store/chat-lifecycle.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/chat-lifecycle.service.spec.ts
@@ -79,7 +79,6 @@ function makeTab(overrides: Partial<TabState> = {}): TabState {
     streamingState: null,
     currentMessageId: null,
     claudeSessionId: SESS_1,
-    isCompacting: false,
     queuedContent: null,
     queuedOptions: null,
     ...overrides,

--- a/libs/frontend/chat/src/lib/services/chat-store/compaction-advisory-correlator.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/compaction-advisory-correlator.service.ts
@@ -1,0 +1,323 @@
+import { Injectable, inject } from '@angular/core';
+import { SessionId } from '@ptah-extension/shared';
+import {
+  ConversationRegistry,
+  TabManagerService,
+  TabSessionBinding,
+  type ConversationId,
+  type TabId,
+} from '@ptah-extension/chat-state';
+import type { TabState } from '@ptah-extension/chat-types';
+
+/** The id a compaction's lifecycle state is stored under, plus its thread. */
+export interface CompactionLifecycleKey {
+  readonly key: SessionId;
+  readonly conversationId: ConversationId | null;
+}
+
+/**
+ * One PostCompact advisory. `key` is where the compaction's lifecycle state
+ * lives; `incomingSessionId` is the id the advisory arrived with. They differ
+ * after an SDK session rotation, which is the case this record exists for.
+ */
+export interface PostCompactAdvisory {
+  readonly originTabId: TabId;
+  readonly incomingSessionId: SessionId;
+  readonly conversationId: ConversationId | null;
+  readonly generation: number;
+  timeoutId: ReturnType<typeof setTimeout> | null;
+  fallbackApplied: boolean;
+  /** The fallback reload came back as an unverified (stale) snapshot. */
+  fallbackStale: boolean;
+  staleRetryTimeoutId: ReturnType<typeof setTimeout> | null;
+  staleRetryScheduled: boolean;
+}
+
+/**
+ * CompactionAdvisoryCorrelator — correlates the PostCompact advisory with the
+ * compaction it belongs to, across SDK session-id rotation.
+ *
+ * Extracted from `CompactionLifecycleService` (facade rule): the lifecycle
+ * keeps its public API and state machine; this collaborator owns the advisory
+ * records, the resolution of a replaceable session id to the id the lifecycle
+ * state is keyed by, the delayed fallback with its ownership re-check, and the
+ * single retry of a stale fallback snapshot.
+ *
+ * Why resolution is needed: timers, advisories and generations are keyed by
+ * the session id `compaction_start` carried. A tab can rotate to a new SDK id
+ * before PostCompact arrives, and PostCompact can carry either id. The
+ * conversation registry already relates every alias the router appended, so a
+ * compaction started under A and completed under B resolves to A's state.
+ */
+@Injectable({ providedIn: 'root' })
+export class CompactionAdvisoryCorrelator {
+  /**
+   * PostCompact is advisory: the SDK hook proves compaction finished, but only
+   * the streamed compact_boundary carries authoritative token metadata. Give
+   * that stream a short turn before recovering the visible transcript. The
+   * same wait spaces the one retry of a stale fallback snapshot.
+   */
+  static readonly POST_COMPACT_BOUNDARY_WAIT_MS = 250;
+  private static readonly MAX_POST_COMPACT_ADVISORY_SESSIONS = 256;
+
+  private readonly tabManager = inject(TabManagerService);
+  private readonly conversationRegistry = inject(ConversationRegistry);
+  private readonly tabSessionBinding = inject(TabSessionBinding);
+
+  private readonly advisories = new Map<SessionId, PostCompactAdvisory>();
+
+  /**
+   * Resolve the id a compaction's lifecycle state is keyed by. Pure read:
+   * never creates a binding or conversation.
+   *
+   * 1. `incoming` itself when it already owns advisory or lifecycle state;
+   * 2. otherwise another session of the same conversation that does;
+   * 3. otherwise `incoming`.
+   */
+  resolveLifecycleKey(
+    incoming: SessionId,
+    hasLifecycleState: (sessionId: SessionId) => boolean,
+  ): CompactionLifecycleKey {
+    const conversation = this.conversationOfSession(incoming);
+    const conversationId = conversation?.id ?? null;
+    const owns = (sessionId: SessionId): boolean =>
+      this.advisories.has(sessionId) || hasLifecycleState(sessionId);
+    if (owns(incoming)) return { key: incoming, conversationId };
+    const aliases = conversation ? [...conversation.sessions].reverse() : [];
+    for (const alias of aliases) {
+      if (alias !== incoming && owns(alias)) {
+        return { key: alias, conversationId };
+      }
+    }
+    return { key: incoming, conversationId };
+  }
+
+  /**
+   * Tabs a PostCompact advisory applies to: those owning the incoming id, then
+   * those owning the resolved key, then every tab bound to the conversation.
+   * Only an id unknown to every tab and conversation yields none.
+   */
+  tabsForCompaction(
+    lifecycle: CompactionLifecycleKey & { readonly incoming: SessionId },
+  ): readonly TabState[] {
+    const direct = this.tabManager.findTabsBySessionId(lifecycle.incoming);
+    if (direct.length > 0) return direct;
+    if (lifecycle.key !== lifecycle.incoming) {
+      const byKey = this.tabManager.findTabsBySessionId(lifecycle.key);
+      if (byKey.length > 0) return byKey;
+    }
+    if (!lifecycle.conversationId) return [];
+    const allTabs = this.tabManager.tabs();
+    return this.tabSessionBinding
+      .tabsFor(lifecycle.conversationId)
+      .map((tabId) => allTabs.find((tab) => tab.id === tabId))
+      .filter((tab): tab is TabState => tab != null);
+  }
+
+  /**
+   * The advisory's origin: the tab that owns the incoming id, else the first
+   * tab the compaction started on that still exists, else the first candidate.
+   */
+  originTabFor(
+    tabs: readonly TabState[],
+    incoming: SessionId,
+    startedTabIds: readonly TabId[],
+  ): TabId {
+    const owner = tabs.find((tab) => tab.claudeSessionId === incoming);
+    if (owner) return owner.id;
+    const survivor = startedTabIds.find((tabId) =>
+      tabs.some((tab) => tab.id === tabId),
+    );
+    return survivor ?? tabs[0].id;
+  }
+
+  has(key: SessionId): boolean {
+    return this.advisories.has(key);
+  }
+
+  get(key: SessionId): PostCompactAdvisory | undefined {
+    return this.advisories.get(key);
+  }
+
+  /** Drop a record and every timer it holds. */
+  delete(key: SessionId): void {
+    const advisory = this.advisories.get(key);
+    if (!advisory) return;
+    this.clearTimers(advisory);
+    this.advisories.delete(key);
+  }
+
+  clearAll(): void {
+    for (const advisory of this.advisories.values()) this.clearTimers(advisory);
+    this.advisories.clear();
+  }
+
+  /**
+   * Drop advisories `tabId` originated. The sweep keys off the record's own
+   * `originTabId`, not off the live tab list — a CLOSED tab is already gone
+   * from `tabs()`. A pending (timed) advisory dies with its tab; a
+   * `fallbackApplied` record survives only while another tab still owns the
+   * session, so a late boundary can merge its metrics there (PR #493 review D).
+   */
+  dropForTab(tabId: TabId): void {
+    for (const [key, advisory] of this.advisories) {
+      if (advisory.originTabId !== tabId) continue;
+      const pending = advisory.timeoutId !== null;
+      const stillOwnedElsewhere = this.tabManager
+        .findTabsBySessionId(advisory.incomingSessionId)
+        .some((candidate) => candidate.id !== tabId);
+      if (pending || !stillOwnedElsewhere) this.delete(key);
+    }
+  }
+
+  /**
+   * Arm the fallback: if no compact_boundary settles this compaction within
+   * the wait, re-check the origin's ownership and apply one targeted reload
+   * through `onFallback`. The record is retained afterwards so a late boundary
+   * can merge metrics without a second reload or count increment.
+   */
+  schedule(params: {
+    readonly key: SessionId;
+    readonly incoming: SessionId;
+    readonly conversationId: ConversationId | null;
+    readonly originTabId: TabId;
+    readonly generation: number;
+    readonly onFallback: (originTabId: TabId) => void;
+  }): void {
+    const advisory: PostCompactAdvisory = {
+      originTabId: params.originTabId,
+      incomingSessionId: params.incoming,
+      conversationId: params.conversationId,
+      generation: params.generation,
+      timeoutId: null,
+      fallbackApplied: false,
+      fallbackStale: false,
+      staleRetryTimeoutId: null,
+      staleRetryScheduled: false,
+    };
+    const timeoutId = setTimeout(() => {
+      if (this.advisories.get(params.key) !== advisory) return;
+      if (advisory.timeoutId !== timeoutId) return;
+      advisory.timeoutId = null;
+
+      // Re-read ownership immediately before fallback mutation. A closed tab,
+      // or one rebound to an unrelated conversation, is no longer an owner.
+      const origin = this.tabManager
+        .tabs()
+        .find((tab) => tab.id === advisory.originTabId);
+      if (!origin || !this.stillOwnsCompaction(origin, params.key, advisory)) {
+        this.advisories.delete(params.key);
+        console.info(
+          '[ChatStore] PostCompact advisory fallback skipped; originating tab no longer owns session',
+          { sessionId: advisory.incomingSessionId, tabId: advisory.originTabId },
+        );
+        return;
+      }
+
+      advisory.fallbackApplied = true;
+      console.info(
+        '[ChatStore] PostCompact advisory fallback applying one targeted reload without boundary metrics',
+        { sessionId: advisory.incomingSessionId, tabId: origin.id },
+      );
+      params.onFallback(origin.id);
+      this.advisories.set(params.key, advisory);
+    }, CompactionAdvisoryCorrelator.POST_COMPACT_BOUNDARY_WAIT_MS);
+    advisory.timeoutId = timeoutId;
+    this.advisories.set(params.key, advisory);
+    this.trim();
+  }
+
+  /**
+   * The fallback reload came back stale. Retry it exactly once after the
+   * boundary wait; if it is still stale, log once and stop — the live
+   * compact_boundary, if it arrives, reloads it (see `fallbackStale`).
+   * `retry` resolves `true` when the retried snapshot is still stale.
+   */
+  scheduleStaleRetry(key: SessionId, retry: () => Promise<boolean>): void {
+    const advisory = this.advisories.get(key);
+    if (!advisory) return;
+    advisory.fallbackStale = true;
+    if (advisory.staleRetryScheduled) return;
+    advisory.staleRetryScheduled = true;
+    advisory.staleRetryTimeoutId = setTimeout(() => {
+      advisory.staleRetryTimeoutId = null;
+      if (this.advisories.get(key) !== advisory) return;
+      void retry().then((stillStale) => {
+        if (this.advisories.get(key) !== advisory) return;
+        advisory.fallbackStale = stillStale;
+        if (stillStale) {
+          console.warn(
+            '[ChatStore] PostCompact fallback snapshot is still unverified after one retry; a live compact_boundary will reload it',
+            { sessionId: advisory.incomingSessionId },
+          );
+        }
+      });
+    }, CompactionAdvisoryCorrelator.POST_COMPACT_BOUNDARY_WAIT_MS);
+  }
+
+  /**
+   * An origin still owns the compaction when it holds either id the
+   * compaction is known by, or when its current session is an alias of the
+   * same conversation (an SDK rotation the router already recorded). A tab
+   * rebound to an unrelated session fails both.
+   */
+  private stillOwnsCompaction(
+    origin: TabState,
+    key: SessionId,
+    advisory: PostCompactAdvisory,
+  ): boolean {
+    const current = origin.claudeSessionId;
+    if (current === key || current === advisory.incomingSessionId) return true;
+    if (!current || !advisory.conversationId) return false;
+    return (
+      this.tabSessionBinding.conversationFor(origin.id) ===
+        advisory.conversationId &&
+      this.conversationRegistry.findContainingSession(current)?.id ===
+        advisory.conversationId
+    );
+  }
+
+  /**
+   * The conversation that knows `sessionId`: the one containing it anywhere in
+   * its history, else the one bound to a tab currently owning it.
+   */
+  private conversationOfSession(sessionId: SessionId): {
+    readonly id: ConversationId;
+    readonly sessions: readonly SessionId[];
+  } | null {
+    const containing = this.conversationRegistry.findContainingSession(sessionId);
+    if (containing) {
+      return { id: containing.id, sessions: containing.sessions ?? [] };
+    }
+    const owner = this.tabManager
+      .tabs()
+      .find((tab) => tab.claudeSessionId === sessionId);
+    const bound = owner ? this.tabSessionBinding.conversationFor(owner.id) : null;
+    if (!bound) return null;
+    const record = this.conversationRegistry.getRecord(bound);
+    return { id: bound, sessions: record?.sessions ?? [] };
+  }
+
+  private clearTimers(advisory: PostCompactAdvisory): void {
+    if (advisory.timeoutId) clearTimeout(advisory.timeoutId);
+    if (advisory.staleRetryTimeoutId) clearTimeout(advisory.staleRetryTimeoutId);
+    advisory.timeoutId = null;
+    advisory.staleRetryTimeoutId = null;
+  }
+
+  /**
+   * Bound the advisory map the same way the generation map is bounded: a
+   * `fallbackApplied` record whose session never sees another boundary used to
+   * accumulate without limit (PR #493 review D).
+   */
+  private trim(): void {
+    while (
+      this.advisories.size >
+      CompactionAdvisoryCorrelator.MAX_POST_COMPACT_ADVISORY_SESSIONS
+    ) {
+      const oldest = this.advisories.keys().next().value;
+      if (!oldest) return;
+      this.delete(oldest);
+    }
+  }
+}

--- a/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts
@@ -1352,6 +1352,60 @@ describe('CompactionLifecycleService', () => {
       expect(applyCompactionCompleteMock).toHaveBeenCalledTimes(256);
     });
 
+    it('bounds the generation map: an evicted generation sends a late boundary down the full reload path', () => {
+      // `compactionGenerations` is capped at MAX_COMPACTION_GENERATION_SESSIONS
+      // (256) INDEPENDENTLY of the advisory map's own cap, so a host tracking
+      // many compacting sessions can evict a session's generation while its
+      // fallbackApplied advisory is still alive. `currentCompactionGeneration`
+      // then reads 0, the advisory's stamped generation no longer matches, and
+      // the boundary must take the full reload path instead of a metrics-only
+      // merge. That is the SAFE branch — an extra reload, never wrong data —
+      // and it is the only remaining way to reach the mismatch arm now that
+      // `clearCompactionStateForTab` keeps a shared generation (review C).
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
+      service.handleCompactionStart(SESS_1); // generation 1, first entry in.
+      service.handleCompactionCompleteNotification(makePayload());
+      jest.advanceTimersByTime(250); // Fallback applies; the record is retained.
+      applyCompactionCompleteMock.mockClear();
+      switchSessionMock.mockClear();
+      seedPostCompactionContextMock.mockClear();
+
+      // One generation entry per unrelated session. 256 more starts take the
+      // map to 257, and the trim evicts SESS_1 as the oldest key.
+      const bulkSessions = Array.from({ length: 256 }, () => SessionId.create());
+      const bulkTabs = bulkSessions.map((sessionId, i) =>
+        makeTab({ id: `gen-${i}`, claudeSessionId: sessionId }),
+      );
+      for (let i = 0; i < bulkTabs.length; i++) {
+        tabToConv[bulkTabs[i].id as unknown as string] =
+          `gen-conv-${i}` as unknown as ConversationId;
+      }
+      tabs = [...tabs, ...bulkTabs];
+      for (const sessionId of bulkSessions) {
+        service.handleCompactionStart(sessionId);
+      }
+
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_1,
+        preTokens: 9000,
+        postTokens: 1600,
+      });
+
+      expect(seedPostCompactionContextMock).not.toHaveBeenCalled();
+      expect(applyCompactionCompleteMock).toHaveBeenCalledWith(
+        'tab-1',
+        expect.objectContaining({
+          compactionCount: 1,
+          postCompactionContextTokens: 1600,
+        }),
+      );
+      expect(switchSessionMock).toHaveBeenCalledWith(SESS_1, {
+        reason: 'compaction',
+        targetTabId: 'tab-1',
+      });
+    });
+
     it('ignores a PostCompact advisory after chat-error cleanup because generations survive (review E)', () => {
       tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
       service.handleCompactionStart(SESS_1);

--- a/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts
@@ -1222,6 +1222,164 @@ describe('CompactionLifecycleService', () => {
         { sessionId: SESS_1, tabId: 'tab-1' },
       );
     });
+
+    // -------------------------------------------------------------------
+    // PR #493 reviews D + E: fallbackApplied advisory records must not
+    // accumulate without bound, must die with their originating tab when
+    // no other tab owns the session, must stay merge-capable while another
+    // tab still owns it, and must not outlive their compaction generation.
+    // -------------------------------------------------------------------
+    it('drops a fallbackApplied record when its originating tab clears and no other tab owns the session', () => {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
+      service.handleCompactionCompleteNotification(makePayload());
+      jest.advanceTimersByTime(250);
+      applyCompactionCompleteMock.mockClear();
+      switchSessionMock.mockClear();
+      seedPostCompactionContextMock.mockClear();
+
+      // The originating tab closed; nothing else owns the session. The sweep
+      // keys off the record's own originTabId, so it runs even though the tab
+      // is already gone from the tab list.
+      tabs = [];
+      service.clearCompactionStateForTab('tab-1');
+
+      // A late boundary now takes the full reload path instead of being
+      // swallowed as a metrics-only merge by the dead record.
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_1,
+        preTokens: 9000,
+        postTokens: 1600,
+      });
+
+      expect(applyCompactionCompleteMock).toHaveBeenCalledTimes(1);
+      expect(switchSessionMock).toHaveBeenCalledTimes(1);
+      expect(seedPostCompactionContextMock).not.toHaveBeenCalled();
+    });
+
+    it('keeps a fallbackApplied record while another tab still owns the session', () => {
+      tabs = [
+        makeTab({ id: 'tab-1', claudeSessionId: SESS_SHARED }),
+        makeTab({ id: 'tab-2', claudeSessionId: SESS_SHARED }),
+      ];
+      service.handleCompactionCompleteNotification(
+        makePayload({ sessionId: SESS_SHARED }),
+      );
+      jest.advanceTimersByTime(250);
+      applyCompactionCompleteMock.mockClear();
+      switchSessionMock.mockClear();
+
+      // Origin tab clears, but tab-2 still owns the session.
+      tabs = tabs.filter((t) => t.id !== 'tab-1');
+      service.clearCompactionStateForTab('tab-1');
+
+      // The late boundary can still merge its metrics into the surviving tab.
+      service.handleCompactionComplete({
+        tabId: 'tab-2',
+        compactionSessionId: SESS_SHARED,
+        preTokens: 9000,
+        postTokens: 1600,
+      });
+
+      expect(applyCompactionCompleteMock).not.toHaveBeenCalled();
+      expect(switchSessionMock).not.toHaveBeenCalled();
+      expect(seedPostCompactionContextMock).toHaveBeenCalledWith('tab-2', 1600);
+    });
+
+    it('reloads normally when a surviving fallback record no longer matches the session generation', () => {
+      tabs = [
+        makeTab({ id: 'tab-1', claudeSessionId: SESS_SHARED }),
+        makeTab({ id: 'tab-2', claudeSessionId: SESS_SHARED }),
+      ];
+      service.handleCompactionStart(SESS_SHARED);
+      service.handleCompactionCompleteNotification(
+        makePayload({ sessionId: SESS_SHARED }),
+      );
+      jest.advanceTimersByTime(250);
+      // Generation 2: start clears the generation-1 record and its own
+      // advisory arms next.
+      service.handleCompactionStart(SESS_SHARED);
+      service.handleCompactionCompleteNotification(
+        makePayload({ sessionId: SESS_SHARED }),
+      );
+      jest.advanceTimersByTime(250);
+      applyCompactionCompleteMock.mockClear();
+      switchSessionMock.mockClear();
+      seedPostCompactionContextMock.mockClear();
+
+      // tab-1 clears while tab-2 still owns the session, so the generation-2
+      // record survives — but the generation entry it belonged to is gone.
+      service.clearCompactionStateForTab('tab-1');
+
+      // The boundary arriving now cannot be the one this fallback stood in
+      // for: the record's generation matches nothing, so the boundary takes
+      // the full reload path rather than a metrics-only merge. The fan-out
+      // applies per owned tab, so both tabs sharing the session reload.
+      service.handleCompactionComplete({
+        tabId: 'tab-2',
+        compactionSessionId: SESS_SHARED,
+        preTokens: 9000,
+        postTokens: 1600,
+      });
+
+      expect(applyCompactionCompleteMock).toHaveBeenCalledTimes(2);
+      expect(switchSessionMock).toHaveBeenCalledTimes(2);
+      expect(seedPostCompactionContextMock).not.toHaveBeenCalled();
+    });
+
+    it('bounds the advisory map: the oldest pending advisory is evicted past the cap', () => {
+      // One more session than MAX_POST_COMPACT_ADVISORY_SESSIONS (256), each
+      // with its own tab so every fallback is admissible.
+      const sessions = Array.from({ length: 257 }, () => SessionId.create());
+      tabs = sessions.map((sessionId, i) =>
+        makeTab({ id: `bulk-${i}`, claudeSessionId: sessionId }),
+      );
+      for (let i = 0; i < tabs.length; i++) {
+        tabToConv[tabs[i].id as unknown as string] =
+          `bulk-conv-${i}` as unknown as ConversationId;
+      }
+      for (const sessionId of sessions) {
+        service.handleCompactionCompleteNotification(
+          makePayload({ sessionId }),
+        );
+      }
+      jest.advanceTimersByTime(250);
+
+      // The first session's record was evicted by the cap; its timer fires
+      // into a deleted record and does nothing. Every other fallback applies.
+      expect(applyCompactionCompleteMock).toHaveBeenCalledTimes(256);
+    });
+
+    it('ignores a PostCompact advisory after chat-error cleanup because generations survive (review E)', () => {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
+      service.handleCompactionStart(SESS_1);
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_1,
+        preTokens: 8000,
+        postTokens: 1500,
+      });
+      applyCompactionCompleteMock.mockClear();
+      switchSessionMock.mockClear();
+
+      // CHAT_ERROR cleanup path: no tabId, so it sweeps recovery timers and
+      // advisories. Before review E it also wiped compactionGenerations, so
+      // the PostCompact advisory below scheduled a second reload plus
+      // another compaction-count increment.
+      service.clearCompactionState();
+      jest.advanceTimersByTime(SAFETY_TIMEOUT_MS);
+
+      service.handleCompactionCompleteNotification(makePayload());
+      jest.advanceTimersByTime(250);
+
+      expect(applyCompactionCompleteMock).not.toHaveBeenCalled();
+      expect(switchSessionMock).not.toHaveBeenCalled();
+      expect(info).toHaveBeenCalledWith(
+        '[ChatStore] PostCompact advisory ignored; matching compact_boundary already completed',
+        { sessionId: SESS_1 },
+      );
+    });
   });
 
   describe('clearCompactionStateForTab', () => {

--- a/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts
@@ -51,6 +51,7 @@ import {
 // compactionSessionId), and `TabId.from()` on the tabId for the
 // closed-mid-compaction fallback path. Mint stable UUIDs once per spec run.
 const SESS_1 = SessionId.create();
+const SESS_2 = SessionId.create();
 const SESS_RELOAD = SessionId.create();
 const SESS_SHARED = SessionId.create();
 const SESS_UNKNOWN = SessionId.create();
@@ -100,9 +101,11 @@ describe('CompactionLifecycleService', () => {
   let tabs: TabState[];
   let applyCompactionTimeoutResetMock: jest.Mock;
   let applyCompactionCompleteMock: jest.Mock;
+  let seedPostCompactionContextMock: jest.Mock;
   let findTabsBySessionIdMock: jest.Mock;
   let markTabIdleMock: jest.Mock;
   let setStatusMock: jest.Mock;
+  let getCurrentSessionIdMock: jest.Mock;
   let clearCacheMock: jest.Mock;
   let switchSessionMock: jest.Mock;
   let setCompactionStateMock: jest.Mock;
@@ -116,6 +119,7 @@ describe('CompactionLifecycleService', () => {
   let findContainingSessionMock: jest.Mock;
   let createMock: jest.Mock;
   let warn: jest.SpyInstance;
+  let info: jest.SpyInstance;
 
   // Each tab maps to a synthetic conversation id so registry writes are
   // observable without standing up the real binding service. Rebuilt per test
@@ -136,12 +140,14 @@ describe('CompactionLifecycleService', () => {
     tabs = [makeTab()];
     applyCompactionTimeoutResetMock = jest.fn();
     applyCompactionCompleteMock = jest.fn();
+    seedPostCompactionContextMock = jest.fn();
     // Service uses plural fan-out lookup.
     findTabsBySessionIdMock = jest.fn((sessionId: string) =>
       tabs.filter((t) => t.claudeSessionId === sessionId),
     );
     markTabIdleMock = jest.fn();
     setStatusMock = jest.fn();
+    getCurrentSessionIdMock = jest.fn(() => SESS_1);
     clearCacheMock = jest.fn();
     switchSessionMock = jest.fn().mockResolvedValue(undefined);
     setCompactionStateMock = jest.fn();
@@ -175,6 +181,7 @@ describe('CompactionLifecycleService', () => {
     const tabManagerMock = {
       applyCompactionTimeoutReset: applyCompactionTimeoutResetMock,
       applyCompactionComplete: applyCompactionCompleteMock,
+      seedPostCompactionContext: seedPostCompactionContextMock,
       findTabsBySessionId: findTabsBySessionIdMock,
       markTabIdle: markTabIdleMock,
       tabs: () => tabs,
@@ -182,6 +189,7 @@ describe('CompactionLifecycleService', () => {
 
     const sessionManagerMock = {
       setStatus: setStatusMock,
+      getCurrentSessionId: getCurrentSessionIdMock,
     } as unknown as SessionManager;
 
     const treeBuilderMock = {
@@ -209,6 +217,7 @@ describe('CompactionLifecycleService', () => {
     } as unknown as TabSessionBinding;
 
     warn = jest.spyOn(console, 'warn').mockImplementation();
+    info = jest.spyOn(console, 'info').mockImplementation();
 
     TestBed.configureTestingModule({
       providers: [
@@ -226,6 +235,7 @@ describe('CompactionLifecycleService', () => {
 
   afterEach(() => {
     warn.mockRestore();
+    info.mockRestore();
     jest.useRealTimers();
     TestBed.resetTestingModule();
   });
@@ -248,12 +258,66 @@ describe('CompactionLifecycleService', () => {
       );
     });
 
-    it('clears prior timeout before scheduling new one', () => {
+    it('restarts only the same session timer without leaking its prior handle', () => {
       service.handleCompactionStart(SESS_1);
       service.handleCompactionStart(SESS_1);
-      // Advance time to verify only ONE timeout fires (the second one)
+      // Advance time to verify only ONE timeout fires (the second one).
       jest.advanceTimersByTime(SAFETY_TIMEOUT_MS);
       expect(applyCompactionTimeoutResetMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('arms recovery timers independently for concurrent sessions', () => {
+      tabs = [
+        makeTab({ id: 'tab-1', claudeSessionId: SESS_1 }),
+        makeTab({ id: 'tab-2', claudeSessionId: SESS_2 }),
+      ];
+
+      service.handleCompactionStart(SESS_1);
+      service.handleCompactionStart(SESS_2);
+      jest.advanceTimersByTime(SAFETY_TIMEOUT_MS);
+
+      expect(applyCompactionTimeoutResetMock).toHaveBeenCalledWith('tab-1');
+      expect(applyCompactionTimeoutResetMock).toHaveBeenCalledWith('tab-2');
+    });
+
+    it('expires only session A and leaves session B armed', () => {
+      tabs = [
+        makeTab({ id: 'tab-1', claudeSessionId: SESS_1 }),
+        makeTab({ id: 'tab-2', claudeSessionId: SESS_2 }),
+      ];
+
+      service.handleCompactionStart(SESS_1);
+      jest.advanceTimersByTime(1);
+      service.handleCompactionStart(SESS_2);
+      jest.advanceTimersByTime(SAFETY_TIMEOUT_MS - 1);
+
+      expect(applyCompactionTimeoutResetMock).toHaveBeenCalledWith('tab-1');
+      expect(applyCompactionTimeoutResetMock).not.toHaveBeenCalledWith('tab-2');
+
+      jest.advanceTimersByTime(1);
+      expect(applyCompactionTimeoutResetMock).toHaveBeenCalledWith('tab-2');
+    });
+
+    it('does not clear a shared conversation after its tab rebinds to session B', () => {
+      tabToConv['tab-2'] = tabToConv['tab-1'];
+      tabs = [
+        makeTab({ id: 'tab-1', claudeSessionId: SESS_1 }),
+        makeTab({ id: 'tab-2', claudeSessionId: SESS_2 }),
+      ];
+      service.handleCompactionStart(SESS_1);
+      tabs = [
+        makeTab({ id: 'tab-1', claudeSessionId: SESS_2 }),
+        makeTab({ id: 'tab-2', claudeSessionId: SESS_2 }),
+      ];
+      setCompactionStateMock.mockClear();
+
+      jest.advanceTimersByTime(SAFETY_TIMEOUT_MS);
+
+      expect(applyCompactionTimeoutResetMock).not.toHaveBeenCalled();
+      expect(markTabIdleMock).not.toHaveBeenCalled();
+      expect(setCompactionStateMock).not.toHaveBeenCalledWith(tabToConv['tab-1'], {
+        inFlight: false,
+      });
     });
 
     it('does NOT fire the safety net at the old 120s ceiling — a real large-session compaction takes ~2 minutes', () => {
@@ -279,6 +343,53 @@ describe('CompactionLifecycleService', () => {
   });
 
   describe('handleCompactionComplete', () => {
+    it('clears only the completed session timer and leaves another session armed', () => {
+      tabs = [
+        makeTab({ id: 'tab-1', claudeSessionId: SESS_1 }),
+        makeTab({ id: 'tab-2', claudeSessionId: SESS_2 }),
+      ];
+      service.handleCompactionStart(SESS_1);
+      service.handleCompactionStart(SESS_2);
+
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_1,
+      });
+      jest.advanceTimersByTime(SAFETY_TIMEOUT_MS);
+
+      expect(applyCompactionTimeoutResetMock).not.toHaveBeenCalledWith('tab-1');
+      expect(applyCompactionTimeoutResetMock).toHaveBeenCalledWith('tab-2');
+    });
+
+    it('does not reset or seed an originating tab rebound to another session', () => {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_2 })];
+      findTabsBySessionIdMock.mockReturnValueOnce([
+        makeTab({ id: 'tab-1', claudeSessionId: SESS_1 }),
+      ]);
+
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_1,
+        postTokens: 1200,
+      });
+
+      expect(applyCompactionCompleteMock).not.toHaveBeenCalled();
+      expect(switchSessionMock).not.toHaveBeenCalled();
+      expect(setCompactionMarkerTokensMock).not.toHaveBeenCalled();
+    });
+
+    it('does not set global status loaded after the current session changes', () => {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
+      getCurrentSessionIdMock.mockReturnValue(SESS_2);
+
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_1,
+      });
+
+      expect(setStatusMock).not.toHaveBeenCalledWith('loaded');
+    });
+
     it('clears tree-builder cache, resets tab, increments compactionCount, switches session', () => {
       tabs = [
         makeTab({
@@ -293,12 +404,36 @@ describe('CompactionLifecycleService', () => {
       expect(clearCacheMock).toHaveBeenCalled();
       expect(applyCompactionCompleteMock).toHaveBeenCalledWith(
         'tab-1',
-        expect.objectContaining({ compactionCount: 3 }),
+        expect.objectContaining({
+          compactionCount: 3,
+          postCompactionContextTokens: undefined,
+        }),
       );
       expect(switchSessionMock).toHaveBeenCalledWith(SESS_1, {
         reason: 'compaction',
         targetTabId: 'tab-1',
       });
+    });
+
+    it('forwards postTokens only to the matching post-compaction tab seed', () => {
+      tabs = [
+        makeTab({ id: 'tab-1', claudeSessionId: SESS_1 }),
+        makeTab({ id: 'tab-2', claudeSessionId: SESS_2 }),
+      ];
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_1,
+        postTokens: 1200,
+      });
+
+      expect(applyCompactionCompleteMock).toHaveBeenCalledWith(
+        'tab-1',
+        expect.objectContaining({ postCompactionContextTokens: 1200 }),
+      );
+      expect(applyCompactionCompleteMock).not.toHaveBeenCalledWith(
+        'tab-2',
+        expect.anything(),
+      );
     });
 
     it('snapshots preloadedStats when none exist and messages are present', () => {
@@ -923,6 +1058,170 @@ describe('CompactionLifecycleService', () => {
         }),
       );
     });
+
+    it('deduplicates repeated PostCompact advisories into one fallback reload', () => {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
+
+      service.handleCompactionCompleteNotification(makePayload());
+      service.handleCompactionCompleteNotification(makePayload());
+      jest.advanceTimersByTime(250);
+
+      expect(applyCompactionCompleteMock).toHaveBeenCalledTimes(1);
+      expect(switchSessionMock).toHaveBeenCalledTimes(1);
+      expect(switchSessionMock).toHaveBeenCalledWith(SESS_1, {
+        reason: 'compaction',
+        targetTabId: 'tab-1',
+      });
+    });
+
+    it('cancels the advisory fallback when a real boundary arrives first', () => {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
+
+      service.handleCompactionCompleteNotification(makePayload());
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_1,
+        preTokens: 8000,
+        postTokens: 1500,
+        durationMs: 1200,
+      });
+      jest.advanceTimersByTime(250);
+
+      expect(applyCompactionCompleteMock).toHaveBeenCalledTimes(1);
+      expect(switchSessionMock).toHaveBeenCalledTimes(1);
+      expect(setCompactionMarkerTokensMock).toHaveBeenCalledWith(
+        tabToConv['tab-1'],
+        expect.objectContaining({ preTokens: 8000, postTokens: 1500, durationMs: 1200 }),
+      );
+    });
+
+    it('does not schedule a fallback when the matching boundary completed before PostCompact', () => {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
+
+      service.handleCompactionStart(SESS_1);
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_1,
+        preTokens: 8000,
+        postTokens: 1500,
+      });
+      applyCompactionCompleteMock.mockClear();
+      switchSessionMock.mockClear();
+
+      service.handleCompactionCompleteNotification(makePayload());
+      jest.advanceTimersByTime(250);
+
+      expect(applyCompactionCompleteMock).not.toHaveBeenCalled();
+      expect(switchSessionMock).not.toHaveBeenCalled();
+      expect(info).toHaveBeenCalledWith(
+        '[ChatStore] PostCompact advisory ignored; matching compact_boundary already completed',
+        { sessionId: SESS_1 },
+      );
+    });
+
+    it('reloads once without boundary metrics when the advisory wait expires', () => {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
+
+      service.handleCompactionCompleteNotification(makePayload());
+      jest.advanceTimersByTime(250);
+
+      expect(applyCompactionCompleteMock).toHaveBeenCalledWith('tab-1', {
+        preloadedStats: null,
+        compactionCount: 1,
+        postCompactionContextTokens: undefined,
+      });
+      expect(setCompactionMarkerTokensMock).toHaveBeenCalledWith(
+        tabToConv['tab-1'],
+        expect.objectContaining({
+          preTokens: null,
+          postTokens: null,
+          durationMs: null,
+        }),
+      );
+      expect(info).toHaveBeenCalledWith(
+        '[ChatStore] PostCompact advisory fallback applying one targeted reload without boundary metrics',
+        { sessionId: SESS_1, tabId: 'tab-1' },
+      );
+    });
+
+    it('merges a late real boundary into the marker without another reload or count increment', () => {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
+
+      service.handleCompactionCompleteNotification(makePayload());
+      jest.advanceTimersByTime(250);
+      applyCompactionCompleteMock.mockClear();
+      switchSessionMock.mockClear();
+      setCompactionMarkerTokensMock.mockClear();
+
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_1,
+        preTokens: 9000,
+        postTokens: 1600,
+        durationMs: 1400,
+      });
+
+      expect(applyCompactionCompleteMock).not.toHaveBeenCalled();
+      expect(switchSessionMock).not.toHaveBeenCalled();
+      expect(seedPostCompactionContextMock).toHaveBeenCalledWith('tab-1', 1600);
+      expect(setCompactionMarkerTokensMock).toHaveBeenCalledWith(
+        tabToConv['tab-1'],
+        expect.objectContaining({
+          preTokens: 9000,
+          postTokens: 1600,
+          durationMs: 1400,
+        }),
+      );
+      expect(info).toHaveBeenCalledWith(
+        '[ChatStore] Late compact_boundary merged verified metrics after PostCompact fallback without reload',
+        { sessionId: SESS_1, ownedTabCount: 1 },
+      );
+    });
+
+    it('reloads a later compaction when the previous fallback never received its boundary', () => {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
+
+      service.handleCompactionCompleteNotification(makePayload());
+      jest.advanceTimersByTime(250);
+      applyCompactionCompleteMock.mockClear();
+      switchSessionMock.mockClear();
+      seedPostCompactionContextMock.mockClear();
+
+      service.handleCompactionStart(SESS_1);
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_1,
+        preTokens: 9000,
+        postTokens: 1600,
+        durationMs: 1400,
+      });
+
+      expect(applyCompactionCompleteMock).toHaveBeenCalledTimes(1);
+      expect(switchSessionMock).toHaveBeenCalledTimes(1);
+      expect(switchSessionMock).toHaveBeenCalledWith(SESS_1, {
+        reason: 'compaction',
+        targetTabId: 'tab-1',
+      });
+      expect(info).not.toHaveBeenCalledWith(
+        '[ChatStore] Late compact_boundary merged verified metrics after PostCompact fallback without reload',
+        expect.anything(),
+      );
+    });
+
+    it('skips the fallback when its originating tab closes or rebinds before the timer fires', () => {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_1 })];
+
+      service.handleCompactionCompleteNotification(makePayload());
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_2 })];
+      jest.advanceTimersByTime(250);
+
+      expect(applyCompactionCompleteMock).not.toHaveBeenCalled();
+      expect(switchSessionMock).not.toHaveBeenCalled();
+      expect(info).toHaveBeenCalledWith(
+        '[ChatStore] PostCompact advisory fallback skipped; originating tab no longer owns session',
+        { sessionId: SESS_1, tabId: 'tab-1' },
+      );
+    });
   });
 
   describe('clearCompactionStateForTab', () => {
@@ -931,6 +1230,22 @@ describe('CompactionLifecycleService', () => {
       expect(setCompactionStateMock).toHaveBeenCalledWith(tabToConv['tab-1'], {
         inFlight: false,
       });
+    });
+
+    it('clears only the cleared tab session timer when sessions share a conversation', () => {
+      tabToConv['tab-2'] = tabToConv['tab-1'];
+      tabs = [
+        makeTab({ id: 'tab-1', claudeSessionId: SESS_1 }),
+        makeTab({ id: 'tab-2', claudeSessionId: SESS_2 }),
+      ];
+      service.handleCompactionStart(SESS_1);
+      service.handleCompactionStart(SESS_2);
+
+      service.clearCompactionStateForTab('tab-1');
+      jest.advanceTimersByTime(SAFETY_TIMEOUT_MS);
+
+      expect(applyCompactionTimeoutResetMock).not.toHaveBeenCalledWith('tab-1');
+      expect(applyCompactionTimeoutResetMock).toHaveBeenCalledWith('tab-2');
     });
   });
 
@@ -947,7 +1262,13 @@ describe('CompactionLifecycleService', () => {
       expect(applyCompactionTimeoutResetMock).not.toHaveBeenCalled();
     });
 
-    it('without tabId, sweeps all in-flight conversations', () => {
+    it('without tabId, sweeps all timers as well as in-flight conversations', () => {
+      tabs = [
+        makeTab({ id: 'tab-1', claudeSessionId: SESS_1 }),
+        makeTab({ id: 'tab-2', claudeSessionId: SESS_2 }),
+      ];
+      service.handleCompactionStart(SESS_1);
+      service.handleCompactionStart(SESS_2);
       const c1 = tabToConv['tab-1'];
       const c2 = tabToConv['tab-2'];
       const c3 = tabToConv['tab-3'];
@@ -966,6 +1287,8 @@ describe('CompactionLifecycleService', () => {
       expect(setCompactionStateMock).not.toHaveBeenCalledWith(c3, {
         inFlight: false,
       });
+      jest.advanceTimersByTime(SAFETY_TIMEOUT_MS);
+      expect(applyCompactionTimeoutResetMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts
@@ -206,6 +206,7 @@ describe('CompactionLifecycleService', () => {
       setCompactionMarkerSummary: setCompactionMarkerSummaryMock,
       conversations: conversationsMock,
       findContainingSession: findContainingSessionMock,
+      getRecord: jest.fn(() => null),
       create: createMock,
     } as unknown as ConversationRegistry;
 
@@ -1377,6 +1378,208 @@ describe('CompactionLifecycleService', () => {
       expect(info).toHaveBeenCalledWith(
         '[ChatStore] PostCompact advisory ignored; matching compact_boundary already completed',
         { sessionId: SESS_1 },
+      );
+    });
+  });
+
+  describe('PostCompact correlation across session rotation (TASK_2026_414 Gap 2)', () => {
+    // A: the id compaction_start carried. B: the SDK id the tab rotated to.
+    const SESS_A = SessionId.create();
+    const SESS_B = SessionId.create();
+
+    function postPayload(sessionId: SessionId): SdkCompactionCompletePayload {
+      return {
+        sessionId,
+        cwd: '/workspace',
+        trigger: 'auto',
+        compactSummary: 'summary',
+        timestamp: 1_700_000_000_999,
+      };
+    }
+
+    async function flushMicrotasks(): Promise<void> {
+      for (let i = 0; i < 10; i += 1) await Promise.resolve();
+    }
+
+    beforeEach(() => {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_A })];
+      // The router appended B to the same conversation when it saw the alias.
+      findContainingSessionMock.mockImplementation((sessionId: SessionId) =>
+        sessionId === SESS_A || sessionId === SESS_B
+          ? { id: tabToConv['tab-1'], sessions: [SESS_A, SESS_B] }
+          : null,
+      );
+      switchSessionMock.mockResolvedValue({ staleSnapshot: false });
+    });
+
+    function rotateTabToB(): void {
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: SESS_B })];
+    }
+
+    it('start(A) → rotate tab to B → Post(B) with no boundary → one reload on B, A recovery timer cleared, registry inFlight false', async () => {
+      service.handleCompactionStart(SESS_A);
+      rotateTabToB();
+
+      service.handleCompactionCompleteNotification(postPayload(SESS_B));
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks();
+
+      expect(switchSessionMock).toHaveBeenCalledTimes(1);
+      expect(switchSessionMock).toHaveBeenCalledWith(SESS_B, {
+        reason: 'compaction',
+        targetTabId: 'tab-1',
+      });
+      expect(applyCompactionCompleteMock).toHaveBeenCalledTimes(1);
+      expect(setCompactionStateMock).toHaveBeenLastCalledWith(
+        tabToConv['tab-1'],
+        { inFlight: false },
+      );
+
+      // A's timer was cleared: no false "lost event" warning at 10 minutes.
+      jest.advanceTimersByTime(SAFETY_TIMEOUT_MS);
+      expect(warn).not.toHaveBeenCalledWith(
+        '[ChatStore] Compaction safety timeout reached — compaction_complete event may have been lost',
+      );
+      expect(applyCompactionTimeoutResetMock).not.toHaveBeenCalled();
+      expect(switchSessionMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('start(A) → rotate to B → Post(A) still reloads the rotated tab by its current id B', async () => {
+      service.handleCompactionStart(SESS_A);
+      rotateTabToB();
+
+      service.handleCompactionCompleteNotification(postPayload(SESS_A));
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks();
+
+      expect(switchSessionMock).toHaveBeenCalledTimes(1);
+      expect(switchSessionMock).toHaveBeenCalledWith(SESS_B, {
+        reason: 'compaction',
+        targetTabId: 'tab-1',
+      });
+      jest.advanceTimersByTime(SAFETY_TIMEOUT_MS);
+      expect(applyCompactionTimeoutResetMock).not.toHaveBeenCalled();
+    });
+
+    it('boundary(B) after start(A) clears the A recovery timer', () => {
+      service.handleCompactionStart(SESS_A);
+      rotateTabToB();
+
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_B,
+        postTokens: 1000,
+      });
+      jest.advanceTimersByTime(SAFETY_TIMEOUT_MS);
+
+      expect(applyCompactionTimeoutResetMock).not.toHaveBeenCalled();
+      expect(warn).not.toHaveBeenCalledWith(
+        '[ChatStore] Compaction safety timeout reached — compaction_complete event may have been lost',
+      );
+    });
+
+    it('Post-only fallback with staleSnapshot clears the banner and retries exactly once without re-applying completion', async () => {
+      switchSessionMock.mockResolvedValue({ staleSnapshot: true });
+      service.handleCompactionStart(SESS_A);
+
+      service.handleCompactionCompleteNotification(postPayload(SESS_A));
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks();
+
+      expect(switchSessionMock).toHaveBeenCalledTimes(1);
+      expect(setCompactionStateMock).toHaveBeenLastCalledWith(
+        tabToConv['tab-1'],
+        { inFlight: false },
+      );
+
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks();
+      expect(switchSessionMock).toHaveBeenCalledTimes(2);
+      expect(switchSessionMock).toHaveBeenLastCalledWith(SESS_A, {
+        reason: 'compaction',
+        targetTabId: 'tab-1',
+      });
+
+      jest.advanceTimersByTime(250 * 10);
+      await flushMicrotasks();
+      expect(switchSessionMock).toHaveBeenCalledTimes(2);
+      expect(applyCompactionCompleteMock).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        '[ChatStore] PostCompact fallback snapshot is still unverified after one retry; a live compact_boundary will reload it',
+        { sessionId: SESS_A },
+      );
+    });
+
+    it('late boundary after a stale fallback reloads without a second compactionCount increment', async () => {
+      switchSessionMock.mockResolvedValue({ staleSnapshot: true });
+      service.handleCompactionStart(SESS_A);
+      service.handleCompactionCompleteNotification(postPayload(SESS_A));
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks();
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks();
+      applyCompactionCompleteMock.mockClear();
+      switchSessionMock.mockClear();
+      switchSessionMock.mockResolvedValue({ staleSnapshot: false });
+
+      service.handleCompactionComplete({
+        tabId: 'tab-1',
+        compactionSessionId: SESS_A,
+        preTokens: 9000,
+        postTokens: 1600,
+      });
+      await flushMicrotasks();
+
+      expect(applyCompactionCompleteMock).not.toHaveBeenCalled();
+      expect(seedPostCompactionContextMock).toHaveBeenCalledWith('tab-1', 1600);
+      expect(switchSessionMock).toHaveBeenCalledTimes(1);
+      expect(switchSessionMock).toHaveBeenCalledWith(SESS_A, {
+        reason: 'compaction',
+        targetTabId: 'tab-1',
+      });
+    });
+
+    it('a verified fallback does not retry', async () => {
+      service.handleCompactionStart(SESS_A);
+      service.handleCompactionCompleteNotification(postPayload(SESS_A));
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks();
+      jest.advanceTimersByTime(250 * 4);
+      await flushMicrotasks();
+
+      expect(switchSessionMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('Post for an id unknown to every tab and conversation still warns and no-ops', () => {
+      const unknown = SessionId.create();
+      service.handleCompactionStart(SESS_A);
+
+      service.handleCompactionCompleteNotification(postPayload(unknown));
+      jest.advanceTimersByTime(250);
+
+      expect(markCompactionCompleteMock).not.toHaveBeenCalled();
+      expect(switchSessionMock).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        '[ChatStore] handleCompactionCompleteNotification: no tab bound to sessionId',
+        { sessionId: unknown },
+      );
+    });
+
+    it('origin rebound to an unrelated conversation before the timer skips the fallback', () => {
+      const unrelated = SessionId.create();
+      service.handleCompactionStart(SESS_A);
+      rotateTabToB();
+      service.handleCompactionCompleteNotification(postPayload(SESS_B));
+
+      tabs = [makeTab({ id: 'tab-1', claudeSessionId: unrelated })];
+      tabToConv['tab-1'] = 'conv-unrelated' as unknown as ConversationId;
+      jest.advanceTimersByTime(250);
+
+      expect(applyCompactionCompleteMock).not.toHaveBeenCalled();
+      expect(switchSessionMock).not.toHaveBeenCalled();
+      expect(info).toHaveBeenCalledWith(
+        '[ChatStore] PostCompact advisory fallback skipped; originating tab no longer owns session',
+        { sessionId: SESS_B, tabId: 'tab-1' },
       );
     });
   });

--- a/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts
@@ -1287,7 +1287,7 @@ describe('CompactionLifecycleService', () => {
       expect(seedPostCompactionContextMock).toHaveBeenCalledWith('tab-2', 1600);
     });
 
-    it('reloads normally when a surviving fallback record no longer matches the session generation', () => {
+    it('keeps the shared generation while another tab owns the session, so a late boundary still merges', () => {
       tabs = [
         makeTab({ id: 'tab-1', claudeSessionId: SESS_SHARED }),
         makeTab({ id: 'tab-2', claudeSessionId: SESS_SHARED }),
@@ -1308,14 +1308,15 @@ describe('CompactionLifecycleService', () => {
       switchSessionMock.mockClear();
       seedPostCompactionContextMock.mockClear();
 
-      // tab-1 clears while tab-2 still owns the session, so the generation-2
-      // record survives — but the generation entry it belonged to is gone.
+      // tab-1 clears while tab-2 still owns the session. The generation is
+      // SHARED by every tab on the session, so it survives with the
+      // fallbackApplied record that belongs to it (PR #493 review C). Deleting
+      // it here made the record read generation 0, fail the generation check,
+      // and take the full reload path.
       service.clearCompactionStateForTab('tab-1');
 
-      // The boundary arriving now cannot be the one this fallback stood in
-      // for: the record's generation matches nothing, so the boundary takes
-      // the full reload path rather than a metrics-only merge. The fan-out
-      // applies per owned tab, so both tabs sharing the session reload.
+      // The boundary IS the one this fallback stood in for: same generation,
+      // so it merges its metrics instead of reloading the transcript again.
       service.handleCompactionComplete({
         tabId: 'tab-2',
         compactionSessionId: SESS_SHARED,
@@ -1323,9 +1324,9 @@ describe('CompactionLifecycleService', () => {
         postTokens: 1600,
       });
 
-      expect(applyCompactionCompleteMock).toHaveBeenCalledTimes(2);
-      expect(switchSessionMock).toHaveBeenCalledTimes(2);
-      expect(seedPostCompactionContextMock).not.toHaveBeenCalled();
+      expect(applyCompactionCompleteMock).not.toHaveBeenCalled();
+      expect(switchSessionMock).not.toHaveBeenCalled();
+      expect(seedPostCompactionContextMock).toHaveBeenCalledWith('tab-2', 1600);
     });
 
     it('bounds the advisory map: the oldest pending advisory is evicted past the cap', () => {

--- a/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.spec.ts
@@ -85,7 +85,6 @@ function makeTab(overrides: Partial<TabState> = {}): TabState {
     streamingState: null,
     currentMessageId: null,
     claudeSessionId: SESS_1,
-    isCompacting: false,
     compactionCount: 0,
     queuedContent: null,
     queuedOptions: null,
@@ -1602,6 +1601,107 @@ describe('CompactionLifecycleService — unbound-tab binding recovery (real regi
       expect.objectContaining({ inFlight: false }),
     );
     expect(registry.compactionMarkerFor(convId)?.summary).toBe('recap');
+  });
+
+  describe('isCompactingForTab (the one registry derivation every surface reads)', () => {
+    // Fuller tab-manager/session stubs than the suite default: these cases
+    // drive the completion, fallback and safety-timeout paths end to end.
+    let switchSession: jest.Mock;
+
+    beforeEach(() => {
+      TestBed.resetTestingModule();
+      switchSession = jest.fn().mockResolvedValue(undefined);
+      const tabManagerMock = {
+        applyCompactionTimeoutReset: jest.fn(),
+        applyCompactionComplete: jest.fn(),
+        seedPostCompactionContext: jest.fn(),
+        findTabsBySessionId: jest.fn((sessionId: string) =>
+          tabs.filter((t) => t.claudeSessionId === sessionId),
+        ),
+        markTabIdle: jest.fn(),
+        tabs: () => tabs,
+      } as unknown as TabManagerService;
+      TestBed.configureTestingModule({
+        providers: [
+          CompactionLifecycleService,
+          ConversationRegistry,
+          TabSessionBinding,
+          { provide: TabManagerService, useValue: tabManagerMock },
+          {
+            provide: SessionManager,
+            useValue: {
+              setStatus: jest.fn(),
+              getCurrentSessionId: jest.fn(() => null),
+            } as unknown as SessionManager,
+          },
+          {
+            provide: ExecutionTreeBuilderService,
+            useValue: {
+              clearCache: jest.fn(),
+            } as unknown as ExecutionTreeBuilderService,
+          },
+          {
+            provide: SessionLoaderService,
+            useValue: { switchSession } as unknown as SessionLoaderService,
+          },
+        ],
+      });
+      service = TestBed.inject(CompactionLifecycleService);
+      registry = TestBed.inject(ConversationRegistry);
+      binding = TestBed.inject(TabSessionBinding);
+      jest.spyOn(console, 'info').mockImplementation();
+    });
+
+    async function flushMicrotasks(): Promise<void> {
+      for (let i = 0; i < 10; i += 1) await Promise.resolve();
+    }
+
+    it('is true after handleCompactionStart for the bound tab', () => {
+      service.handleCompactionStart(SESS);
+      expect(service.isCompactingForTab(TAB_ID)).toBe(true);
+    });
+
+    it('is false after authoritative handleCompactionComplete settles', async () => {
+      service.handleCompactionStart(SESS);
+      service.handleCompactionComplete({
+        tabId: TAB_ID,
+        compactionSessionId: SESS,
+        postTokens: 1000,
+      });
+      await flushMicrotasks();
+      expect(switchSession).toHaveBeenCalledTimes(1);
+      expect(service.isCompactingForTab(TAB_ID)).toBe(false);
+    });
+
+    it('is false after PostCompact advisory fallback settles', async () => {
+      service.handleCompactionStart(SESS);
+      service.handleCompactionCompleteNotification({
+        sessionId: SESS,
+        cwd: '/workspace',
+        trigger: 'auto',
+        compactSummary: 'recap',
+        timestamp: 1_700_000_000_000,
+      });
+      jest.advanceTimersByTime(250);
+      await flushMicrotasks();
+      expect(switchSession).toHaveBeenCalledTimes(1);
+      expect(service.isCompactingForTab(TAB_ID)).toBe(false);
+    });
+
+    it('is false after the safety timeout fires', () => {
+      service.handleCompactionStart(SESS);
+      expect(service.isCompactingForTab(TAB_ID)).toBe(true);
+      jest.advanceTimersByTime(SAFETY_TIMEOUT_MS);
+      expect(service.isCompactingForTab(TAB_ID)).toBe(false);
+    });
+
+    it('is false for an unknown, malformed, null or unbound tab id', () => {
+      service.handleCompactionStart(SESS);
+      expect(service.isCompactingForTab(SharedTabId.create())).toBe(false);
+      expect(service.isCompactingForTab('not-a-tab-id')).toBe(false);
+      expect(service.isCompactingForTab(null)).toBe(false);
+      expect(service.isCompactingForTab(undefined)).toBe(false);
+    });
   });
 
   it('still no-ops when the session has no tab at all — that case is unchanged', () => {

--- a/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts
@@ -92,6 +92,11 @@ export class CompactionLifecycleService {
    * Tracks the independent PostCompact signal without inventing a boundary.
    * A late real boundary after the fallback may enrich marker metrics, but it
    * must never replay the destructive completion/reload a second time.
+   *
+   * `generation` records which compaction generation the advisory (or its
+   * applied fallback) belongs to. A fallback record only counts as
+   * "already applied" while it matches the session's current generation —
+   * after a new compaction starts, its late boundary must reload normally.
    */
   private readonly postCompactAdvisories = new Map<
     SessionId,
@@ -99,8 +104,10 @@ export class CompactionLifecycleService {
       originTabId: TabId;
       timeoutId: ReturnType<typeof setTimeout> | null;
       fallbackApplied: boolean;
+      generation: number;
     }
   >();
+  private static readonly MAX_POST_COMPACT_ADVISORY_SESSIONS = 256;
 
   /**
    * Per-session compaction generations correlate the two independently ordered
@@ -237,7 +244,12 @@ export class CompactionLifecycleService {
       if (advisory.timeoutId) clearTimeout(advisory.timeoutId);
     }
     this.postCompactAdvisories.clear();
-    this.compactionGenerations.clear();
+    // `compactionGenerations` is deliberately NOT cleared: handleCompactionComplete
+    // marks a generation authoritative there, and this method runs on the
+    // CHAT_ERROR cleanup path — wiping it would let a later PostCompact
+    // advisory for the same generation schedule a fallback reload after the
+    // boundary already arrived. The map is already bounded by
+    // trimCompactionGenerations.
   }
 
   /**
@@ -357,15 +369,26 @@ export class CompactionLifecycleService {
   }): void {
     const compactionSid = SessionId.from(result.compactionSessionId);
     if (!result.advisoryFallback) {
+      // Snapshot the current generation BEFORE the authoritative stamp: the
+      // stamp resurrects a deleted entry with generation 1, which would break
+      // the match for an advisory armed before any compaction start (gen 0).
+      const generationAtBoundary = this.currentCompactionGeneration(compactionSid);
       this.markAuthoritativeCompactionGeneration(compactionSid);
       const advisory = this.postCompactAdvisories.get(compactionSid);
       if (advisory?.timeoutId) {
         clearTimeout(advisory.timeoutId);
         this.postCompactAdvisories.delete(compactionSid);
       } else if (advisory?.fallbackApplied) {
-        this.mergeLateCompactionBoundary(compactionSid, result);
+        if (advisory.generation === generationAtBoundary) {
+          // Same generation: merge the late boundary's metrics/context seed
+          // without a second reload or another compaction-count increment.
+          this.mergeLateCompactionBoundary(compactionSid, result);
+          this.postCompactAdvisories.delete(compactionSid);
+          return;
+        }
+        // The fallback belonged to an older generation; the boundary arriving
+        // now is for the current one and must take the full reload path.
         this.postCompactAdvisories.delete(compactionSid);
-        return;
       }
     }
     this.treeBuilder.clearCache();
@@ -678,7 +701,9 @@ export class CompactionLifecycleService {
       originTabId: tabs[0].id,
       timeoutId,
       fallbackApplied: false,
+      generation: this.currentCompactionGeneration(compactionSid),
     });
+    this.trimPostCompactAdvisories();
     console.info(
       '[ChatStore] PostCompact advisory received; waiting briefly for real compact_boundary',
       { sessionId: compactionSid },
@@ -742,6 +767,26 @@ export class CompactionLifecycleService {
     return state != null && state.authoritativeGeneration === state.generation;
   }
 
+  private currentCompactionGeneration(sessionId: SessionId): number {
+    return this.compactionGenerations.get(sessionId)?.generation ?? 0;
+  }
+
+  /**
+   * Bound the advisory map the same way the generation map is bounded: a
+   * `fallbackApplied` record whose session never sees another boundary used to
+   * accumulate without limit (PR #493 review D).
+   */
+  private trimPostCompactAdvisories(): void {
+    while (
+      this.postCompactAdvisories.size >
+      CompactionLifecycleService.MAX_POST_COMPACT_ADVISORY_SESSIONS
+    ) {
+      const oldestSessionId = this.postCompactAdvisories.keys().next().value;
+      if (!oldestSessionId) return;
+      this.postCompactAdvisories.delete(oldestSessionId);
+    }
+  }
+
   private trimCompactionGenerations(): void {
     while (
       this.compactionGenerations.size >
@@ -786,10 +831,22 @@ export class CompactionLifecycleService {
     const tab = this.tabManager.tabs().find((candidate) => candidate.id === tabId);
     if (tab?.claudeSessionId) {
       this.compactionGenerations.delete(tab.claudeSessionId);
-      const advisory = this.postCompactAdvisories.get(tab.claudeSessionId);
-      if (advisory?.originTabId === tabId && advisory.timeoutId) {
-        clearTimeout(advisory.timeoutId);
-        this.postCompactAdvisories.delete(tab.claudeSessionId);
+    }
+    // Drop advisories this tab originated. The sweep keys off the record's
+    // own `originTabId`, not off the live tab list — a CLOSED tab is already
+    // gone from `tabs()`, so its session is resolvable only through the
+    // record. A pending (timed) advisory dies with its tab; a `fallbackApplied`
+    // record survives only while another tab still owns the session, so a
+    // late boundary can merge its metrics there. Left alone these records
+    // accumulated without bound (PR #493 review D).
+    for (const [advisorySessionId, advisory] of this.postCompactAdvisories) {
+      if (advisory.originTabId !== tabId) continue;
+      if (advisory.timeoutId) clearTimeout(advisory.timeoutId);
+      const sessionStillOwnedByAnotherTab = this.tabManager
+        .findTabsBySessionId(advisorySessionId)
+        .some((candidate) => candidate.id !== tabId);
+      if (advisory.timeoutId || !sessionStillOwnedByAnotherTab) {
+        this.postCompactAdvisories.delete(advisorySessionId);
       }
     }
     const convId = this.tabSessionBinding.conversationFor(tabId);

--- a/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts
@@ -21,7 +21,8 @@ import { SessionLoaderService } from './session-loader.service';
  * CompactionLifecycleService - Owns the SDK session-compaction state machine.
  *
  * Responsibilities:
- * - Per-tab `isCompacting` flag management
+ * - Conversation-registry compaction state (`isCompactingForTab` is the one
+ *   read every compaction surface uses — banner and input overlay alike)
  * - Compaction safety-fallback timeout (10 min) — dismisses banner if backend
  *   never sends `compaction_complete`
  * - Compaction-complete reload flow: tree-cache clear, preloadedStats
@@ -142,6 +143,25 @@ export class CompactionLifecycleService {
    */
   private readonly _suppressAnimateOnce = signal(false);
   readonly suppressAnimateOnce = this._suppressAnimateOnce.asReadonly();
+
+  /**
+   * Whether the conversation bound to `rawTabId` has a compaction in flight.
+   *
+   * The ONE derivation of "is this tab compacting". The chat-view banner and
+   * the chat-input overlay both read it, so they cannot disagree: a second
+   * per-tab flag lost its only writer when the registry became the source of
+   * truth and left the overlay dark while the banner showed. Reads signals
+   * only, so a caller's `computed()` stays reactive. An unknown, malformed or
+   * unbound tab id is simply not compacting.
+   */
+  isCompactingForTab(rawTabId: string | null | undefined): boolean {
+    if (!rawTabId) return false;
+    const tabId = TabId.safeParse(rawTabId);
+    if (!tabId) return false;
+    const convId = this.tabSessionBinding.conversationFor(tabId);
+    if (!convId) return false;
+    return this.conversationRegistry.compactionStateFor(convId)?.inFlight ?? false;
+  }
 
   /**
    * Handle compaction start event from backend (SDK Session Compaction).

--- a/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts
@@ -889,6 +889,14 @@ export class CompactionLifecycleService {
    * of truth); banner and input overlay read from the registry. The
    * generation and timer are addressed through the tab's CURRENT session's
    * lifecycle key, so a rotated tab still clears its compaction's state.
+   *
+   * The generation is SHARED by every tab on the session, so it is deleted
+   * only when no other tab still owns it — the same ownership rule
+   * `CompactionAdvisoryCorrelator.dropForTab` applies to the advisory record.
+   * Deleting it unconditionally left a surviving `fallbackApplied` advisory
+   * reading generation 0, so the late boundary failed the generation check and
+   * took the full reload path instead of merging its metrics
+   * (PR #493 review C).
    */
   clearCompactionStateForTab(tabId: TabId): void {
     const tab = this.tabManager.tabs().find((candidate) => candidate.id === tabId);
@@ -897,7 +905,12 @@ export class CompactionLifecycleService {
         tab.claudeSessionId,
         this.hasLifecycleState,
       );
-      this.compactionGenerations.delete(key);
+      const ownedElsewhere = this.tabManager
+        .findTabsBySessionId(tab.claudeSessionId)
+        .some((candidate) => candidate.id !== tabId);
+      if (!ownedElsewhere) {
+        this.compactionGenerations.delete(key);
+      }
     }
     this.advisoryCorrelator.dropForTab(tabId);
     const convId = this.tabSessionBinding.conversationFor(tabId);

--- a/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts
@@ -44,17 +44,21 @@ export class CompactionLifecycleService {
   private readonly tabSessionBinding = inject(TabSessionBinding);
 
   /**
-   * Timeout ID for compaction safety fallback.
+   * Recovery timers are owned by their compacting SDK session. A timer is UI
+   * lifecycle cleanup only; it is not evidence that the backend is ready.
    *
-   * DESIGN NOTE: This is intentionally stored as a class property rather than
-   * a signal because:
-   * 1. The timeout ID is not UI state - it's an internal cleanup mechanism
-   * 2. setTimeout returns a number/NodeJS.Timeout, not a serializable value
-   * 3. We only need to clear it, never read it in templates
-   *
-   * The associated `isCompacting` per-tab field IS the UI state that components observe.
+   * Keeping the captured tabs and conversations with the handle prevents a
+   * terminal path for session A from clearing the timer or banner state that
+   * belongs to session B.
    */
-  private compactionTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  private readonly compactionRecoveryTimers = new Map<
+    SessionId,
+    {
+      timeoutId: ReturnType<typeof setTimeout>;
+      tabIds: readonly TabId[];
+      conversationIds: readonly ConversationId[];
+    }
+  >();
 
   /**
    * Safety fallback timeout for compaction notification (milliseconds).
@@ -76,6 +80,39 @@ export class CompactionLifecycleService {
    * this constant needs — not tightness.
    */
   private static readonly COMPACTION_SAFETY_TIMEOUT_MS = 600000;
+
+  /**
+   * PostCompact is advisory: the SDK hook proves compaction finished, but only
+   * the streamed compact_boundary carries authoritative token metadata. Give
+   * that stream a short turn before recovering the visible transcript.
+   */
+  private static readonly POST_COMPACT_BOUNDARY_WAIT_MS = 250;
+
+  /**
+   * Tracks the independent PostCompact signal without inventing a boundary.
+   * A late real boundary after the fallback may enrich marker metrics, but it
+   * must never replay the destructive completion/reload a second time.
+   */
+  private readonly postCompactAdvisories = new Map<
+    SessionId,
+    {
+      originTabId: TabId;
+      timeoutId: ReturnType<typeof setTimeout> | null;
+      fallbackApplied: boolean;
+    }
+  >();
+
+  /**
+   * Per-session compaction generations correlate the two independently ordered
+   * completion signals. A boundary completing generation N suppresses a later
+   * PostCompact for N; the next compaction start advances N and permits its own
+   * advisory. This is bounded state, not a time-based grace window.
+   */
+  private readonly compactionGenerations = new Map<
+    SessionId,
+    { generation: number; authoritativeGeneration: number | null }
+  >();
+  private static readonly MAX_COMPACTION_GENERATION_SESSIONS = 256;
 
   /**
    * One-tick auto-animate suppression flag.
@@ -117,10 +154,14 @@ export class CompactionLifecycleService {
       );
       return;
     }
-    if (this.compactionTimeoutId) {
-      clearTimeout(this.compactionTimeoutId);
-      this.compactionTimeoutId = null;
-    }
+    this.clearCompactionRecoveryTimer(compactionSid);
+    // A new compaction supersedes any advisory left by the previous one; a
+    // retained `fallbackApplied` entry would otherwise turn this generation's
+    // real boundary into a metrics-only merge and skip its reload.
+    const staleAdvisory = this.postCompactAdvisories.get(compactionSid);
+    if (staleAdvisory?.timeoutId) clearTimeout(staleAdvisory.timeoutId);
+    this.postCompactAdvisories.delete(compactionSid);
+    this.beginCompactionGeneration(compactionSid);
     const compactingConvIds = this.ensureConversationIdsForTabs(
       tabs.map((t) => t.id),
       compactionSid,
@@ -133,22 +174,70 @@ export class CompactionLifecycleService {
       });
     }
     const compactingTabIds = tabs.map((t) => t.id);
-    this.compactionTimeoutId = setTimeout(() => {
-      for (const tabId of compactingTabIds) {
+    const timeoutId = setTimeout(() => {
+      const recovery = this.compactionRecoveryTimers.get(compactionSid);
+      if (!recovery || recovery.timeoutId !== timeoutId) return;
+      this.compactionRecoveryTimers.delete(compactionSid);
+
+      const ownedConversationIds = new Set<ConversationId>();
+      for (const tabId of recovery.tabIds) {
+        const tab = this.tabManager
+          .tabs()
+          .find((candidate) => candidate.id === tabId);
+        if (tab?.claudeSessionId !== compactionSid) continue;
+        const conversationId = this.tabSessionBinding.conversationFor(tabId);
+        if (!conversationId || !recovery.conversationIds.includes(conversationId)) {
+          continue;
+        }
+        ownedConversationIds.add(conversationId);
         this.tabManager.applyCompactionTimeoutReset(tabId);
         this.tabManager.markTabIdle(tabId);
       }
-      for (const convId of compactingConvIds) {
-        this.conversationRegistry.setCompactionState(convId, {
+      for (const conversationId of ownedConversationIds) {
+        this.conversationRegistry.setCompactionState(conversationId, {
           inFlight: false,
         });
       }
-      this.sessionManager.setStatus('loaded');
-      this.compactionTimeoutId = null;
+      if (this.sessionManager.getCurrentSessionId() === compactionSid) {
+        this.sessionManager.setStatus('loaded');
+      }
       console.warn(
         '[ChatStore] Compaction safety timeout reached — compaction_complete event may have been lost',
       );
     }, CompactionLifecycleService.COMPACTION_SAFETY_TIMEOUT_MS);
+    this.compactionRecoveryTimers.set(compactionSid, {
+      timeoutId,
+      tabIds: compactingTabIds,
+      conversationIds: compactingConvIds,
+    });
+  }
+
+  private clearCompactionRecoveryTimer(sessionId: SessionId): void {
+    const recovery = this.compactionRecoveryTimers.get(sessionId);
+    if (!recovery) return;
+    clearTimeout(recovery.timeoutId);
+    this.compactionRecoveryTimers.delete(sessionId);
+  }
+
+  private clearCompactionRecoveryTimerForTab(tabId: TabId): void {
+    const tab = this.tabManager.tabs().find((candidate) => candidate.id === tabId);
+    if (!tab?.claudeSessionId) return;
+    const sessionId = tab.claudeSessionId;
+    const recovery = this.compactionRecoveryTimers.get(sessionId);
+    if (!recovery || !recovery.tabIds.includes(tabId)) return;
+    this.clearCompactionRecoveryTimer(sessionId);
+  }
+
+  private clearAllCompactionRecoveryTimers(): void {
+    for (const recovery of this.compactionRecoveryTimers.values()) {
+      clearTimeout(recovery.timeoutId);
+    }
+    this.compactionRecoveryTimers.clear();
+    for (const advisory of this.postCompactAdvisories.values()) {
+      if (advisory.timeoutId) clearTimeout(advisory.timeoutId);
+    }
+    this.postCompactAdvisories.clear();
+    this.compactionGenerations.clear();
   }
 
   /**
@@ -264,13 +353,23 @@ export class CompactionLifecycleService {
     preTokens?: number;
     postTokens?: number;
     durationMs?: number;
+    advisoryFallback?: boolean;
   }): void {
-    if (this.compactionTimeoutId) {
-      clearTimeout(this.compactionTimeoutId);
-      this.compactionTimeoutId = null;
+    const compactionSid = SessionId.from(result.compactionSessionId);
+    if (!result.advisoryFallback) {
+      this.markAuthoritativeCompactionGeneration(compactionSid);
+      const advisory = this.postCompactAdvisories.get(compactionSid);
+      if (advisory?.timeoutId) {
+        clearTimeout(advisory.timeoutId);
+        this.postCompactAdvisories.delete(compactionSid);
+      } else if (advisory?.fallbackApplied) {
+        this.mergeLateCompactionBoundary(compactionSid, result);
+        this.postCompactAdvisories.delete(compactionSid);
+        return;
+      }
     }
     this.treeBuilder.clearCache();
-    const compactionSid = SessionId.from(result.compactionSessionId);
+    this.clearCompactionRecoveryTimer(compactionSid);
     const allTabs = this.tabManager.tabs();
     const originatingTab = allTabs.find((t) => t.id === result.tabId);
     const sessionTabs = this.tabManager.findTabsBySessionId(compactionSid);
@@ -318,8 +417,57 @@ export class CompactionLifecycleService {
       }
     }
 
+    // Only an originating tab that still owns the compacting session can
+    // establish the fallback conversation. A tab rebound before this completion
+    // is unrelated; using its new conversation here would contaminate it.
+    const compactionConversationId =
+      containingConv?.id ??
+      (originatingTab?.claudeSessionId === compactionSid
+        ? this.tabSessionBinding.conversationFor(originatingTab.id)
+        : null);
+    const sourceSessionByTab = new Map(
+      Array.from(fanoutMap.values())
+        .filter((tab): tab is NonNullable<typeof originatingTab> => tab != null)
+        .map((tab) => [tab.id, tab.claudeSessionId]),
+    );
+    // A direct compacting-session match in the initial lookup proves the
+    // completion belonged to this origin at dispatch time. If its current owner
+    // has since changed, it must be excluded rather than admitted by the
+    // session-rotation fallback. Older notifications whose initial lookup did
+    // not identify the origin retain the existing fallback behavior.
+    const originatingSnapshotOwnsCompactionSession = sessionTabs.some(
+      (tab) => tab.id === result.tabId && tab.claudeSessionId === compactionSid,
+    );
     const fanoutTabs = Array.from(fanoutMap.values()).filter(
-      (t): t is NonNullable<typeof originatingTab> => t != null,
+      (t): t is NonNullable<typeof originatingTab> => {
+        if (!t) return false;
+        // Re-read the tab's ownership immediately before mutating it. A
+        // compaction completion can race with a targeted rebind; only the
+        // compacting session itself, its still-bound conversation, or an
+        // unchanged snapshot owner may receive the reset, marker, seed, and
+        // reload. The last case preserves legitimate SDK session rotation.
+        const current = this.tabManager.tabs().find((tab) => tab.id === t.id);
+        if (!current) return false;
+        if (
+          t.id === result.tabId &&
+          originatingSnapshotOwnsCompactionSession &&
+          current.claudeSessionId !== compactionSid
+        ) {
+          return false;
+        }
+        if (current.claudeSessionId === compactionSid) return true;
+        if (
+          current.claudeSessionId === sourceSessionByTab.get(t.id) &&
+          (t.id !== result.tabId || !originatingSnapshotOwnsCompactionSession)
+        ) {
+          return true;
+        }
+        return (
+          compactionConversationId != null &&
+          this.tabSessionBinding.conversationFor(current.id) ===
+            compactionConversationId
+        );
+      },
     );
 
     // [compaction-diag] TEMPORARY — remove after the 2-tile stale-transcript
@@ -381,10 +529,13 @@ export class CompactionLifecycleService {
         this.tabManager.applyCompactionComplete(t.id, {
           preloadedStats,
           compactionCount: (t.compactionCount ?? 0) + 1,
+          postCompactionContextTokens: result.postTokens,
         });
         this.tabManager.markTabIdle(t.id);
       }
-      this.sessionManager.setStatus('loaded');
+      if (this.sessionManager.getCurrentSessionId() === compactionSid) {
+        this.sessionManager.setStatus('loaded');
+      }
       const reloadTargets = fanoutTabs.map((tab) => ({
         tabId: tab.id,
         sessionId: tab.claudeSessionId ?? compactionSid,
@@ -477,6 +628,129 @@ export class CompactionLifecycleService {
         );
       }
     }
+
+    // PostCompact is advisory. A compact_boundary may have completed this
+    // generation first; do not let its later hook delivery replay completion.
+    if (this.isAuthoritativelyCompletedGeneration(compactionSid)) {
+      console.info(
+        '[ChatStore] PostCompact advisory ignored; matching compact_boundary already completed',
+        { sessionId: compactionSid },
+      );
+      return;
+    }
+    // Deduplicate repeated hook deliveries and let a real compact_boundary own
+    // the normal authoritative completion path.
+    if (this.postCompactAdvisories.has(compactionSid)) return;
+    const timeoutId = setTimeout(() => {
+      const advisory = this.postCompactAdvisories.get(compactionSid);
+      if (!advisory || advisory.timeoutId !== timeoutId) return;
+      advisory.timeoutId = null;
+
+      // Re-read ownership immediately before fallback mutation. A closed or
+      // rebound tab is no longer an owner and cannot be reloaded by this hook.
+      const origin = this.tabManager
+        .tabs()
+        .find((tab) => tab.id === advisory.originTabId);
+      if (origin?.claudeSessionId !== compactionSid) {
+        this.postCompactAdvisories.delete(compactionSid);
+        console.info(
+          '[ChatStore] PostCompact advisory fallback skipped; originating tab no longer owns session',
+          { sessionId: compactionSid, tabId: advisory.originTabId },
+        );
+        return;
+      }
+
+      advisory.fallbackApplied = true;
+      console.info(
+        '[ChatStore] PostCompact advisory fallback applying one targeted reload without boundary metrics',
+        { sessionId: compactionSid, tabId: origin.id },
+      );
+      this.handleCompactionComplete({
+        tabId: origin.id,
+        compactionSessionId: compactionSid,
+        advisoryFallback: true,
+      });
+      // Retain the record so a later boundary can merge metrics without a
+      // second reload or another compaction-count increment.
+      this.postCompactAdvisories.set(compactionSid, advisory);
+    }, CompactionLifecycleService.POST_COMPACT_BOUNDARY_WAIT_MS);
+    this.postCompactAdvisories.set(compactionSid, {
+      originTabId: tabs[0].id,
+      timeoutId,
+      fallbackApplied: false,
+    });
+    console.info(
+      '[ChatStore] PostCompact advisory received; waiting briefly for real compact_boundary',
+      { sessionId: compactionSid },
+    );
+  }
+
+  private mergeLateCompactionBoundary(
+    sessionId: SessionId,
+    result: {
+      preTokens?: number;
+      postTokens?: number;
+      durationMs?: number;
+    },
+  ): void {
+    const ownedTabs = this.tabManager
+      .findTabsBySessionId(sessionId)
+      .filter((tab) => tab.claudeSessionId === sessionId);
+    for (const tab of ownedTabs) {
+      this.tabManager.seedPostCompactionContext(tab.id, result.postTokens);
+    }
+    const completedAt = Date.now();
+    for (const convId of this.collectConversationIdsForTabs(
+      ownedTabs.map((tab) => tab.id),
+    )) {
+      this.conversationRegistry.setCompactionMarkerTokens(convId, {
+        preTokens: result.preTokens ?? null,
+        postTokens: result.postTokens ?? null,
+        durationMs: result.durationMs ?? null,
+        completedAt,
+      });
+    }
+    console.info(
+      '[ChatStore] Late compact_boundary merged verified metrics after PostCompact fallback without reload',
+      { sessionId, ownedTabCount: ownedTabs.length },
+    );
+  }
+
+  private beginCompactionGeneration(sessionId: SessionId): void {
+    const prior = this.compactionGenerations.get(sessionId);
+    this.compactionGenerations.delete(sessionId);
+    this.compactionGenerations.set(sessionId, {
+      generation: (prior?.generation ?? 0) + 1,
+      authoritativeGeneration: null,
+    });
+    this.trimCompactionGenerations();
+  }
+
+  private markAuthoritativeCompactionGeneration(sessionId: SessionId): void {
+    const prior = this.compactionGenerations.get(sessionId);
+    this.compactionGenerations.delete(sessionId);
+    const generation = prior?.generation ?? 1;
+    this.compactionGenerations.set(sessionId, {
+      generation,
+      authoritativeGeneration: generation,
+    });
+    this.trimCompactionGenerations();
+  }
+
+  private isAuthoritativelyCompletedGeneration(sessionId: SessionId): boolean {
+    const state = this.compactionGenerations.get(sessionId);
+    return state != null && state.authoritativeGeneration === state.generation;
+  }
+
+  private trimCompactionGenerations(): void {
+    while (
+      this.compactionGenerations.size >
+      CompactionLifecycleService.MAX_COMPACTION_GENERATION_SESSIONS
+    ) {
+      const oldestSessionId = this.compactionGenerations.keys().next().value;
+      if (!oldestSessionId) return;
+      this.compactionGenerations.delete(oldestSessionId);
+    }
   }
 
   /**
@@ -509,8 +783,18 @@ export class CompactionLifecycleService {
    * banner UI reads from the registry.
    */
   clearCompactionStateForTab(tabId: TabId): void {
+    const tab = this.tabManager.tabs().find((candidate) => candidate.id === tabId);
+    if (tab?.claudeSessionId) {
+      this.compactionGenerations.delete(tab.claudeSessionId);
+      const advisory = this.postCompactAdvisories.get(tab.claudeSessionId);
+      if (advisory?.originTabId === tabId && advisory.timeoutId) {
+        clearTimeout(advisory.timeoutId);
+        this.postCompactAdvisories.delete(tab.claudeSessionId);
+      }
+    }
     const convId = this.tabSessionBinding.conversationFor(tabId);
     if (convId) {
+      this.clearCompactionRecoveryTimerForTab(tabId);
       this.conversationRegistry.setCompactionState(convId, { inFlight: false });
     }
   }
@@ -524,19 +808,17 @@ export class CompactionLifecycleService {
    * consulting `tab.isCompacting`.
    */
   clearCompactionState(tabId?: TabId): void {
-    if (this.compactionTimeoutId) {
-      clearTimeout(this.compactionTimeoutId);
-      this.compactionTimeoutId = null;
-    }
     if (tabId) {
       const convId = this.tabSessionBinding.conversationFor(tabId);
       if (convId) {
+        this.clearCompactionRecoveryTimerForTab(tabId);
         this.conversationRegistry.setCompactionState(convId, {
           inFlight: false,
         });
       }
       return;
     }
+    this.clearAllCompactionRecoveryTimers();
     for (const conv of this.conversationRegistry.conversations()) {
       if (conv.compactionInFlight) {
         this.conversationRegistry.setCompactionState(conv.id, {

--- a/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/compaction-lifecycle.service.ts
@@ -11,11 +11,13 @@ import {
   TabId,
   type ConversationId,
 } from '@ptah-extension/chat-state';
+import type { TabState } from '@ptah-extension/chat-types';
 import {
   SessionManager,
   ExecutionTreeBuilderService,
 } from '@ptah-extension/chat-streaming';
 import { SessionLoaderService } from './session-loader.service';
+import { CompactionAdvisoryCorrelator } from './compaction-advisory-correlator.service';
 
 /**
  * CompactionLifecycleService - Owns the SDK session-compaction state machine.
@@ -27,6 +29,12 @@ import { SessionLoaderService } from './session-loader.service';
  *   never sends `compaction_complete`
  * - Compaction-complete reload flow: tree-cache clear, preloadedStats
  *   snapshot, message clear, sidebar refresh, session re-switch
+ *
+ * PostCompact advisory correlation (across SDK session-id rotation) and the
+ * single retry of a stale fallback snapshot live in the injected
+ * `CompactionAdvisoryCorrelator`. Every map operation here goes through the
+ * lifecycle KEY it resolves, so start(A) → rotate to B → completion(B) finds
+ * A's timer, advisory and generation.
  */
 @Injectable({ providedIn: 'root' })
 export class CompactionLifecycleService {
@@ -36,13 +44,14 @@ export class CompactionLifecycleService {
   private readonly sessionLoader = inject(SessionLoaderService);
   /**
    * `ConversationRegistry` is the single source of truth for compaction state.
-   * The lifecycle service writes through here instead of mutating per-tab
-   * `isCompacting`, eliminating the registry/tab drift that left the banner
-   * stuck on the safety timeout when StreamRouter had not registered the
-   * conversation by `compaction_complete` time.
+   * The lifecycle service writes through here instead of mutating a per-tab
+   * flag, eliminating the registry/tab drift that left the banner stuck on the
+   * safety timeout when StreamRouter had not registered the conversation by
+   * `compaction_complete` time.
    */
   private readonly conversationRegistry = inject(ConversationRegistry);
   private readonly tabSessionBinding = inject(TabSessionBinding);
+  private readonly advisoryCorrelator = inject(CompactionAdvisoryCorrelator);
 
   /**
    * Recovery timers are owned by their compacting SDK session. A timer is UI
@@ -83,34 +92,6 @@ export class CompactionLifecycleService {
   private static readonly COMPACTION_SAFETY_TIMEOUT_MS = 600000;
 
   /**
-   * PostCompact is advisory: the SDK hook proves compaction finished, but only
-   * the streamed compact_boundary carries authoritative token metadata. Give
-   * that stream a short turn before recovering the visible transcript.
-   */
-  private static readonly POST_COMPACT_BOUNDARY_WAIT_MS = 250;
-
-  /**
-   * Tracks the independent PostCompact signal without inventing a boundary.
-   * A late real boundary after the fallback may enrich marker metrics, but it
-   * must never replay the destructive completion/reload a second time.
-   *
-   * `generation` records which compaction generation the advisory (or its
-   * applied fallback) belongs to. A fallback record only counts as
-   * "already applied" while it matches the session's current generation —
-   * after a new compaction starts, its late boundary must reload normally.
-   */
-  private readonly postCompactAdvisories = new Map<
-    SessionId,
-    {
-      originTabId: TabId;
-      timeoutId: ReturnType<typeof setTimeout> | null;
-      fallbackApplied: boolean;
-      generation: number;
-    }
-  >();
-  private static readonly MAX_POST_COMPACT_ADVISORY_SESSIONS = 256;
-
-  /**
    * Per-session compaction generations correlate the two independently ordered
    * completion signals. A boundary completing generation N suppresses a later
    * PostCompact for N; the next compaction start advances N and permits its own
@@ -143,6 +124,11 @@ export class CompactionLifecycleService {
    */
   private readonly _suppressAnimateOnce = signal(false);
   readonly suppressAnimateOnce = this._suppressAnimateOnce.asReadonly();
+
+  /** Whether `sessionId` keys a recovery timer or a compaction generation. */
+  private readonly hasLifecycleState = (sessionId: SessionId): boolean =>
+    this.compactionRecoveryTimers.has(sessionId) ||
+    this.compactionGenerations.has(sessionId);
 
   /**
    * Whether the conversation bound to `rawTabId` has a compaction in flight.
@@ -185,9 +171,7 @@ export class CompactionLifecycleService {
     // A new compaction supersedes any advisory left by the previous one; a
     // retained `fallbackApplied` entry would otherwise turn this generation's
     // real boundary into a metrics-only merge and skip its reload.
-    const staleAdvisory = this.postCompactAdvisories.get(compactionSid);
-    if (staleAdvisory?.timeoutId) clearTimeout(staleAdvisory.timeoutId);
-    this.postCompactAdvisories.delete(compactionSid);
+    this.advisoryCorrelator.delete(compactionSid);
     this.beginCompactionGeneration(compactionSid);
     const compactingConvIds = this.ensureConversationIdsForTabs(
       tabs.map((t) => t.id),
@@ -249,10 +233,13 @@ export class CompactionLifecycleService {
   private clearCompactionRecoveryTimerForTab(tabId: TabId): void {
     const tab = this.tabManager.tabs().find((candidate) => candidate.id === tabId);
     if (!tab?.claudeSessionId) return;
-    const sessionId = tab.claudeSessionId;
-    const recovery = this.compactionRecoveryTimers.get(sessionId);
+    const { key } = this.advisoryCorrelator.resolveLifecycleKey(
+      tab.claudeSessionId,
+      this.hasLifecycleState,
+    );
+    const recovery = this.compactionRecoveryTimers.get(key);
     if (!recovery || !recovery.tabIds.includes(tabId)) return;
-    this.clearCompactionRecoveryTimer(sessionId);
+    this.clearCompactionRecoveryTimer(key);
   }
 
   private clearAllCompactionRecoveryTimers(): void {
@@ -260,10 +247,7 @@ export class CompactionLifecycleService {
       clearTimeout(recovery.timeoutId);
     }
     this.compactionRecoveryTimers.clear();
-    for (const advisory of this.postCompactAdvisories.values()) {
-      if (advisory.timeoutId) clearTimeout(advisory.timeoutId);
-    }
-    this.postCompactAdvisories.clear();
+    this.advisoryCorrelator.clearAll();
     // `compactionGenerations` is deliberately NOT cleared: handleCompactionComplete
     // marks a generation authoritative there, and this method runs on the
     // CHAT_ERROR cleanup path — wiping it would let a later PostCompact
@@ -276,19 +260,17 @@ export class CompactionLifecycleService {
    * READ-ONLY resolution: the set of unique conversation ids ALREADY bound to
    * the given tabs. Tabs with no binding are silently skipped — see the C1
    * fallback contract: `chat-view` reads exclusively from the registry, so an
-   * unbound tab simply will not render a banner. The previous fallback to
-   * `tab.isCompacting` is the bug that fix removed, and it STAYS removed: a
-   * per-tab boolean is a second source of truth for compaction state and is
-   * exactly the registry/tab drift the registry exists to eliminate.
+   * unbound tab simply will not render a banner. A per-tab boolean fallback is
+   * a second source of truth for compaction state and is exactly the
+   * registry/tab drift the registry exists to eliminate.
    *
-   * `ensureConversationIdsForTabs` is NOT a reintroduction of that fallback.
-   * It never reads `tab.isCompacting` and never invents state — it mints a
-   * real `ConversationRegistry` record and a real `TabSessionBinding` edge, so
-   * afterwards this method resolves the tab through the ordinary path like any
-   * router-bound tab. One is "guess from a stale tab flag"; the other is
-   * "create the binding that was missing". Use this read-only variant on the
-   * fan-out/teardown paths, where a tab that was never part of the compaction
-   * must not acquire a conversation as a side effect of cleanup.
+   * `ensureConversationIdsForTabs` is NOT such a fallback. It never reads a
+   * tab flag and never invents state — it mints a real `ConversationRegistry`
+   * record and a real `TabSessionBinding` edge, so afterwards this method
+   * resolves the tab through the ordinary path like any router-bound tab. Use
+   * this read-only variant on the fan-out/teardown paths, where a tab that was
+   * never part of the compaction must not acquire a conversation as a side
+   * effect of cleanup.
    */
   private collectConversationIdsForTabs(
     tabIds: readonly TabId[],
@@ -378,6 +360,9 @@ export class CompactionLifecycleService {
    * the same conversation as the originating tab) and apply the
    * preserved stats + `markTabIdle` to each. Every cleared tab is reloaded by
    * its explicit tab id so duplicate session representations recover in place.
+   *
+   * Timers, advisories and generations are addressed by the lifecycle KEY:
+   * a completion keyed B for a compaction started under A settles A's state.
    */
   handleCompactionComplete(result: {
     tabId: string;
@@ -388,31 +373,42 @@ export class CompactionLifecycleService {
     advisoryFallback?: boolean;
   }): void {
     const compactionSid = SessionId.from(result.compactionSessionId);
+    const { key } = this.advisoryCorrelator.resolveLifecycleKey(
+      compactionSid,
+      this.hasLifecycleState,
+    );
     if (!result.advisoryFallback) {
       // Snapshot the current generation BEFORE the authoritative stamp: the
       // stamp resurrects a deleted entry with generation 1, which would break
       // the match for an advisory armed before any compaction start (gen 0).
-      const generationAtBoundary = this.currentCompactionGeneration(compactionSid);
-      this.markAuthoritativeCompactionGeneration(compactionSid);
-      const advisory = this.postCompactAdvisories.get(compactionSid);
+      const generationAtBoundary = this.currentCompactionGeneration(key);
+      this.markAuthoritativeCompactionGeneration(key);
+      const advisory = this.advisoryCorrelator.get(key);
       if (advisory?.timeoutId) {
-        clearTimeout(advisory.timeoutId);
-        this.postCompactAdvisories.delete(compactionSid);
+        this.advisoryCorrelator.delete(key);
       } else if (advisory?.fallbackApplied) {
         if (advisory.generation === generationAtBoundary) {
           // Same generation: merge the late boundary's metrics/context seed
-          // without a second reload or another compaction-count increment.
-          this.mergeLateCompactionBoundary(compactionSid, result);
-          this.postCompactAdvisories.delete(compactionSid);
+          // without another compaction-count increment. A fallback whose
+          // snapshot came back stale still owes the transcript a verified
+          // reload, and this boundary is the evidence it was waiting for.
+          const ownedTabs = this.mergeLateCompactionBoundary(
+            [compactionSid, key],
+            result,
+          );
+          if (advisory.fallbackStale) {
+            this.reloadWithoutReapplying(ownedTabs, compactionSid);
+          }
+          this.advisoryCorrelator.delete(key);
           return;
         }
         // The fallback belonged to an older generation; the boundary arriving
         // now is for the current one and must take the full reload path.
-        this.postCompactAdvisories.delete(compactionSid);
+        this.advisoryCorrelator.delete(key);
       }
     }
     this.treeBuilder.clearCache();
-    this.clearCompactionRecoveryTimer(compactionSid);
+    this.clearCompactionRecoveryTimer(key);
     const allTabs = this.tabManager.tabs();
     const originatingTab = allTabs.find((t) => t.id === result.tabId);
     const sessionTabs = this.tabManager.findTabsBySessionId(compactionSid);
@@ -439,10 +435,11 @@ export class CompactionLifecycleService {
     }
 
     // (2) Conversation expansion. Resolve the conversation ids for the tabs
-    //     collected so far plus the conversation that contains the compacting
-    //     session, then expand each conversation back to all of its bound tabs.
-    //     Catches tiles whose `claudeSessionId` has rotated away from
-    //     `compactionSessionId` but that still belong to the same conversation.
+    //     collected so far plus the conversations that contain the compacting
+    //     session and its lifecycle key, then expand each conversation back to
+    //     all of its bound tabs. Catches tiles whose `claudeSessionId` has
+    //     rotated away from `compactionSessionId` but that still belong to the
+    //     same conversation.
     const convIds = new Set<ConversationId>();
     for (const t of fanoutMap.values()) {
       if (!t) continue;
@@ -452,6 +449,10 @@ export class CompactionLifecycleService {
     const containingConv =
       this.conversationRegistry.findContainingSession(compactionSid);
     if (containingConv) convIds.add(containingConv.id);
+    if (key !== compactionSid) {
+      const keyConv = this.conversationRegistry.findContainingSession(key);
+      if (keyConv) convIds.add(keyConv.id);
+    }
     for (const convId of convIds) {
       for (const boundTabId of this.tabSessionBinding.tabsFor(convId)) {
         if (fanoutMap.has(boundTabId)) continue;
@@ -522,6 +523,7 @@ export class CompactionLifecycleService {
     console.warn('[compaction-diag] handleCompactionComplete decision', {
       resultTabId: result.tabId,
       compactionSessionId: result.compactionSessionId,
+      lifecycleKey: key,
       originatingTabFound: !!originatingTab,
       allTabs: allTabs.map((t) => ({
         id: t.id,
@@ -595,11 +597,16 @@ export class CompactionLifecycleService {
         this.clearCompactionStateForFanout(fanoutTabs);
         return;
       }
+      const staleTargets: TabId[] = [];
       let pending = reloadTargets.length;
       const onSettle = (): void => {
         pending -= 1;
         if (pending > 0) return;
+        // The banner clears even when a snapshot was stale.
         this.clearCompactionStateForFanout(fanoutTabs);
+        if (result.advisoryFallback && staleTargets.length > 0) {
+          this.retryStaleFallbackOnce(key, staleTargets, compactionSid);
+        }
       };
       for (const target of reloadTargets) {
         this.sessionLoader
@@ -607,12 +614,19 @@ export class CompactionLifecycleService {
             reason: 'compaction',
             targetTabId: target.tabId,
           })
-          .catch((err) => {
-            console.warn(
-              '[ChatStore] Failed to reload session after compaction:',
-              err,
-            );
-          })
+          // One `then(resolved, rejected)` hop, not `then().catch()`: the settle
+          // handler keeps the same microtask position it always had.
+          .then(
+            (outcome) => {
+              if (outcome?.staleSnapshot) staleTargets.push(target.tabId);
+            },
+            (err: unknown) => {
+              console.warn(
+                '[ChatStore] Failed to reload session after compaction:',
+                err,
+              );
+            },
+          )
           .finally(onSettle);
       }
     } else {
@@ -626,20 +640,31 @@ export class CompactionLifecycleService {
    * `ConversationRegistry` so SESSION_STATS no longer needs a wall-clock
    * grace window to detect the post-compaction tail. Fans out to every tab
    * bound to the payload's session id and stamps each conversation once.
-   * No-tab-bound case warns and no-ops (does NOT throw) so a stale RPC
-   * delivery after tab close does not crash the webview.
+   * An id unknown to every tab AND conversation warns and no-ops (does NOT
+   * throw) so a stale RPC delivery after tab close does not crash the webview.
    *
    * A tab that exists but has no conversation binding is NOT the no-op case.
    * This push routinely lands before `StreamRouter` has bound the tab, and
    * returning early there is what left the compaction marker without its
    * summary. `ensureConversationIdsForTabs` establishes the binding instead,
    * so the stamp always has somewhere to land.
+   *
+   * The payload id may be a rotated alias of the id the compaction started
+   * under; the correlator resolves both the tabs and the lifecycle key.
    */
   handleCompactionCompleteNotification(
     payload: SdkCompactionCompletePayload,
   ): void {
     const compactionSid = SessionId.from(payload.sessionId);
-    const tabs = this.tabManager.findTabsBySessionId(compactionSid);
+    const lifecycle = this.advisoryCorrelator.resolveLifecycleKey(
+      compactionSid,
+      this.hasLifecycleState,
+    );
+    const { key } = lifecycle;
+    const tabs = this.advisoryCorrelator.tabsForCompaction({
+      ...lifecycle,
+      incoming: compactionSid,
+    });
     if (tabs.length === 0) {
       console.warn(
         '[ChatStore] handleCompactionCompleteNotification: no tab bound to sessionId',
@@ -674,7 +699,7 @@ export class CompactionLifecycleService {
 
     // PostCompact is advisory. A compact_boundary may have completed this
     // generation first; do not let its later hook delivery replay completion.
-    if (this.isAuthoritativelyCompletedGeneration(compactionSid)) {
+    if (this.isAuthoritativelyCompletedGeneration(key)) {
       console.info(
         '[ChatStore] PostCompact advisory ignored; matching compact_boundary already completed',
         { sessionId: compactionSid },
@@ -683,64 +708,96 @@ export class CompactionLifecycleService {
     }
     // Deduplicate repeated hook deliveries and let a real compact_boundary own
     // the normal authoritative completion path.
-    if (this.postCompactAdvisories.has(compactionSid)) return;
-    const timeoutId = setTimeout(() => {
-      const advisory = this.postCompactAdvisories.get(compactionSid);
-      if (!advisory || advisory.timeoutId !== timeoutId) return;
-      advisory.timeoutId = null;
-
-      // Re-read ownership immediately before fallback mutation. A closed or
-      // rebound tab is no longer an owner and cannot be reloaded by this hook.
-      const origin = this.tabManager
-        .tabs()
-        .find((tab) => tab.id === advisory.originTabId);
-      if (origin?.claudeSessionId !== compactionSid) {
-        this.postCompactAdvisories.delete(compactionSid);
-        console.info(
-          '[ChatStore] PostCompact advisory fallback skipped; originating tab no longer owns session',
-          { sessionId: compactionSid, tabId: advisory.originTabId },
-        );
-        return;
-      }
-
-      advisory.fallbackApplied = true;
-      console.info(
-        '[ChatStore] PostCompact advisory fallback applying one targeted reload without boundary metrics',
-        { sessionId: compactionSid, tabId: origin.id },
-      );
-      this.handleCompactionComplete({
-        tabId: origin.id,
-        compactionSessionId: compactionSid,
-        advisoryFallback: true,
-      });
-      // Retain the record so a later boundary can merge metrics without a
-      // second reload or another compaction-count increment.
-      this.postCompactAdvisories.set(compactionSid, advisory);
-    }, CompactionLifecycleService.POST_COMPACT_BOUNDARY_WAIT_MS);
-    this.postCompactAdvisories.set(compactionSid, {
-      originTabId: tabs[0].id,
-      timeoutId,
-      fallbackApplied: false,
-      generation: this.currentCompactionGeneration(compactionSid),
+    if (this.advisoryCorrelator.has(key)) return;
+    this.advisoryCorrelator.schedule({
+      key,
+      incoming: compactionSid,
+      conversationId: lifecycle.conversationId ?? convIds[0] ?? null,
+      originTabId: this.advisoryCorrelator.originTabFor(
+        tabs,
+        compactionSid,
+        this.compactionRecoveryTimers.get(key)?.tabIds ?? [],
+      ),
+      generation: this.currentCompactionGeneration(key),
+      onFallback: (originTabId) =>
+        this.handleCompactionComplete({
+          tabId: originTabId,
+          compactionSessionId: compactionSid,
+          advisoryFallback: true,
+        }),
     });
-    this.trimPostCompactAdvisories();
     console.info(
       '[ChatStore] PostCompact advisory received; waiting briefly for real compact_boundary',
       { sessionId: compactionSid },
     );
   }
 
+  /**
+   * The fallback reload for `staleTabIds` came back unverified. Retry it once,
+   * by each tab's CURRENT session id, with no count increment and no re-seed.
+   */
+  private retryStaleFallbackOnce(
+    key: SessionId,
+    staleTabIds: readonly TabId[],
+    compactionSid: SessionId,
+  ): void {
+    this.advisoryCorrelator.scheduleStaleRetry(key, async () => {
+      let stillStale = false;
+      for (const tabId of staleTabIds) {
+        const tab = this.tabManager.tabs().find((t) => t.id === tabId);
+        if (!tab) continue;
+        try {
+          const outcome = await this.sessionLoader.switchSession(
+            tab.claudeSessionId ?? compactionSid,
+            { reason: 'compaction', targetTabId: tabId },
+          );
+          if (outcome?.staleSnapshot) stillStale = true;
+        } catch (err: unknown) {
+          console.warn(
+            '[ChatStore] Failed to retry a stale compaction reload:',
+            err,
+          );
+        }
+      }
+      return stillStale;
+    });
+  }
+
+  /** Reload tabs by their current session id without re-applying completion. */
+  private reloadWithoutReapplying(
+    tabs: readonly TabState[],
+    compactionSid: SessionId,
+  ): void {
+    for (const tab of tabs) {
+      this.sessionLoader
+        .switchSession(tab.claudeSessionId ?? compactionSid, {
+          reason: 'compaction',
+          targetTabId: tab.id,
+        })
+        .catch((err: unknown) => {
+          console.warn(
+            '[ChatStore] Failed to reload a stale compaction snapshot after its boundary:',
+            err,
+          );
+        });
+    }
+  }
+
   private mergeLateCompactionBoundary(
-    sessionId: SessionId,
+    sessionIds: readonly SessionId[],
     result: {
       preTokens?: number;
       postTokens?: number;
       durationMs?: number;
     },
-  ): void {
-    const ownedTabs = this.tabManager
-      .findTabsBySessionId(sessionId)
-      .filter((tab) => tab.claudeSessionId === sessionId);
+  ): TabState[] {
+    const owned = new Map<string, TabState>();
+    for (const sessionId of new Set(sessionIds)) {
+      for (const tab of this.tabManager.findTabsBySessionId(sessionId)) {
+        if (tab.claudeSessionId === sessionId) owned.set(tab.id, tab);
+      }
+    }
+    const ownedTabs = Array.from(owned.values());
     for (const tab of ownedTabs) {
       this.tabManager.seedPostCompactionContext(tab.id, result.postTokens);
     }
@@ -757,8 +814,9 @@ export class CompactionLifecycleService {
     }
     console.info(
       '[ChatStore] Late compact_boundary merged verified metrics after PostCompact fallback without reload',
-      { sessionId, ownedTabCount: ownedTabs.length },
+      { sessionId: sessionIds[0], ownedTabCount: ownedTabs.length },
     );
+    return ownedTabs;
   }
 
   private beginCompactionGeneration(sessionId: SessionId): void {
@@ -789,22 +847,6 @@ export class CompactionLifecycleService {
 
   private currentCompactionGeneration(sessionId: SessionId): number {
     return this.compactionGenerations.get(sessionId)?.generation ?? 0;
-  }
-
-  /**
-   * Bound the advisory map the same way the generation map is bounded: a
-   * `fallbackApplied` record whose session never sees another boundary used to
-   * accumulate without limit (PR #493 review D).
-   */
-  private trimPostCompactAdvisories(): void {
-    while (
-      this.postCompactAdvisories.size >
-      CompactionLifecycleService.MAX_POST_COMPACT_ADVISORY_SESSIONS
-    ) {
-      const oldestSessionId = this.postCompactAdvisories.keys().next().value;
-      if (!oldestSessionId) return;
-      this.postCompactAdvisories.delete(oldestSessionId);
-    }
   }
 
   private trimCompactionGenerations(): void {
@@ -844,31 +886,20 @@ export class CompactionLifecycleService {
    * Public for use by ChatMessageHandler on CHAT_COMPLETE.
    *
    * Clears the in-flight flag on the conversation registry (single source
-   * of truth). The legacy per-tab `isCompacting` flag is no longer written;
-   * banner UI reads from the registry.
+   * of truth); banner and input overlay read from the registry. The
+   * generation and timer are addressed through the tab's CURRENT session's
+   * lifecycle key, so a rotated tab still clears its compaction's state.
    */
   clearCompactionStateForTab(tabId: TabId): void {
     const tab = this.tabManager.tabs().find((candidate) => candidate.id === tabId);
     if (tab?.claudeSessionId) {
-      this.compactionGenerations.delete(tab.claudeSessionId);
+      const { key } = this.advisoryCorrelator.resolveLifecycleKey(
+        tab.claudeSessionId,
+        this.hasLifecycleState,
+      );
+      this.compactionGenerations.delete(key);
     }
-    // Drop advisories this tab originated. The sweep keys off the record's
-    // own `originTabId`, not off the live tab list — a CLOSED tab is already
-    // gone from `tabs()`, so its session is resolvable only through the
-    // record. A pending (timed) advisory dies with its tab; a `fallbackApplied`
-    // record survives only while another tab still owns the session, so a
-    // late boundary can merge its metrics there. Left alone these records
-    // accumulated without bound (PR #493 review D).
-    for (const [advisorySessionId, advisory] of this.postCompactAdvisories) {
-      if (advisory.originTabId !== tabId) continue;
-      if (advisory.timeoutId) clearTimeout(advisory.timeoutId);
-      const sessionStillOwnedByAnotherTab = this.tabManager
-        .findTabsBySessionId(advisorySessionId)
-        .some((candidate) => candidate.id !== tabId);
-      if (advisory.timeoutId || !sessionStillOwnedByAnotherTab) {
-        this.postCompactAdvisories.delete(advisorySessionId);
-      }
-    }
+    this.advisoryCorrelator.dropForTab(tabId);
     const convId = this.tabSessionBinding.conversationFor(tabId);
     if (convId) {
       this.clearCompactionRecoveryTimerForTab(tabId);
@@ -882,7 +913,7 @@ export class CompactionLifecycleService {
    * Sweeps the conversation registry instead of the tab list. The "no tabId"
    * path walks every conversation with `inFlight=true` and clears it; this
    * preserves the "drop banners everywhere on stale state" semantics without
-   * consulting `tab.isCompacting`.
+   * consulting any per-tab flag.
    */
   clearCompactionState(tabId?: TabId): void {
     if (tabId) {

--- a/libs/frontend/chat/src/lib/services/chat-store/message-dispatch.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/message-dispatch.service.spec.ts
@@ -50,7 +50,6 @@ function makeTab(overrides: Partial<TabState> = {}): TabState {
     streamingState: null,
     currentMessageId: null,
     claudeSessionId: 'sess-1',
-    isCompacting: false,
     queuedContent: null,
     queuedOptions: null,
     ...overrides,

--- a/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts
@@ -299,6 +299,98 @@ describe('SessionLoaderService', () => {
       ]);
     });
 
+    it('applyResumeStats uses snapshot.contextWindow (gpt-5.6-sol, 400000) instead of the name lookup', async () => {
+      const restoredTabId = TabId.from('0b1f7f7e-5b8a-4c7e-9d1a-4f2d6a3b8c11');
+      activeTabSessionIdSignal.set(SESSION);
+      activeTabIdSignal.set(restoredTabId);
+      const stats = {
+        totalCost: null,
+        tokens: { input: 40_000, output: 1_000, cacheRead: 0, cacheCreation: 0 },
+        messageCount: 3,
+        model: 'gpt-5.6-sol',
+        modelUsageList: [
+          {
+            model: 'gpt-5.6-sol',
+            inputTokens: 40_000,
+            outputTokens: 1_000,
+            costUSD: null,
+            contextWindow: 400_000,
+          },
+        ],
+        contextSnapshot: {
+          model: 'gpt-5.6-sol',
+          contextTokens: 40_000,
+          contextWindow: 400_000,
+        },
+      };
+      rpcCall.mockImplementation(async (method: string) =>
+        method === 'chat:resume'
+          ? { success: true, data: { stats } }
+          : { success: true, data: {} },
+      );
+
+      activeTabStatusSignal.set('loaded');
+      TestBed.tick();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setLiveModelStats).toHaveBeenCalledWith(restoredTabId, {
+        model: 'gpt-5.6-sol',
+        contextUsed: 40_000,
+        contextWindow: 400_000,
+        contextPercent: 10,
+      });
+      expect(setModelUsageList).toHaveBeenCalledWith(restoredTabId, [
+        expect.objectContaining({
+          model: 'gpt-5.6-sol',
+          contextWindow: 400_000,
+        }),
+      ]);
+    });
+
+    it('falls back to getModelContextWindow when the field is absent or not positive', async () => {
+      const restoredTabId = TabId.from('3c9e2f4a-7d1b-4e6a-8b2c-5a9f0e1d7c22');
+      activeTabSessionIdSignal.set(SESSION);
+      activeTabIdSignal.set(restoredTabId);
+      const stats = {
+        totalCost: 1,
+        tokens: { input: 10, output: 2, cacheRead: 0, cacheCreation: 0 },
+        messageCount: 1,
+        model: 'claude-opus-5',
+        modelUsageList: [
+          {
+            model: 'claude-sonnet-4-5',
+            inputTokens: 10,
+            outputTokens: 2,
+            costUSD: 1,
+          },
+        ],
+        contextSnapshot: {
+          model: 'claude-opus-5',
+          contextTokens: 10_000,
+          contextWindow: 0,
+        },
+      };
+      rpcCall.mockImplementation(async (method: string) =>
+        method === 'chat:resume'
+          ? { success: true, data: { stats } }
+          : { success: true, data: {} },
+      );
+
+      activeTabStatusSignal.set('loaded');
+      TestBed.tick();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(setLiveModelStats).toHaveBeenCalledWith(
+        restoredTabId,
+        expect.objectContaining({ contextWindow: 1_000_000 }),
+      );
+      expect(setModelUsageList).toHaveBeenCalledWith(restoredTabId, [
+        expect.objectContaining({ contextWindow: 200_000 }),
+      ]);
+    });
+
     it('clears stale restored-tab stats when a successful resume has no stats', async () => {
       const restoredTabId = TabId.from('c74b7af0-4c5c-4336-821c-e2fe28cd921d');
       activeTabSessionIdSignal.set(SESSION);

--- a/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts
@@ -1392,7 +1392,7 @@ describe('SessionLoaderService', () => {
           reason: 'compaction',
           targetTabId: TAB_B,
         }),
-      ).resolves.toBeUndefined();
+      ).resolves.toEqual({ staleSnapshot: true });
 
       expect(harness.applyResumeFailure).toHaveBeenCalledWith(TAB_B);
       expect(harness.markTabIdle).toHaveBeenCalledWith(TAB_B);
@@ -1404,6 +1404,37 @@ describe('SessionLoaderService', () => {
       expect(harness.processStreamEvent).not.toHaveBeenCalled();
       expect(harness.finalizeSessionHistory).not.toHaveBeenCalled();
       expect(harness.setPreloadedStats).not.toHaveBeenCalled();
+    });
+
+    it('switchSession resolves { staleSnapshot: false } for a verified compaction reload and a normal resume', async () => {
+      const harness = makeTargetedService();
+      rpcCall.mockImplementation(async (method: string) =>
+        method === 'chat:resume'
+          ? {
+              success: true,
+              data: {
+                messages: [
+                  {
+                    id: 'm-verified',
+                    role: 'assistant',
+                    timestamp: 1,
+                    content: 'verified',
+                  },
+                ],
+              },
+            }
+          : { success: true, data: {} },
+      );
+
+      await expect(
+        harness.service.switchSession(SESSION, {
+          reason: 'compaction',
+          targetTabId: TAB_B,
+        }),
+      ).resolves.toEqual({ staleSnapshot: false });
+      await expect(harness.service.switchSession(SESSION)).resolves.toEqual({
+        staleSnapshot: false,
+      });
     });
 
     it('applies a staleSnapshot response on a normal resume', async () => {

--- a/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.spec.ts
@@ -1009,6 +1009,8 @@ describe('SessionLoaderService', () => {
       const markSessionActive = jest.fn();
       const setPreloadedStats = jest.fn();
       const setLiveModelStats = jest.fn();
+      const applyResumeFailure = jest.fn();
+      const markTabIdle = jest.fn();
 
       const tabManagerMock = {
         pendingSessionLoad: computed(() => null),
@@ -1025,7 +1027,8 @@ describe('SessionLoaderService', () => {
         switchTab: jest.fn(),
         openSessionTab,
         applyResumingSession,
-        applyResumeFailure: jest.fn(),
+        applyResumeFailure,
+        markTabIdle,
         applyResumedHistory,
         applyLoadedSessionStats,
         setLiveModelStats,
@@ -1078,6 +1081,9 @@ describe('SessionLoaderService', () => {
         markSessionActive,
         setPreloadedStats,
         setLiveModelStats,
+        applyResumeFailure,
+        markTabIdle,
+        sessionManagerMock,
       };
     }
 
@@ -1133,6 +1139,63 @@ describe('SessionLoaderService', () => {
         undefined,
       );
     });
+
+    it.each([
+      ['absent', undefined],
+      ['zero', { model: 'claude-sonnet-4-5', contextTokens: 0 }],
+      ['historical', { model: 'claude-sonnet-4-5', contextTokens: 85_000 }],
+    ])(
+      'preserves a fresh compaction context seed over %s history context stats',
+      async (_historyKind, contextSnapshot) => {
+        const seededLiveStats = {
+          model: 'claude-opus-5',
+          contextUsed: 1200,
+          contextWindow: 1_000_000,
+          contextPercent: 0.1,
+        };
+        const harness = makeTargetedService([
+          { id: TAB_A, claudeSessionId: SESSION, name: 'A' },
+          {
+            id: TAB_B,
+            claudeSessionId: SESSION,
+            name: 'B',
+            liveModelStats: seededLiveStats,
+          },
+        ]);
+        rpcCall.mockImplementation(async (method: string) =>
+          method === 'chat:resume'
+            ? {
+                success: true,
+                data: {
+                  events: [{ type: 'noop' }],
+                  stats: {
+                    totalCost: 4.2,
+                    tokens: {
+                      input: 10,
+                      output: 5,
+                      cacheRead: 2,
+                      cacheCreation: 1,
+                    },
+                    messageCount: 3,
+                    model: 'claude-sonnet-4-5',
+                    ...(contextSnapshot ? { contextSnapshot } : {}),
+                  },
+                },
+              }
+            : { success: true, data: {} },
+        );
+
+        await harness.service.switchSession(SESSION, {
+          reason: 'compaction',
+          targetTabId: TAB_B,
+        });
+
+        expect(harness.setLiveModelStats).toHaveBeenLastCalledWith(
+          TAB_B,
+          seededLiveStats,
+        );
+      },
+    );
 
     it('uses the dedicated context snapshot model instead of aggregate resume stats for the gauge', async () => {
       const harness = makeTargetedService();
@@ -1215,6 +1278,110 @@ describe('SessionLoaderService', () => {
       expect(harness.setPreloadedStats).not.toHaveBeenCalled();
     });
 
+    it('contains a stale targeted compaction snapshot and settles the tab idle', async () => {
+      const harness = makeTargetedService();
+      rpcCall.mockImplementation(async (method: string) =>
+        method === 'chat:resume'
+          ? {
+              success: true,
+              data: {
+                staleSnapshot: true as const,
+                events: [{ type: 'stale-event' }],
+                stats: { totalCost: 99 },
+                cliSessions: [{ agentId: 'stale-agent' }],
+                resumableSubagents: [{ toolCallId: 'stale-subagent' }],
+              },
+            }
+          : { success: true, data: {} },
+      );
+
+      await expect(
+        harness.service.switchSession(SESSION, {
+          reason: 'compaction',
+          targetTabId: TAB_B,
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(harness.applyResumeFailure).toHaveBeenCalledWith(TAB_B);
+      expect(harness.markTabIdle).toHaveBeenCalledWith(TAB_B);
+      expect(harness.sessionManagerMock.setStatus).toHaveBeenLastCalledWith(
+        'loaded',
+      );
+      expect(harness.applyLoadedSessionStats).not.toHaveBeenCalled();
+      expect(harness.applyResumedHistory).not.toHaveBeenCalled();
+      expect(harness.processStreamEvent).not.toHaveBeenCalled();
+      expect(harness.finalizeSessionHistory).not.toHaveBeenCalled();
+      expect(harness.setPreloadedStats).not.toHaveBeenCalled();
+    });
+
+    it('applies a staleSnapshot response on a normal resume', async () => {
+      const harness = makeTargetedService();
+      rpcCall.mockImplementation(async (method: string) =>
+        method === 'chat:resume'
+          ? {
+              success: true,
+              data: {
+                staleSnapshot: true as const,
+                messages: [
+                  {
+                    id: 'm-normal-stale',
+                    role: 'assistant',
+                    timestamp: 1,
+                    content: 'normal resume still applies',
+                  },
+                ],
+              },
+            }
+          : { success: true, data: {} },
+      );
+
+      await harness.service.switchSession(SESSION);
+
+      expect(harness.applyResumedHistory).toHaveBeenCalledWith(
+        TAB_A,
+        expect.arrayContaining([
+          expect.objectContaining({ id: 'm-normal-stale' }),
+        ]),
+      );
+      expect(harness.applyResumeFailure).not.toHaveBeenCalled();
+    });
+
+    it('adopts a null-owned target for a compaction reload', async () => {
+      const harness = makeTargetedService([
+        {
+          id: TAB_A,
+          claudeSessionId: null as unknown as SessionId,
+          name: 'adoptable',
+        },
+      ]);
+      rpcCall.mockImplementation(async (method: string) =>
+        method === 'chat:resume'
+          ? {
+              success: true,
+              data: {
+                messages: [
+                  { id: 'm-adopt', role: 'assistant', timestamp: 1, content: 'ok' },
+                ],
+              },
+            }
+          : { success: true, data: {} },
+      );
+
+      await harness.service.switchSession(SESSION, {
+        reason: 'compaction',
+        targetTabId: TAB_A,
+      });
+
+      expect(harness.applyResumingSession).toHaveBeenCalledWith(
+        TAB_A,
+        expect.objectContaining({ sessionId: SESSION }),
+      );
+      expect(harness.applyResumedHistory).toHaveBeenCalledWith(
+        TAB_A,
+        expect.anything(),
+      );
+    });
+
     it('fails loudly when the target does not own the requested session', async () => {
       const harness = makeTargetedService([
         {
@@ -1294,6 +1461,42 @@ describe('SessionLoaderService', () => {
       expect(harness.applyLoadedSessionStats).not.toHaveBeenCalled();
       expect(harness.processStreamEvent).not.toHaveBeenCalled();
       expect(harness.finalizeSessionHistory).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates concurrent compaction reloads for the same target tab', async () => {
+      let resolveLoad!: (value: { success: true; data: object }) => void;
+      const load = new Promise<{ success: true; data: object }>((resolve) => {
+        resolveLoad = resolve;
+      });
+      const harness = makeTargetedService();
+      rpcCall.mockImplementation((method: string) =>
+        method === 'session:load'
+          ? load
+          : Promise.resolve({
+              success: true,
+              data: {
+                messages: [
+                  { id: 'm-dedupe', role: 'assistant', timestamp: 1, content: 'ok' },
+                ],
+              },
+            }),
+      );
+
+      const first = harness.service.switchSession(SESSION, {
+        reason: 'compaction',
+        targetTabId: TAB_A,
+      });
+      const duplicate = harness.service.switchSession(SESSION, {
+        reason: 'compaction',
+        targetTabId: TAB_A,
+      });
+
+      expect(
+        rpcCall.mock.calls.filter(([method]) => method === 'session:load'),
+      ).toHaveLength(1);
+      resolveLoad({ success: true, data: {} });
+      await Promise.all([first, duplicate]);
+      expect(harness.applyResumedHistory).toHaveBeenCalledTimes(1);
     });
 
     it('keys in-flight targeted loads by both session and tab', async () => {

--- a/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts
@@ -811,7 +811,7 @@ export class SessionLoaderService {
       tabId,
       (stats.modelUsageList ?? []).map((entry) => ({
         ...entry,
-        contextWindow: getModelContextWindow(entry.model),
+        contextWindow: this.wireContextWindow(entry.contextWindow, entry.model),
       })),
     );
 
@@ -830,7 +830,10 @@ export class SessionLoaderService {
       return;
     }
 
-    const contextWindow = getModelContextWindow(snapshot.model);
+    const contextWindow = this.wireContextWindow(
+      snapshot.contextWindow,
+      snapshot.model,
+    );
     this.tabManager.setLiveModelStats(tabId, {
       model: snapshot.model,
       contextUsed: snapshot.contextTokens,
@@ -840,6 +843,20 @@ export class SessionLoaderService {
           ? Math.round((snapshot.contextTokens / contextWindow) * 1000) / 10
           : 0,
     });
+  }
+
+  /**
+   * The backend carries the window it knows (including provider-discovered
+   * ones the renderer's bundled table cannot resolve). Reverse-resolving from
+   * the model name is only the fallback for an older payload or unknown model.
+   */
+  private wireContextWindow(
+    carried: number | undefined,
+    model: string,
+  ): number {
+    return typeof carried === 'number' && Number.isFinite(carried) && carried > 0
+      ? carried
+      : getModelContextWindow(model);
   }
 
   /**

--- a/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts
@@ -631,12 +631,18 @@ export class SessionLoaderService {
       if (targetTabId) {
         this.streamingHandler.clearPendingUpdates(resolvedTabId);
       }
-      this.tabManager.applyResumingSession(resolvedTabId, {
-        sessionId,
-        name: title,
-        title,
-        streamingState: createEmptyStreamingState(),
-      });
+      // A targeted compaction reload must keep the compacted transcript visible
+      // until its immutable snapshot is known to be boundary-ready. Applying
+      // the normal resume initializer here would clear that transcript before a
+      // staleSnapshot response can be contained.
+      if (opts?.reason !== 'compaction' || !targetTabId) {
+        this.tabManager.applyResumingSession(resolvedTabId, {
+          sessionId,
+          name: title,
+          title,
+          streamingState: createEmptyStreamingState(),
+        });
+      }
       this.sessionManager.setNodeMaps(
         {
           agents: new Map(),
@@ -671,6 +677,29 @@ export class SessionLoaderService {
         this.requireTargetTab(sessionId, targetTabId);
       }
 
+      if (
+        opts?.reason === 'compaction' &&
+        targetTabId &&
+        resumeResult.data?.staleSnapshot === true
+      ) {
+        // The backend could not verify this compaction snapshot's boundary.
+        // Do not let its stale transcript, stats, or auxiliary state replace
+        // the compaction marker and preloaded totals already on this tab.
+        this.tabManager.applyResumeFailure(resolvedTabId);
+        this.tabManager.markTabIdle(resolvedTabId);
+        this.sessionManager.setStatus('loaded');
+        return;
+      }
+
+      if (opts?.reason === 'compaction' && targetTabId) {
+        this.tabManager.applyResumingSession(resolvedTabId, {
+          sessionId,
+          name: title,
+          title,
+          streamingState: createEmptyStreamingState(),
+        });
+      }
+
       const events = resumeResult.data?.events;
       const messages = resumeResult.data?.messages;
       const stats = resumeResult.data?.stats;
@@ -684,7 +713,10 @@ export class SessionLoaderService {
       // third branch below) therefore cost the whole Agents panel silently.
       this.applyCliSessions(cliSessions, sessionId);
       if (stats) {
-        this.applyResumeStats(resolvedTabId, stats);
+        this.applyResumeStats(resolvedTabId, stats, {
+          preserveCompactionContextSeed:
+            opts?.reason === 'compaction' && targetTabId != null,
+        });
       } else if (
         !targetTabId &&
         resumeResult.success &&
@@ -747,11 +779,15 @@ export class SessionLoaderService {
   private requireTargetTab(sessionId: SessionId, targetTabId: TabId): TabState {
     const target =
       this.tabManager.findTabByIdAcrossWorkspaces(targetTabId)?.tab;
-    if (!target || target.claudeSessionId !== sessionId) {
+    const ownsDifferentSession =
+      target?.claudeSessionId != null && target.claudeSessionId !== sessionId;
+    if (!target || ownsDifferentSession) {
       throw new Error(
         `[SessionLoaderService] Compaction reload target ${targetTabId} no longer owns session ${sessionId}`,
       );
     }
+    // A null owner is adoptable. applyResumingSession binds it after the
+    // session-load re-check; later checks still reject a competing owner.
     return target;
   }
 
@@ -759,7 +795,17 @@ export class SessionLoaderService {
   private applyResumeStats(
     tabId: TabId,
     stats: NonNullable<ChatResumeResult['stats']>,
+    options?: { preserveCompactionContextSeed?: boolean },
   ): void {
+    // Capture before applying persisted stats: applyLoadedSessionStats creates a
+    // zero-valued live-model placeholder, which would otherwise erase the fresh
+    // post-compaction seed before this targeted-reload guard can preserve it.
+    const compactionContextSeed =
+      options?.preserveCompactionContextSeed === true
+        ? this.tabManager.findTabByIdAcrossWorkspaces(tabId)?.tab
+            .liveModelStats ?? null
+        : null;
+
     this.tabManager.applyLoadedSessionStats(tabId, stats, stats.model ?? null);
     this.tabManager.setModelUsageList(
       tabId,
@@ -768,6 +814,15 @@ export class SessionLoaderService {
         contextWindow: getModelContextWindow(entry.model),
       })),
     );
+
+    // A targeted compaction reload reads immutable history, which may still
+    // describe the pre-compaction generation. Its context snapshot must never
+    // displace the fresh post-compaction seed; the next live usage frame owns
+    // that replacement. Ordinary resumes retain their existing behavior.
+    if (compactionContextSeed) {
+      this.tabManager.setLiveModelStats(tabId, compactionContextSeed);
+      return;
+    }
 
     const snapshot = stats.contextSnapshot;
     if (!snapshot) {

--- a/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/session-loader.service.ts
@@ -548,11 +548,16 @@ export class SessionLoaderService {
    *
    * The backend returns FlatStreamEventUnion[] which we process exactly
    * like live streaming events, building the same execution tree.
+   *
+   * Resolves `staleSnapshot: true` only when a targeted compaction reload was
+   * contained because the backend could not verify its boundary; the
+   * compaction lifecycle uses it to retry that reload once. Every other
+   * completed or skipped path (including a coalesced duplicate) resolves false.
    */
   async switchSession(
     sessionId: SessionId,
     opts?: SwitchSessionOptions,
-  ): Promise<void> {
+  ): Promise<{ staleSnapshot: boolean }> {
     const targetTabId = opts?.targetTabId;
     const loadKey = targetTabId ? `${sessionId}:${targetTabId}` : sessionId;
     const targetedTab = targetTabId
@@ -564,7 +569,7 @@ export class SessionLoaderService {
         '[SessionLoaderService] Skipping duplicate switchSession for:',
         sessionId,
       );
-      return;
+      return { staleSnapshot: false };
     }
 
     const existingTab =
@@ -575,7 +580,7 @@ export class SessionLoaderService {
         .some((t) => t.id === existingTab.id);
       if (inActiveWorkspace) {
         this.tabManager.switchTab(existingTab.id);
-        return;
+        return { staleSnapshot: false };
       }
     }
 
@@ -688,7 +693,7 @@ export class SessionLoaderService {
         this.tabManager.applyResumeFailure(resolvedTabId);
         this.tabManager.markTabIdle(resolvedTabId);
         this.sessionManager.setStatus('loaded');
-        return;
+        return { staleSnapshot: true };
       }
 
       if (opts?.reason === 'compaction' && targetTabId) {
@@ -767,6 +772,7 @@ export class SessionLoaderService {
           }`,
         );
       }
+      return { staleSnapshot: false };
     } catch (error: unknown) {
       this._resumableSubagents.set([]);
       this._resumableSubagentsSessionId = null;

--- a/libs/frontend/chat/src/lib/services/chat-store/session-stats-aggregator.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/chat-store/session-stats-aggregator.service.spec.ts
@@ -44,7 +44,6 @@ function makeTab(overrides: Partial<TabState> = {}): TabState {
     streamingState: null,
     currentMessageId: null,
     claudeSessionId: SESS_1,
-    isCompacting: false,
     queuedContent: null,
     queuedOptions: null,
     preloadedStats: null,

--- a/libs/frontend/chat/src/lib/services/chat.store.ts
+++ b/libs/frontend/chat/src/lib/services/chat.store.ts
@@ -197,7 +197,7 @@ export class ChatStore {
     sessionId: SessionId,
     opts?: { reason?: 'compaction'; activate?: boolean },
   ): Promise<void> {
-    return this.sessionLoader.switchSession(sessionId, opts);
+    await this.sessionLoader.switchSession(sessionId, opts);
   }
 
   removeSessionFromList(sessionId: SessionId): void {

--- a/libs/frontend/chat/src/lib/services/chat.store.ts
+++ b/libs/frontend/chat/src/lib/services/chat.store.ts
@@ -96,7 +96,14 @@ export class ChatStore {
   readonly questionRequests = this.permissionHandler.questionRequests;
   readonly resumableSubagents = this.sessionLoader.resumableSubagents;
   readonly licenseStatus = this.lifecycle.licenseStatus;
-  readonly isCompacting = this.tabManager.activeTabIsCompacting;
+
+  /**
+   * Registry-derived compaction state for one tab. Every compaction surface
+   * (banner, input overlay) reads this so they agree by construction.
+   */
+  isCompactingForTab(tabId: string | null | undefined): boolean {
+    return this.compaction.isCompactingForTab(tabId);
+  }
 
   readonly activeTab = computed(() => this.tabManager.activeTab());
   readonly currentSessionId = this.tabManager.activeTabSessionId;

--- a/libs/shared/src/lib/types/rpc/rpc-chat.types.ts
+++ b/libs/shared/src/lib/types/rpc/rpc-chat.types.ts
@@ -268,6 +268,12 @@ export interface ChatResumeResult {
     contextSnapshot?: {
       model: string;
       contextTokens: number;
+      /**
+       * The model's context window as the backend knows it (including windows
+       * discovered from a provider catalogue). Absent when unknown; the
+       * renderer falls back to its own name lookup only then.
+       */
+      contextWindow?: number;
     };
     /** Number of agent/subagent JSONL files found for this session */
     agentSessionCount?: number;
@@ -277,6 +283,8 @@ export interface ChatResumeResult {
       inputTokens: number;
       outputTokens: number;
       costUSD: number | null;
+      /** Backend-known context window; absent when unknown. */
+      contextWindow?: number;
     }>;
   } | null;
   /**

--- a/libs/shared/src/lib/types/rpc/rpc-chat.types.ts
+++ b/libs/shared/src/lib/types/rpc/rpc-chat.types.ts
@@ -292,6 +292,13 @@ export interface ChatResumeResult {
    */
   cliSessions?: import('../agent-process.types').CliSessionReference[];
   /**
+   * `true` when the single immutable history snapshot (events, messages, and
+   * stats from one JSONL parse) could not be verified against the expected
+   * compact-boundary generation. Additive only: absent means the snapshot is
+   * verified (or the read predates compaction tracking).
+   */
+  staleSnapshot?: true;
+  /**
    * `true` when a live SDK Query was started during this resume call.
    * Only populated when the request included `activate: true`.
    */

--- a/libs/shared/src/lib/utils/pricing.utils.spec.ts
+++ b/libs/shared/src/lib/utils/pricing.utils.spec.ts
@@ -284,6 +284,100 @@ describe('pricing.utils', () => {
     });
   });
 
+  describe('registerModelContextWindows', () => {
+    // The registry is module state; isolate each case in a fresh module so
+    // registrations never leak between tests or into other describe blocks.
+    function freshModule(): typeof import('./pricing.utils') {
+      let mod!: typeof import('./pricing.utils');
+      jest.isolateModules(() => {
+        mod = jest.requireActual('./pricing.utils');
+      });
+      return mod;
+    }
+
+    it('unpriced discovered {id:"gpt-5.6-sol", contextLength:400000} → getModelContextWindow 400000', () => {
+      const mod = freshModule();
+      expect(mod.getModelContextWindow('gpt-5.6-sol')).toBe(0);
+      mod.registerModelContextWindows([
+        { id: 'gpt-5.6-sol', contextLength: 400_000 },
+      ]);
+      expect(mod.findModelPricing('gpt-5.6-sol')).toBeNull();
+      expect(mod.getModelContextWindow('gpt-5.6-sol')).toBe(400_000);
+    });
+
+    it('registry beats a partial pricing match', () => {
+      const mod = freshModule();
+      // `gpt-4o-ultra` partially matches the bundled `gpt-4o` (128k) entry.
+      expect(mod.getModelContextWindow('gpt-4o-ultra')).toBe(128_000);
+      mod.registerModelContextWindows([
+        { id: 'gpt-4o-ultra', contextLength: 512_000 },
+      ]);
+      expect(mod.getModelContextWindow('gpt-4o-ultra')).toBe(512_000);
+    });
+
+    it('matches exactly only — a shorter registered id never answers a longer one', () => {
+      const mod = freshModule();
+      mod.registerModelContextWindows([{ id: 'gpt-5', contextLength: 272_000 }]);
+      expect(mod.getModelContextWindow('gpt-5')).toBe(272_000);
+      expect(mod.getModelContextWindow('gpt-5.6-sol')).toBe(0);
+    });
+
+    it('provider-prefixed and dotted aliases resolve', () => {
+      const mod = freshModule();
+      mod.registerModelContextWindows([
+        { id: 'OpenAI/GPT-5.6-Sol', contextLength: 400_000 },
+      ]);
+      expect(mod.getModelContextWindow('openai/gpt-5.6-sol')).toBe(400_000);
+      expect(mod.getModelContextWindow('gpt-5.6-sol')).toBe(400_000);
+      expect(mod.getModelContextWindow('gpt-5-6-sol')).toBe(400_000);
+      expect(mod.getModelContextWindow('GPT-5.6-SOL')).toBe(400_000);
+    });
+
+    it('ignores 0, negative, NaN, Infinity', () => {
+      const mod = freshModule();
+      mod.registerModelContextWindows([
+        { id: 'ctx-zero', contextLength: 0 },
+        { id: 'ctx-negative', contextLength: -5 },
+        { id: 'ctx-nan', contextLength: Number.NaN },
+        { id: 'ctx-infinite', contextLength: Number.POSITIVE_INFINITY },
+      ]);
+      for (const id of ['ctx-zero', 'ctx-negative', 'ctx-nan', 'ctx-infinite']) {
+        expect(mod.getModelContextWindow(id)).toBe(0);
+      }
+    });
+
+    it('stores fractional lengths as integers', () => {
+      const mod = freshModule();
+      mod.registerModelContextWindows([
+        { id: 'ctx-fraction', contextLength: 131_072.9 },
+      ]);
+      expect(mod.getModelContextWindow('ctx-fraction')).toBe(131_072);
+    });
+
+    it('evicts oldest past the bound, and a re-register refreshes recency', () => {
+      const mod = freshModule();
+      mod.registerModelContextWindows([
+        { id: 'ctx-oldest', contextLength: 100_000 },
+        { id: 'ctx-refreshed', contextLength: 100_000 },
+      ]);
+      // Refresh `ctx-refreshed` so it is newer than the filler below.
+      const filler = Array.from({ length: 4094 }, (_, i) => ({
+        id: `ctx-filler-${i}`,
+        contextLength: 1_000,
+      }));
+      mod.registerModelContextWindows(filler);
+      mod.registerModelContextWindows([
+        { id: 'ctx-refreshed', contextLength: 200_000 },
+      ]);
+      expect(mod.getModelContextWindow('ctx-refreshed')).toBe(200_000);
+      // 4096 keys fit; the next registration evicts the oldest (`ctx-oldest`).
+      mod.registerModelContextWindows([{ id: 'ctx-newest', contextLength: 1 }]);
+      expect(mod.getModelContextWindow('ctx-oldest')).toBe(0);
+      expect(mod.getModelContextWindow('ctx-newest')).toBe(1);
+      expect(mod.getModelContextWindow('ctx-refreshed')).toBe(200_000);
+    });
+  });
+
   describe('getModelPricingDescription', () => {
     it('formats pricing as $X/1M per input/output', () => {
       expect(getModelPricingDescription('gpt-4o')).toBe(

--- a/libs/shared/src/lib/utils/pricing.utils.ts
+++ b/libs/shared/src/lib/utils/pricing.utils.ts
@@ -380,6 +380,23 @@ export function registerModelContextWindows(
  * OpenRouter happens in the extension host, a different module instance), so
  * that warning fired for every Claude model on every session load.
  */
+/**
+ * The context window provider model DISCOVERY reported for this exact id, or
+ * `0` when discovery never registered it.
+ *
+ * Deliberately narrower than {@link getModelContextWindow}: no bundled pricing
+ * table, no family regex, no partial matching of any kind. A caller that must
+ * only override an authoritative value when the provider itself answered —
+ * the proxy branch of the result-stats path — needs exactly this, because
+ * `lookupPricingEntry` would fuzzily resolve an unknown `gpt-4o-ultra` to the
+ * bundled `gpt-4o` window and override the SDK for a model nobody discovered
+ * (PR #493 review C).
+ */
+export function getDiscoveredContextWindow(modelId: string): number {
+  if (!modelId) return 0;
+  return discoveredContextWindows.get(modelId.toLowerCase()) ?? 0;
+}
+
 export function getModelContextWindow(modelId: string): number {
   if (!modelId) return 0;
   const discovered = discoveredContextWindows.get(modelId.toLowerCase());

--- a/libs/shared/src/lib/utils/pricing.utils.ts
+++ b/libs/shared/src/lib/utils/pricing.utils.ts
@@ -296,7 +296,79 @@ export function calculateMessageCost(
 }
 
 /**
+ * Upper bound on discovered context-window keys. Each model registers up to
+ * three keys (id, provider-stripped id, dotted→hyphen alias), so this holds
+ * well over a thousand models — more than any provider catalogue — while still
+ * bounding a long-lived process that browses many providers.
+ */
+const MAX_DISCOVERED_CONTEXT_WINDOW_KEYS = 4096;
+
+/**
+ * Context windows reported by provider model discovery, keyed by EXACT
+ * normalized id. Separate from pricing on purpose: a discovered model with a
+ * real `context_window` but no published price (every Codex subscription
+ * model) never reaches the pricing map, so coupling the two left those models
+ * with no window at all. Insertion order is recency — a re-register refreshes
+ * the key — and the oldest key is evicted past the bound.
+ */
+const discoveredContextWindows = new Map<string, number>();
+
+/**
+ * The exact keys one discovered model id answers to: the lowercase id, the
+ * `provider/`-stripped form, and the dots→hyphens alias of the stripped form
+ * (the same aliasing the pricing feed applies, so an SDK-reported id matches).
+ */
+function contextWindowKeys(modelId: string): string[] {
+  const fullId = modelId.toLowerCase();
+  const keys = new Set<string>([fullId]);
+  const stripped = fullId.includes('/')
+    ? fullId.split('/').slice(1).join('/')
+    : fullId;
+  keys.add(stripped);
+  keys.add(stripped.replace(/\./g, '-'));
+  return Array.from(keys);
+}
+
+/**
+ * Record context windows from provider model discovery, even for models the
+ * pricing catalogue does not know.
+ *
+ * Only finite positive lengths are recorded (as integers); `0`, negatives,
+ * `NaN` and `Infinity` mean "unknown" and are ignored. Lookup is EXACT-match
+ * only — `gpt-5` must never answer for `gpt-5.6-sol` the way the pricing
+ * table's partial matching would.
+ */
+export function registerModelContextWindows(
+  entries: ReadonlyArray<{ readonly id: string; readonly contextLength: number }>,
+): void {
+  for (const entry of entries) {
+    if (!entry || typeof entry.id !== 'string' || entry.id.length === 0) {
+      continue;
+    }
+    const length = entry.contextLength;
+    if (typeof length !== 'number' || !Number.isFinite(length) || length <= 0) {
+      continue;
+    }
+    const window = Math.floor(length);
+    if (window <= 0) continue;
+    for (const key of contextWindowKeys(entry.id)) {
+      discoveredContextWindows.delete(key);
+      discoveredContextWindows.set(key, window);
+    }
+  }
+  while (discoveredContextWindows.size > MAX_DISCOVERED_CONTEXT_WINDOW_KEYS) {
+    const oldest = discoveredContextWindows.keys().next().value;
+    if (oldest === undefined) break;
+    discoveredContextWindows.delete(oldest);
+  }
+}
+
+/**
  * Context window for a model, in tokens. `0` when genuinely unknown.
+ *
+ * A window reported by provider model discovery wins over everything below
+ * (see {@link registerModelContextWindows}); it is the provider's own answer
+ * for that exact id.
  *
  * Deliberately uses the SILENT {@link lookupPricingEntry} rather than
  * {@link findModelPricing}. A catalogue entry is a convenient carrier for
@@ -310,6 +382,8 @@ export function calculateMessageCost(
  */
 export function getModelContextWindow(modelId: string): number {
   if (!modelId) return 0;
+  const discovered = discoveredContextWindows.get(modelId.toLowerCase());
+  if (discovered !== undefined) return discovered;
   const pricing = lookupPricingEntry(modelId);
   if (pricing?.maxTokens) return pricing.maxTokens;
 


### PR DESCRIPTION
## Summary

TASK_2026_414. After a compaction, chat tabs could show a stale transcript, a wrong context gauge, or a duplicate reload, especially during auto compaction with proxied Codex models. This PR makes the compaction lifecycle consistent across the backend and the chat UI, and wires the compaction settings to controls the CLI really honors.

**Backend (`agent-sdk`, `rpc-handlers`, `shared`)**
- A bounded per-session compaction boundary generation registry. A targeted reload applies only after the persisted `compact_boundary` is observed, including when a history read parses it before the live transformer records it. Each distinct boundary advances the expected count once.
- Resume returns one immutable snapshot, flagged `staleSnapshot` when the boundary is not on disk yet. Merged with #492, so the worktree resume context is kept.
- `PostCompact` is an advisory completion. No `compact_boundary` is synthesized, and SDK JSONL is not mutated.
- The JSONL reader keeps `isSynthetic`, and replay suppresses synthetic user records, so replayed and live transcripts match.
- PostCompact falls back to the session ID that PreCompact resolved. PreCompact records the boundary expectation for interactive sessions, and a later live boundary claims it without double counting. Expectations move to the real session ID when the SDK binds it.
- The compaction boundary registry is registered with `instanceCachingFactory`, so it resolves through DI (this was the failing `cli-agent-runtime` smoke test).

**Compaction settings (includes TASK_2026_411 B8)**
- `autoCompactEnabled` and `autoCompactWindow` go through the single `buildFlagSettings` path on the interactive and ptah-cli spawn paths, proven by argv `--settings` tests against the pinned SDK 0.3.150.
- An unset threshold lets the SDK decide. The old 100000 default is removed. Only a valid integer in [100000, 1000000] maps to `autoCompactWindow`; an invalid persisted value warns and is treated as unset.
- Disabled compaction sends `autoCompactEnabled: false`. Manual `/compact` keeps working.
- Removed `compactionControl` (not an SDK option) and the `CLAUDE_CODE_MAX_CONTEXT_TOKENS` override (the CLI reads it only with `DISABLE_COMPACT`).
- Compaction attempt timing is metadata only, with overlap correlation labelled inexact.

**Context windows for proxied models**
- A bounded, exact-match window registry is fed by provider model discovery, even for models without pricing. `gpt-5.6-sol` now reports its real window.
- `contextWindow` is carried in the `chat:resume` context snapshot and model usage, so reload does not guess from the model name.

**Frontend (`chat`, `chat-state`, `chat-ui`)**
- The chat-view banner and the chat-input overlay read the same registry state (`isCompactingForTab`). The dead per-tab `isCompacting` flag is removed.
- Timers, advisories and generations are resolved through the conversation registry, so a start on one session ID and a PostCompact on the rotated ID still give exactly one verified reload. A stale snapshot gets exactly one retry.
- Stale snapshots are contained, safety timers are per session, and tab ownership is checked before every marker, reset, seed, or reload.
- The context gauge seed prefers a known window from before compaction. The marker says "shrank" only when the context decreased.
- PostCompact advisory: a real boundary within 250 ms wins; otherwise one fallback reload without metrics; a late boundary for the same generation only merges metrics. Advisory records carry their generation, are capped at 256, and are dropped when their tab closes.

**Known limit (CLI behavior, not changed here)**
- The CLI still auto-compacts proxied non-Claude models near a 200000 window. A user threshold can only lower that trigger. The gauge shows the real model window.

## Test plan

- [x] `npx nx run-many -t test` on the merged tree for 10 projects (`shared`, `agent-sdk`, `auth-providers`, `cli-agent-runtime`, `rpc-handlers`, `chat-state`, `chat`, `chat-routing`, `chat-streaming`, `cli-engine`; `chat-types` has no test target). All passed, including agent-sdk 1,626 tests and cli-agent-runtime 678 tests with the DI smoke spec. The only failure was `voice-rpc.handlers.spec.ts` timing out under parallel load; it is unchanged by this PR and passes 58/58 when run alone.
- [x] `npx nx run-many -t typecheck` for 14 projects: 13 passed. `ptah-electron:typecheck` fails in `apps/ptah-electron/src/config/build-artifact-gate.ts` (Jest types in the app tsconfig). That file and its tsconfigs are identical to `main`, and PR #494 excludes it.
- [x] Regression tests for every scenario: registry ordering and distinct boundaries, boundary-first then PostCompact, late boundary seed, `isSynthetic` through reader and replay, rotated-session PostCompact with no live boundary, PostCompact without `session_id`, 400k discovered window with no pricing, unset/set/min/max/invalid/disabled threshold argv, banner and overlay agreement, registry resolution through `registerSdkServices`.
- [x] Independent logic reviews: TASK 414 implementation, CodeRabbit follow-ups, and the Codex gap commits (CLEAN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable automatic compaction controls, including validated token-window limits and runtime-selected defaults.
  * Improved session resumption with verified snapshots, stale-snapshot protection, and more reliable compaction recovery.
  * Added support for discovered model context windows in usage and session statistics.
  * Improved compaction status reporting across tabs and preserved post-compaction context information.
* **Bug Fixes**
  * Corrected token-reduction messaging so “shrank” appears only when context actually decreases.
  * Prevented synthetic, metadata, and skill-related content from appearing during session replay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->