### PR TITLE
fix(cli-agent-runtime): end codex turns on their terminal event

### DIFF
--- a/.ptah/specs/TASK_2026_421_8481/batches.md
+++ b/.ptah/specs/TASK_2026_421_8481/batches.md
@@ -1,0 +1,91 @@
+# Batches - TASK_2026_421_8481
+
+Total tasks: 2 | Batches: 1 | Complete: 1/1
+
+Workflow: BUGFIX, minimal. The batch was implemented before this file existed
+(see `implementation-notes.md`). The team-leader ran in verify-and-commit mode
+only.
+
+## Plan validation
+
+Status: PASSED WITH RISKS
+
+Assumptions:
+
+- Leaving `for await` early runs the SDK cleanup. Verified in
+  `node_modules/@openai/codex-sdk/dist/index.js` (0.147.0).
+  `runStreamedInternal` iterates `CodexExec.run`. An early exit calls
+  `return()` through both generators. The `CodexExec.run` `finally` then runs
+  `rl.close()`, `child.removeAllListeners()` and `child.kill()`. `cleanup()`
+  does nothing because no output schema is passed.
+- `continue()` survives an early return. Verified: `CodexExec.run` spawns a new
+  child for each call and pushes `resume <threadId>` when `Thread._id` is set.
+  `_id` is set from `thread.started` before the consumer receives the event.
+- `error` is not terminal. Verified locally: the SDK's own `Thread.run` reads
+  past `error` and stops only on `turn.failed`. The claim that retryable
+  "Reconnecting... n/5" errors come before a turn event is recalled, not
+  measured.
+
+| Risk | Severity | Mitigation |
+| ---- | -------- | ---------- |
+| The SDK `finally` now kills a child that is still alive and removes its listeners, including Node's abort-listener removal. A later `abort()` in the window between kill and exit could make the child emit `error` with no listener. | LOW | Checked `agent-process-manager.service.ts`. `sdkAbortController.abort()` is called only from `releaseSubprocess` (idle release, at least `MIN_SDK_IDLE_RELEASE_MS` = 10 s, or TTL), not right after `done`. The window is closed in practice. |
+| On Windows, `child.kill()` ends only codex.exe, so the powershell.exe grandchild can remain as an orphan. `rl.close()` does not destroy `child.stdout`. | LOW | Out of scope. It needs a tree kill that the SDK does not do. Recorded in the implementation notes. |
+| A `turn.failed` with exit code 0 used to resolve `done` with 0. It now resolves with 1. | LOW | This is intended: the terminal event, not the process exit code, sets the result. |
+| The Cursor adapter (`cursor-cli.adapter.ts` ~347) has the same iterator-end pattern. | LOW | Reported only, not changed. Apply the same fix on a terminal `status` message if Cursor agents are seen stuck in `running`. |
+
+Edge cases:
+
+- Iterator that never ends after `turn.completed` — handled in Task 1.1, pinned in Task 1.2
+- `turn.failed` on an iterator that never ends — Task 1.1 / 1.2
+- A non-terminal `error` event — Task 1.1 (deliberately not a return), pinned in Task 1.2
+- A continuation after an early return — Task 1.2
+- Abort, startup watchdog, error summarization and the iterator-end path — not changed by Task 1.1 (the `catch` and the final `return 0` are the same as before)
+
+## Batch 1: Codex turn completion — COMPLETE (81828c6a9)
+
+- Recommended executor: backend-developer
+- Fallback executor: none needed
+- Execution mode: sequential
+- Rationale: one adapter file and its spec, tightly coupled
+- Tasks: 2 | Depends on: none
+
+### Task 1.1: Return from runTurn on the terminal turn event — COMPLETE
+
+- File: D:/projects/ptah-extension/.claude-worktrees/task-421-codex-agent-completion/libs/backend/cli-agent-runtime/src/lib/cli-agents/cli-adapters/codex-cli.adapter.ts
+- Plan reference: context.md "Fix direction"
+- Implementation: after `handleStreamEvent`, `return 0` on `turn.completed` and
+  `return 1` on `turn.failed` (lines 704-720), with a comment that explains why.
+
+### Task 1.2: Specs for a stream that never ends — COMPLETE
+
+- File: D:/projects/ptah-extension/.claude-worktrees/task-421-codex-agent-completion/libs/backend/cli-agent-runtime/src/lib/cli-agents/cli-adapters/codex-cli.adapter.spec.ts
+- Depends on: Task 1.1
+- Implementation: helpers `createNeverEndingEventSource` and `settleWithin`, and
+  a new describe block with 4 tests: `turn.completed` gives 0 and `return()`
+  is called; `turn.failed` gives 1 and `return()` is called; `error` stays
+  pending and `return()` is not called; a continuation after an early return
+  gives 0 on the same thread. Additions only (0 deleted lines), so the existing
+  specs are untouched.
+
+### Batch 1 verification
+
+Run from the worktree root on 2026-09-11 by team-leader.
+
+- Staged diff read and checked against context.md and the SDK source: PASS
+- `git status`: only the 2 intended files were staged. Nothing was unstaged or untracked.
+- `npx nx run-many -t test -p @ptah-extension/cli-agent-runtime --skip-nx-cache`:
+  header "Running target test for project @ptah-extension/cli-agent-runtime"
+  (1 project). 51 suites passed. 672 tests passed, 1 skipped. Exit 0.
+- `npx nx run-many -t typecheck -p @ptah-extension/cli-agent-runtime --skip-nx-cache`: exit 0
+- `npx tsc --noEmit -p libs/backend/cli-agent-runtime/tsconfig.spec.json`: exit 0
+- `npx nx run-many -t lint -p @ptah-extension/cli-agent-runtime --skip-nx-cache`:
+  0 errors, 37 warnings. The 2 warnings on the adapter (`setAgentId` empty
+  method, `max-lines`) were already there. The file was 1095 lines at HEAD and
+  already over the limit. No new findings.
+- `npx prettier --check` on both files: PASS
+- Reviewer: no separate reviewer was run. The orchestrator gave team-leader
+  the verification gate for this minimal BUGFIX workflow. The continuation and
+  process-kill behaviour was verified against the SDK source and the
+  AgentProcessManager abort call sites.
+- Commit: 81828c6a9 `fix(cli-agent-runtime): end codex turns on their terminal event`.
+  Hooks ran and made no reformat changes. Not pushed.

--- a/.ptah/specs/TASK_2026_421_8481/context.md
+++ b/.ptah/specs/TASK_2026_421_8481/context.md
@@ -1,0 +1,45 @@
+# TASK_2026_421 — Context
+
+## User intent
+
+"Why does the codex cli agent never stop after it finishes?" — then: open it as
+its own task and fix it.
+
+## Workspace
+
+- Worktree: `D:/projects/ptah-extension/.claude-worktrees/task-421-codex-agent-completion`
+- Branch: `fix/task-421-codex-agent-completion` (from `origin/main` @ f7b2c1670)
+- Found while running TASK_2026_420 (agent `bc4db206`, stopped manually).
+
+## Strategy
+
+BUGFIX, Minimal workflow: backend-developer (fix + spec) → team-leader verify
+and commit. Scope: `libs/backend/cli-agent-runtime/src/lib/cli-agents/cli-adapters/codex-cli.adapter.ts`
+and its spec.
+
+## Root cause (evidence)
+
+1. `CodexCliAdapter.runSdk` → `runTurn` (`codex-cli.adapter.ts:684-726`) does
+   `for await (const event of streamedTurn.events)` and returns 0 only when the
+   iterator ends. `turn.completed` only prints the `Usage:` line
+   (`handleTurnCompleted`, ~1060).
+2. `@openai/codex-sdk/dist/index.js:286-290` (`CodexExec.run`): the iterator
+   ends only when `codex.exe` stdout closes, then it awaits the child `exit`.
+3. Measured 2026-09-11: agent spawned 18:54:59Z; `codex.exe` pid 15900 started
+   18:54:59Z and was still alive >1h later, with a `powershell.exe` child
+   (pid 26632, since 18:55:10Z) whose encoded command is the "Long-lived
+   PowerShell AST parser used by the Rust command-safety layer on Windows".
+   Three other Ptah-spawned `codex.exe` processes showed the same shape.
+4. So `sdkHandle.done` never resolves → `AgentProcessManager.handleExit`
+   (`agent-process-manager.service.ts:1736`) never runs → status stays
+   `running` until the timeout.
+5. `codex-cli.adapter.spec.ts:18-31` fakes an iterator that ends right after
+   the last event, which hides the defect.
+
+## Fix direction
+
+Return from `runTurn` on `turn.completed` (0) and `turn.failed` (1) after
+handling the event. Leaving the `for await` early calls the generator's
+`return()`, which runs the SDK `finally` (`rl.close()`, `child.kill()`).
+Continuation (`continue()` → `runTurn`) must keep working. Add a spec whose
+fake iterator stays open after `turn.completed`.

--- a/.ptah/specs/TASK_2026_421_8481/implementation-notes.md
+++ b/.ptah/specs/TASK_2026_421_8481/implementation-notes.md
@@ -1,0 +1,132 @@
+# Implementation notes — TASK_2026_421_8481
+
+Worktree: `D:/projects/ptah-extension/.claude-worktrees/task-421-codex-agent-completion`
+(branch `fix/task-421-codex-agent-completion`). Staged, not committed.
+
+## Change
+
+`libs/backend/cli-agent-runtime/src/lib/cli-agents/cli-adapters/codex-cli.adapter.ts`
+In `runSdk` → `runTurn`, the `for await` loop now returns right after
+`handleStreamEvent` processes a terminal event:
+
+- `turn.completed` → `return 0`
+- `turn.failed` → `return 1`
+
+A short comment above the two checks explains why the loop returns early.
+Nothing else changed: iterator end (0), abort (1), the startup watchdog and
+error summarization all work as before. `agent-process-manager` is unchanged.
+
+### Why returning early kills the child (verified in `@openai/codex-sdk` 0.147.0 `dist/index.js`)
+
+- `Thread.runStreamed` returns `{ events: runStreamedInternal(...) }`
+  (lines 51-53). That generator loops over `CodexExec.run` (lines 77-94).
+- If the consumer leaves the loop, it calls `return()` on the outer generator.
+  The outer generator is paused at `yield parsed`, so its inner `for await`
+  exits. That calls `return()` on `CodexExec.run`, which is paused at
+  `yield line`.
+- `CodexExec.run`'s `finally` (lines 296-303) runs `rl.close()`,
+  `child.removeAllListeners()` and `child.kill()`. Then
+  `runStreamedInternal`'s `finally` runs `cleanup()`, which does nothing
+  because no output schema is passed.
+
+### Continuation after an early return
+
+`continue()` calls `runTurn(message)` again on the same `thread`. The SDK starts
+a **new** child process for each `runStreamed`: `CodexExec.run` spawns per call
+and pushes `resume <threadId>` when `_id` is set (lines 225-227). `Thread._id`
+is set from `thread.started` (line 86) or from the `resumeThread` id, before the
+consumer receives the event. So killing the previous child cannot affect the
+next turn. The thread state lives in `~/.codex/sessions`, not in the process.
+The new spec "runs a continuation after an early return, on the same thread"
+tests this.
+
+### `error` stream event — left non-terminal on purpose
+
+- The `.d.ts` comment on `ThreadErrorEvent` says "unrecoverable error emitted
+  directly by the event stream". That comment alone does not prove the turn
+  ends there.
+- The SDK's own non-streaming consumer, `Thread.run` (lines 97-120), ignores
+  `error`. It `break`s only on `turn.failed`, and `turn.failed` is the only
+  failure it turns into a thrown error. That is local evidence that the SDK
+  expects a turn-level event after `error`.
+- Recalled from outside this repository, not checked here: `codex exec` also
+  sends `error` for retryable stream errors ("Reconnecting... n/5"). It then
+  ends the turn with `turn.failed` or `turn.completed`.
+- Returning on `error` could therefore cut off a turn that is retrying. The
+  adapter does not return on it. A spec pins this: an `error` event on a stream
+  that never ends leaves `done` pending and does not call `return()`.
+
+## Other SDK-based adapters (reported only, not changed)
+
+- **Cursor** (`cursor-cli.adapter.ts` ~347): same shape. The `for await` loop
+  over `run.stream()` returns 0 only when the iterator ends. `@cursor/sdk` runs
+  in-process: `Agent.create`/`send`, no `codex exec`-style child owned by the
+  iterator. Its `SDKMessage` union has a `status` message whose status can be
+  `FINISHED | ERROR | CANCELLED | EXPIRED` (`messages.d.ts:62-68`).
+  `LocalRunStreamResultEvent` / `LocalRunStreamDoneEvent` and
+  `isTerminalLocalRunStreamEvent` exist at the transport layer. Whether
+  `stream()` reliably ends after a terminal status was not measured. If Cursor
+  agents are ever seen stuck in `running`, apply the same fix: return on a
+  terminal `status` message.
+- **Copilot** (`copilot-sdk.adapter.ts` ~402): despite the file name, it spawns
+  the CLI and resolves on the child `close` event. There is no vendor iterator.
+  It has a related risk: a grandchild that holds stdio open delays `close`.
+  That is outside this task.
+- **antigravity / opencode / pi**: they spawn through `spawnCli`. There is no
+  in-process vendor event iterator, so they are not affected by this pattern.
+
+## Specs (`codex-cli.adapter.spec.ts`)
+
+- New helper `createNeverEndingEventSource(events)`. It yields the events, then
+  returns a promise that never settles from `next()`, and records whether
+  `return()` was called.
+- New helper `settleWithin(promise, ms)`. It races the promise against a
+  cleared timer, so a regression fails as an assertion, not as a Jest timeout.
+- New describe block "terminal turn events on a stream that never ends":
+  1. `done` → 0 after `turn.completed`, `return()` called, usage line emitted,
+     session id captured.
+  2. `done` → 1 after `turn.failed`, `return()` called, `[Turn Failed]` emitted.
+  3. An `error` event is not terminal: after 50 ms `done` is still pending and
+     `return()` was not called.
+  4. A continuation after an early return runs on the same thread and
+     resolves 0. Both sources are returned, `startThread` is called once,
+     `runStreamed` is called twice, and the second turn's output is emitted.
+- The existing specs are unchanged and still pass.
+
+## Verification (worktree root unless stated)
+
+- `npx nx run-many -t test -p @ptah-extension/cli-agent-runtime --skip-nx-cache`
+  - Header: `Running target test for project @ptah-extension/cli-agent-runtime`
+    (1 project).
+  - Result: `Test Suites: 51 passed, 51 total`;
+    `Tests: 1 skipped, 672 passed, 673 total`; "Successfully ran target test".
+  - The run also printed Jest's "A worker process has failed to exit
+    gracefully". The codex spec run alone (below) did not print this warning,
+    so it does not come from the new tests. A baseline without this change was
+    not measured.
+- `npx nx run-many -t typecheck -p @ptah-extension/cli-agent-runtime --skip-nx-cache`
+  - EXIT=0, `tsc --noEmit --project libs/backend/cli-agent-runtime/tsconfig.lib.json`,
+    "Successfully ran target typecheck".
+  - The first attempt ran at the same time as the tests and printed nothing, so
+    it was run again.
+- `npx tsc --noEmit -p libs/backend/cli-agent-runtime/tsconfig.spec.json`
+  - EXIT=0, no errors. `tsconfig.lib.json` does not cover the spec file, so
+    this check was added.
+- From `libs/backend/cli-agent-runtime`:
+  `npx jest -c jest.config.ts src/lib/cli-agents/cli-adapters/codex-cli.adapter.spec.ts`
+  - EXIT=0, `Tests: 52 passed, 52 total`.
+- Same command with `-t "never ends"`: EXIT=0,
+  `Tests: 48 skipped, 4 passed, 52 total`. This proves the 4 new tests ran.
+- `npx prettier --check` on both changed files:
+  "All matched files use Prettier code style!"
+- Not done: a mutation run to show the new specs fail without the fix. If the
+  fix is removed, specs 1, 2 and 4 would get `'still-running'` from
+  `settleWithin`, because the fake source never ends.
+
+## Out-of-scope observations
+
+- On Windows, the SDK's `child.kill()` terminates only `codex.exe`. The
+  long-lived `powershell.exe` grandchild seen in the measurement can outlive it
+  as an orphan. That needs a tree kill, which the SDK does not do.
+- `Thread.run` in the SDK (not used by Ptah) also waits for the iterator to end
+  on success. It is the same defect upstream.

--- a/.ptah/specs/TASK_2026_421_8481/task.md
+++ b/.ptah/specs/TASK_2026_421_8481/task.md
@@ -1,0 +1,13 @@
+---
+id: TASK_2026_421_8481
+status: in_review
+type: BUGFIX
+title: Codex CLI agents never reach completed after their turn ends
+description: >-
+  A spawned Codex CLI agent prints its final report and usage line but
+  ptah_agent_status keeps reporting running until the 1-hour timeout, because
+  CodexCliAdapter.runTurn waits for the SDK event iterator to end and the
+  codex.exe child never exits.
+---
+
+Codex agents stay `running` after `turn.completed`. See `context.md`.

--- a/.ptah/specs/TASK_2026_423_bc0d/context.md
+++ b/.ptah/specs/TASK_2026_423_bc0d/context.md
@@ -1,0 +1,28 @@
+# TASK_2026_423 — Context
+
+## Origin
+
+Found while fixing TASK_2026_421 (Codex agents never reached `completed`).
+
+## Evidence
+
+- Measured 2026-09-11: every Ptah-spawned `codex.exe` had a `powershell.exe`
+  child started a few seconds after it, whose encoded command is the
+  "Long-lived PowerShell AST parser used by the Rust command-safety layer on
+  Windows" (it reads JSON requests over stdin).
+- TASK_2026_421 now leaves the SDK event loop on `turn.completed` /
+  `turn.failed`; the SDK `CodexExec.run` `finally`
+  (`node_modules/@openai/codex-sdk/dist/index.js` ~296-303) calls
+  `child.kill()`, which on Windows terminates `codex.exe` only.
+- When `ptah_agent_stop` stopped agent `bc4db206`, both `codex.exe` (15900) and
+  the PowerShell child (26632) exited — so a full stop cleans up; whether the
+  turn-end `child.kill()` does is NOT yet measured.
+
+## To do
+
+1. Measure: after a Codex turn ends through the TASK_2026_421 path, does the
+   PowerShell child outlive `codex.exe`?
+2. If yes: kill the process tree for the Codex child. The SDK does not expose
+   the child pid, so options include the SDK's `codexPathOverride` wrapper,
+   a Job Object, or a post-turn sweep by parent pid. Follow the
+   `cli-agent-runtime` rule that tree kills await a known pid.

--- a/.ptah/specs/TASK_2026_423_bc0d/task.md
+++ b/.ptah/specs/TASK_2026_423_bc0d/task.md
@@ -1,0 +1,12 @@
+---
+id: TASK_2026_423_bc0d
+status: backlog
+type: BUGFIX
+title: Codex long-lived PowerShell child survives the codex.exe kill on Windows
+description: >-
+  When a Codex turn ends, the SDK kills only codex.exe. Its long-lived
+  powershell.exe child, the Rust command-safety AST parser, can stay alive as
+  an orphan because the SDK does not kill the process tree.
+---
+
+Follow-up from TASK_2026_421. See `context.md`.

--- a/.ptah/specs/TASK_2026_424_b6bf/context.md
+++ b/.ptah/specs/TASK_2026_424_b6bf/context.md
@@ -1,0 +1,27 @@
+# TASK_2026_424 — Context
+
+## Origin
+
+Reported (not changed) by the TASK_2026_421 developer while scanning the other
+SDK-based adapters for the Codex defect.
+
+## Evidence
+
+- `libs/backend/cli-agent-runtime/src/lib/cli-agents/cli-adapters/cursor-cli.adapter.ts`
+  ~347: the `for await` over `run.stream()` returns 0 only when the iterator
+  ends — the pattern TASK_2026_421 removed from `CodexCliAdapter.runTurn`.
+- `@cursor/sdk` runs in process (`Agent.create` / `send`); there is no
+  `codex exec`-style child owning the iterator, so the Codex failure mode may
+  not apply.
+- Its `SDKMessage` union has a `status` message with
+  `FINISHED | ERROR | CANCELLED | EXPIRED` (`messages.d.ts` ~62-68), and the
+  transport exposes `isTerminalLocalRunStreamEvent`.
+- Not measured: whether `stream()` reliably ends after a terminal status.
+
+## To do
+
+1. Measure a real Cursor agent run: does `ptah_agent_status` reach
+   `completed` promptly after the final status message?
+2. If not, return from the loop on a terminal `status` message (0 for
+   `FINISHED`, 1 otherwise) and pin it with a never-ending-stream spec, the
+   same way `codex-cli.adapter.spec.ts` does after TASK_2026_421.

--- a/.ptah/specs/TASK_2026_424_b6bf/task.md
+++ b/.ptah/specs/TASK_2026_424_b6bf/task.md
@@ -1,0 +1,13 @@
+---
+id: TASK_2026_424_b6bf
+status: backlog
+type: BUGFIX
+title: Cursor adapter waits for the SDK stream to end before completing
+description: >-
+  CursorCliAdapter returns from its stream loop only when run.stream() ends,
+  the same shape that left Codex agents running until the timeout. Verify
+  whether the stream ends after a terminal status message, and if not, return
+  on it.
+---
+
+Follow-up from TASK_2026_421. See `context.md`.

--- a/libs/backend/cli-agent-runtime/src/lib/cli-agents/cli-adapters/codex-cli.adapter.spec.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/cli-agents/cli-adapters/codex-cli.adapter.spec.ts
@@ -40,6 +40,66 @@ function createFakeEventGenerator(
   return gen;
 }
 
+/**
+ * Fake event source that yields its events and then NEVER ends — the shape
+ * `codex exec` has on Windows when a long-lived child keeps its stdout open
+ * after the final event. Records whether the consumer closed it early, which
+ * is what runs the real SDK's `finally` (readline close + child kill).
+ */
+function createNeverEndingEventSource(events: FakeCodexEvent[]): {
+  events: AsyncGenerator<FakeCodexEvent>;
+  wasReturned: () => boolean;
+} {
+  let index = 0;
+  let returned = false;
+  const gen: AsyncGenerator<FakeCodexEvent> = {
+    [Symbol.asyncIterator]() {
+      return gen;
+    },
+    next(): Promise<IteratorResult<FakeCodexEvent>> {
+      if (!returned && index < events.length) {
+        return Promise.resolve({ done: false, value: events[index++] });
+      }
+      return new Promise<never>(() => {
+        /* stdout never closes */
+      });
+    },
+    async return(): Promise<IteratorResult<FakeCodexEvent>> {
+      returned = true;
+      return { done: true, value: undefined as never };
+    },
+    async throw(err: Error): Promise<IteratorResult<FakeCodexEvent>> {
+      throw err;
+    },
+    [Symbol.asyncDispose](): PromiseLike<void> {
+      return Promise.resolve();
+    },
+  };
+  return { events: gen, wasReturned: () => returned };
+}
+
+/**
+ * Resolve with the promise's value, or with `'still-running'` if it has not
+ * settled within `ms`. Keeps a regression a clear assertion failure instead of
+ * a Jest timeout, and clears its timer so no handle outlives the test.
+ */
+async function settleWithin<T>(
+  promise: Promise<T>,
+  ms = 1000,
+): Promise<T | 'still-running'> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<'still-running'>((resolve) => {
+        timer = setTimeout(() => resolve('still-running'), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /** Minimal event types matching CodexThreadEvent from the adapter */
 type FakeCodexEvent =
   | { type: 'thread.started'; thread_id: string }
@@ -779,6 +839,106 @@ describe('CodexCliAdapter', () => {
       const code = await handle.done;
       expect(code).toBe(1);
       expect(handle.abort.signal.aborted).toBe(true);
+    });
+  });
+
+  // `codex exec` on Windows can keep stdout open long after its final event
+  // (a lingering powershell.exe child), so the SDK iterator never ends. A turn
+  // must finish on its terminal EVENT, and close the stream so the SDK kills
+  // the child — not wait for an end that may take an hour.
+  describe('terminal turn events on a stream that never ends', () => {
+    const defaultOptions = {
+      task: 'Implement feature X',
+      workingDirectory: '/project/root',
+    };
+    const usage = {
+      input_tokens: 10,
+      cached_input_tokens: 0,
+      output_tokens: 5,
+    };
+
+    it('resolves done with 0 after turn.completed and closes the stream', async () => {
+      const source = createNeverEndingEventSource([
+        { type: 'thread.started', thread_id: 'thread-1' },
+        {
+          type: 'item.completed',
+          item: { type: 'agent_message', id: 'm1', text: 'Final report' },
+        },
+        { type: 'turn.completed', usage },
+      ]);
+      mockRunStreamed.mockResolvedValue({ events: source.events });
+
+      const handle = await adapter.runSdk(defaultOptions);
+      const output: string[] = [];
+      handle.onOutput((data: string) => output.push(data));
+
+      expect(await settleWithin(handle.done)).toBe(0);
+      expect(source.wasReturned()).toBe(true);
+      expect(output.join('')).toContain('[Usage: 10 input, 5 output tokens]');
+      expect(handle.getSessionId?.()).toBe('thread-1');
+    });
+
+    it('resolves done with 1 after turn.failed and closes the stream', async () => {
+      const source = createNeverEndingEventSource([
+        { type: 'turn.failed', error: { message: 'rate limited' } },
+      ]);
+      mockRunStreamed.mockResolvedValue({ events: source.events });
+
+      const handle = await adapter.runSdk(defaultOptions);
+      const output: string[] = [];
+      handle.onOutput((data: string) => output.push(data));
+
+      expect(await settleWithin(handle.done)).toBe(1);
+      expect(source.wasReturned()).toBe(true);
+      expect(output).toContain('[Turn Failed] rate limited\n');
+    });
+
+    it('does not treat a stream error event as the end of the turn', async () => {
+      const source = createNeverEndingEventSource([
+        { type: 'error', message: 'Reconnecting... 1/5' },
+      ]);
+      mockRunStreamed.mockResolvedValue({ events: source.events });
+
+      const handle = await adapter.runSdk(defaultOptions);
+      handle.onOutput(() => {
+        /* drain */
+      });
+
+      expect(await settleWithin(handle.done, 50)).toBe('still-running');
+      expect(source.wasReturned()).toBe(false);
+    });
+
+    it('runs a continuation after an early return, on the same thread', async () => {
+      const first = createNeverEndingEventSource([
+        { type: 'turn.completed', usage },
+      ]);
+      const second = createNeverEndingEventSource([
+        {
+          type: 'item.completed',
+          item: { type: 'agent_message', id: 'm2', text: 'Second turn' },
+        },
+        { type: 'turn.completed', usage },
+      ]);
+      mockRunStreamed
+        .mockResolvedValueOnce({ events: first.events })
+        .mockResolvedValueOnce({ events: second.events });
+
+      const handle = await adapter.runSdk(defaultOptions);
+      const output: string[] = [];
+      handle.onOutput((data: string) => output.push(data));
+
+      expect(await settleWithin(handle.done)).toBe(0);
+      expect(first.wasReturned()).toBe(true);
+
+      const outcome = await handle.continue?.('Follow-up message');
+      expect(outcome).toBeDefined();
+      expect(await settleWithin(outcome?.done ?? Promise.resolve(-1))).toBe(0);
+
+      expect(second.wasReturned()).toBe(true);
+      expect(mockStartThread).toHaveBeenCalledTimes(1);
+      expect(mockRunStreamed).toHaveBeenCalledTimes(2);
+      expect(mockRunStreamed.mock.calls[1][0]).toBe('Follow-up message');
+      expect(output).toContain('Second turn\n');
     });
   });
 

--- a/libs/backend/cli-agent-runtime/src/lib/cli-agents/cli-adapters/codex-cli.adapter.ts
+++ b/libs/backend/cli-agent-runtime/src/lib/cli-agents/cli-adapters/codex-cli.adapter.ts
@@ -700,6 +700,24 @@ export class CodexCliAdapter implements CliAdapter {
             itemTextTracker,
             itemsWithDeltas,
           );
+
+          // The turn is over the moment `turn.completed` or `turn.failed`
+          // arrives — never wait for the iterator to end. The SDK ends it only
+          // when `codex exec` closes stdout, and on Windows codex.exe was
+          // measured alive for over an hour after its final event (a
+          // long-lived powershell.exe child holds it open), so `done` never
+          // settled and the agent read `running` until the timeout. Leaving
+          // the loop calls the generator's `return()`, which runs the SDK's
+          // `finally`: readline closed, child killed. `continue()` is safe
+          // because each turn spawns its own `codex exec … resume <threadId>`.
+          // `error` is deliberately NOT terminal: the SDK's own `Thread.run`
+          // reads past it, and the turn still ends with one of these two.
+          if (event.type === 'turn.completed') {
+            return 0;
+          }
+          if (event.type === 'turn.failed') {
+            return 1;
+          }
         }
 
         return 0;


### PR DESCRIPTION
﻿## Summary

Codex CLI agents spawned through `ptah_agent_spawn` printed their final report and usage line, but `ptah_agent_status` kept reporting `running` until the 1-hour timeout.

**Cause**
- `CodexCliAdapter.runTurn` returned only when the Codex SDK event iterator ended.
- The SDK (`CodexExec.run`) ends that iterator only when `codex.exe` closes stdout and exits.
- On Windows, `codex.exe` stayed alive for over an hour after its final event. A long-lived `powershell.exe` child (the Rust command-safety AST parser) kept it open.
- So `done` never resolved, and `AgentProcessManager.handleExit` never marked the agent `completed`.

**Fix**
- `runTurn` now returns `0` right after `turn.completed` and `1` right after `turn.failed`.
- Leaving the loop calls the generator's `return()`. That runs the SDK `finally`, which closes readline and kills the child.
- `continue()` still works: each turn spawns its own `codex exec … resume <threadId>`.
- `error` is not treated as terminal, because the SDK's own `Thread.run` reads past it.

**Also in this PR**: the task spec `TASK_2026_421_8481` and two follow-ups found during the fix:
- `TASK_2026_423`: the PowerShell child can outlive `codex.exe` on Windows, because the SDK does not kill the process tree.
- `TASK_2026_424`: the Cursor adapter uses the same wait-for-stream-end pattern. Not yet measured.

## Test plan

- [x] 4 new specs in `codex-cli.adapter.spec.ts` on a fake event stream that never ends: `turn.completed` resolves 0 and calls `return()`; `turn.failed` resolves 1; `error` stays pending; a continuation after an early return works.
- [x] `nx run-many -t test -p @ptah-extension/cli-agent-runtime`: 51 suites, 672 passed, 1 skipped.
- [x] Typecheck (lib and spec config), lint (no new errors), prettier clean.
- [ ] Manual: spawn a Codex agent, wait for its final output, and confirm that `ptah_agent_status` shows `completed` within seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Codex CLI agents now report completion immediately after a turn finishes instead of remaining in a running state until timeout.
  * Failed Codex turns now correctly report failure status.
  * Continuing work in the same conversation remains supported after a turn completes.

* **Tests**
  * Added coverage for completed and failed turns, stream cleanup, error handling, and conversation continuation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->