### PR TITLE
fix(chat-streaming): split the live bubble at a mid-turn prompt

### DIFF
--- a/.ptah/specs/TASK_2026_420_84d9/batches.md
+++ b/.ptah/specs/TASK_2026_420_84d9/batches.md
@@ -1,0 +1,155 @@
+# Batches - TASK_2026_420_84d9
+
+Total tasks: 3 | Batches: 1 | Complete: 1/1
+
+Worktree: `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split`
+(branch `fix/task-420-mid-turn-bubble-split`, base `origin/main` f7b2c1670).
+
+## Plan validation
+
+Status: PASSED WITH RISKS (no implementation-plan.md; the plan is `context.md` "Fix" plus the
+"Round 2 reviews", Round 3 and Round 4 dispositions)
+
+Assumptions:
+
+- The SDK echoes a live prompt as a root user `message_start` (id = SDK uuid) with a text delta.
+  Verified: `libs/backend/agent-sdk/src/lib/message-transform/user-message.transformer.ts:117-151`,
+  enabled by `replay-user-messages` in `sdk-query-options-builder.ts:889-892`.
+- `nativeUuid` on a bubble identifies THAT bubble's echo. FALSE in one reachable case (R1).
+  Resolved: finalization no longer reads `nativeUuid`.
+
+| Risk | Severity | Mitigation |
+| ---- | -------- | ---------- |
+| Failed continue leaves a false boundary or a duplicate bubble (S1) | HIGH | Task 1.1. Verified addressed |
+| SDK echo renders as an empty assistant bubble (S2) | HIGH | Task 1.2. Verified addressed |
+| `buildTree` no longer returns user roots (contract change) | MEDIUM | Consumer trace, see verification item 2 |
+| `nativeUuid` anchor trusts `reconcileUserMessageNativeUuid`, which stamps the OLDEST unstamped bubble (R1) | HIGH | RESOLVED. Anchor by `id` only; R1 regression spec |
+| Queue-flush failure after the turn finalized drops the prompt bubble (S3) | MEDIUM | ACCEPTED as correct by the orchestrator (context.md Round 4); pinned by spec |
+| Two mid-turn prompts in one state (Moderate-1) | LOW | Two-boundary regression spec |
+| Compaction or the event cap drops the boundary (F3/F4) | LOW | Accepted, documented on `recordUserPromptBoundary` |
+
+Edge cases:
+
+- Boundary and SDK echo in one state: handled in Tasks 1.2 and 1.3
+- Queue-flush failure (rejected or thrown): handled in Task 1.1
+- Idle send after an earlier failed direct send (R1): handled in Task 1.2, pinned in Task 1.3
+- Queue-flush failure after finalization (S3): accepted behavior, pinned in Task 1.3
+- Two boundaries in one state: pinned in Task 1.3
+
+Follow-ups (separate tasks, not this batch):
+
+- `TabManagerService.reconcileUserMessageNativeUuid` stamps the oldest unstamped bubble; this
+  also mis-anchors fork/rewind after a failed send.
+- M2: rewind while a boundary is live is untested (UI-gated while streaming).
+
+## Batch 1: mid-turn bubble split + review revision — COMPLETE (commit bba7b30f1)
+
+- Recommended executor: frontend-developer
+- Fallback executor: frontend-developer (a fresh instance) with this record as input
+- Execution mode: sequential
+- Rationale: tightly coupled changes across the streaming write path, finalization and the
+  sender. One contract (user roots) spans every file.
+- Tasks: 3 | Depends on: none
+
+Files (10, committed in bba7b30f1):
+
+- `libs/frontend/chat-streaming/src/lib/accumulator-core.service.ts`
+- `libs/frontend/chat-streaming/src/lib/execution-tree-builder.service.ts`
+- `libs/frontend/chat-streaming/src/lib/execution-tree-builder.service.spec.ts`
+- `libs/frontend/chat-streaming/src/lib/message-finalization.service.ts`
+- `libs/frontend/chat-streaming/src/lib/message-finalization.service.spec.ts`
+- `libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts`
+- `libs/frontend/chat-streaming/src/lib/streaming-handler.service.spec.ts`
+- `libs/frontend/chat/src/lib/services/message-sender.service.ts`
+- `libs/frontend/chat/src/lib/services/message-sender.service.spec.ts`
+- `libs/frontend/chat/src/lib/services/message-sender.session-identity.spec.ts`
+
+### Task 1.1: boundary record + rollback on failed continue (S1) — COMPLETE
+
+- Verified in the diff:
+  - `accumulator-core.service.ts`: `recordUserPromptBoundary` and `removeUserPromptBoundary`.
+    Removal is shape-guarded and bumps `structuralRevision`.
+  - `streaming-handler.service.ts`: both are workspace-aware and publish to the active or
+    background tab.
+  - `message-sender.service.ts`: the boundary is written and `sentPromptId` set after
+    `setMessages`; the structural-failure exit and the catch both call `rollBackUnsentPrompt`;
+    the queue flush passes `dropBubbleOnFailure = true`; the bubble is dropped only on that flag.
+
+### Task 1.2: user roots break the merge, not emitted; finalization anchors by id (S2, R1) — COMPLETE
+
+- Verified in the diff:
+  - `execution-tree-builder.service.ts`: a user root resets `lastAssistantNode` and
+    `continue`s.
+  - `message-finalization.service.ts` `placeFinalizedTrees`: walks `messageEventIds`; a user
+    root anchors only through `promptById.get(messageId)`, a map keyed by existing USER message
+    `id`. A non-anchor user root (the SDK echo) is skipped.
+  - `nativeUuid` appears in the file only in the doc comment that explains why it is not used.
+    No `nativeUuid` anchor path remains.
+  - `finalizeCurrentMessage` puts stats on the last NEW tree.
+
+### Task 1.3: specs (M1, R1, S3 pin, Moderate-1) — COMPLETE
+
+- Verified on disk:
+  - `message-finalization.service.spec.ts:390` boundary + echo: [before, prompt, after].
+  - `message-finalization.service.spec.ts:429` `never anchors on the SDK echo through a stamped
+    nativeUuid`: no boundary gives the plain append [earlier, user-bubble, before, after].
+  - `message-finalization.service.spec.ts:471` R1 regression: existing
+    [earlier, msg_1_failed(nativeUuid = echo uuid), notice, msg_2_retry], roots [echo, reply],
+    expects [earlier, msg_1_failed, notice, msg_2_retry, reply] with stats on the reply.
+    Matches context.md Round 3.
+  - `message-finalization.service.spec.ts:530` two boundaries: existing [msg0, prompt-a,
+    prompt-b], roots [before, boundary a, mid, boundary b, after], expects
+    [msg0, before, prompt-a, mid, prompt-b, after], stats only on `after`. Matches Round 4
+    Moderate-1.
+  - `message-sender.service.spec.ts:427` S3 pin: a deferred `chat:continue`; the tab is
+    finalized to [before, bubble, after] with `streamingState: null` while the RPC is pending;
+    the RPC rejects; expects `success: false`, boundary removal called with the bubble id, and
+    messages exactly [before, after] as the same objects. Matches Round 4 S3 acceptance.
+  - Earlier M1 and S1 specs (builder boundary+echo, removal, sender rollback, handler removal)
+    unchanged from round 2.
+
+### Batch 1 verification
+
+1. Dispositions:
+   - S1 FIX: addressed.
+   - S2 FIX: addressed.
+   - M1 ADD SPEC: addressed.
+   - M2: note only, unchanged, as disposed.
+   - R1 (Round 3): FIXED. Anchor by `id` only; confirmed in code and by the code-logic
+     re-review (`code-logic-review.md`, R1 row).
+   - S3 (Round 4): ACCEPTED by the orchestrator as correct behavior; pinned by spec. Not a
+     defect for this gate.
+   - Moderate-1 (Round 4): regression spec added.
+2. Contract change (`buildTree` omits user roots): harness-builder and setup-wizard run through
+   `InternalQueryService`, which never enables `replay-user-messages`; subagent user messages
+   carry `parentToolUseId`. CONCLUSIVE (unchanged from the first verification).
+3. Gates, re-run by team-leader from the worktree root on 2026-09-11 (no `nx reset`):
+   - `npx nx run-many -t test -p @ptah-extension/chat-streaming @ptah-extension/chat
+     @ptah-extension/chat-execution-tree --skip-nx-cache`: header "Running target test for 3
+     projects". Exit 0.
+     - chat-execution-tree: 2 suites, 22 passed.
+     - chat-streaming: 22 suites, 479 passed, 1 skipped (480).
+     - chat: 69 suites, 1057 passed, 2 skipped (1059).
+     - The timing-budget spec passed on the first run; no re-run needed.
+   - `npx nx run-many -t typecheck -p @ptah-extension/chat-streaming @ptah-extension/chat
+     --skip-nx-cache`: 2 projects. Exit 0.
+   - `npx nx run-many -t lint -p @ptah-extension/chat-streaming @ptah-extension/chat
+     --skip-nx-cache`: 2 projects, 0 errors, 2 + 17 warnings, exit 0. No warning names a staged
+     file, so no new lint findings.
+   - `npx prettier --check` on the 10 staged files: all clean.
+4. `git status` before commit: exactly the 10 staged files; nothing unstaged or untracked.
+5. Commit: `bba7b30f1 fix(chat-streaming): split the live bubble at a mid-turn prompt`.
+   Hooks ran (no `--no-verify`), exit 0, no reformat, working tree clean after commit.
+   Conforms to `.commitlintrc.json` (type `fix`, scope `chat-streaming`, subject under 72).
+   Not pushed, no PR.
+
+### R1 — history (rejected in Round 3, resolved)
+
+- Trigger was a failed direct send followed by a successful idle retry. The retry's SDK echo was
+  stamped onto the failed bubble by `reconcileUserMessageNativeUuid`, and the `nativeUuid`
+  anchor then placed the reply above its own prompt.
+- Resolution: the `nativeUuid` match was removed from `placeFinalizedTrees`; a user root anchors
+  only on an existing user message `id`. Pinned by the R1 regression spec
+  (`message-finalization.service.spec.ts:471`).
+
+Batch state: COMPLETE. Task carrier moved to `in_review`.

--- a/.ptah/specs/TASK_2026_420_84d9/code-logic-review.md
+++ b/.ptah/specs/TASK_2026_420_84d9/code-logic-review.md
@@ -1,0 +1,253 @@
+# Code Logic Review — `TASK_2026_420_84d9` (RE-REVIEW, round 3)
+
+Scope: full STAGED diff, 10 files, worktree
+`D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split`
+(`git diff --cached`). This is the third pass: round 2 found S1/S2/M1/M2, round 2's
+revision was rejected by team-leader for R1, and this pass re-verifies R1's fix and
+hunts for anything the R1 revision itself introduced.
+
+## Previous findings — status
+
+| ID | Round 2 finding | This pass |
+| --- | --- | --- |
+| S1 | Failed queue-flush leaves an orphaned bubble + false boundary, duplicates on retry | FIXED — verified in `message-sender.service.ts:643-737`, both failure exits roll back, queue flush drops the bubble too. New gap found in the same mechanism, see S3 below. |
+| S2 | Real SDK user-echo root becomes a ghost empty assistant bubble | FIXED — `execution-tree-builder.service.ts:339-347` skips user roots entirely; `buildTree` never emits one. Verified against the event schema (`message_start.id` is a fresh event id, `messageId` is the SDK uuid) — the node/message id chain is internally consistent. |
+| M1 | No spec exercises boundary + real echo together | FIXED — `message-finalization.service.spec.ts:390-427`, `execution-tree-builder.service.spec.ts` (boundary+echo real-accumulator test per `implementation-notes.md`). |
+| M2 | Rewind while a boundary is live is untested | Unchanged, still a documented note only — accepted per round 2 disposition, not re-litigated. |
+| R1 | `nativeUuid` anchor misplaces a reply after a failed direct send (stamped on the oldest unstamped bubble) | FIXED — `placeFinalizedTrees` (`message-finalization.service.ts:48-91`) anchors a user root ONLY when its `messageId` equals an existing user message's `id`; the echo is never an anchor. Regression spec `appends the reply after its own prompt when the echo uuid was stamped on an older failed bubble (R1)` (`message-finalization.service.spec.ts:471-528`) passes and correctly reproduces `main`'s plain-append order. |
+
+## Five logic questions
+
+### 1. How does this fail silently?
+
+- **New, S3**: a queue-flush failure force-removes the optimistic bubble from
+  `tab.messages` (`message-sender.service.ts:719-737`, `rollBackUnsentPrompt`)
+  unconditionally, with no check for whether `finalizeCurrentMessage` already
+  consumed that bubble as a split anchor and persisted the turn around it. If the
+  live turn this flush interrupted finalizes (on its own, later stream events)
+  before the failing RPC's promise settles, the bubble is already gone from the
+  "live" state (boundary removal correctly no-ops — verified,
+  `streaming-handler.service.spec.ts:624-632`) but is NOT gone from
+  `tab.messages`, where it now sits as a real row inside an already-committed
+  split. The rollback still deletes it there, silently dropping a
+  user-visible, already-persisted message from the transcript while the "before"
+  and "after" assistant content on either side of it survives untouched. See
+  Serious-3.
+- Round-2's already-fixed silent paths (S1/S2) stay fixed; no new silent failure
+  found on the ordinary happy or failure paths.
+
+### 2. What user action produces unexpected behaviour?
+
+- Sending a follow-up mid-turn whose `chat:continue` RPC is slow to fail (auth
+  hiccup, backend under load, timeout) while the interrupted turn keeps
+  generating and reaches its own real end before the RPC settles: the user's
+  message visibly appears, gets spliced into the transcript as a legitimate
+  split point, then disappears once the (now stale) failure handler runs — and
+  the text silently reappears later, out of place, at the end of the queue's
+  next successful flush. See S3.
+- Sending two follow-ups mid-turn back-to-back (both delivered) is
+  correct by hand-trace (verified below) but has zero spec coverage — a
+  regression here would not be caught. See Moderate-1.
+
+### 3. What input data produces a wrong answer?
+
+- None beyond S3. `placeFinalizedTrees`'s id-only anchor (`message-finalization.service.ts:57-58`)
+  was traced against: single boundary, boundary+echo, echo-with-no-boundary
+  (plain append), and the R1 stamped-on-stale-bubble case — all correct, all
+  test-pinned except the two-boundary case (Moderate-1).
+
+### 4. What happens when a dependency fails?
+
+- `chat:continue` rejecting or throwing after the boundary write is handled
+  for the "state still live" case (verified) but not for the "state already
+  replaced by a finalization that ran while the RPC was in flight" case — S3.
+- Compaction/event-cap dropping the boundary: unchanged from round 2,
+  accepted/documented, not re-litigated here.
+
+### 5. What is missing that the requirements never mentioned?
+
+- A guard on `rollBackUnsentPrompt`'s bubble-drop path confirming the message
+  it is about to delete is still the tab's OWN unfinalized optimistic bubble
+  (e.g. checking it is not already referenced by a persisted
+  `streamingState` node, or diffing whether `tab.streamingState` is still the
+  same object the boundary was written into) before mutating `tab.messages`.
+- A regression spec for two prompts sent mid-turn in the same live tree
+  (Moderate-1) — the code is correct by trace, but nothing pins it.
+
+## Failure modes
+
+### S3 — Queue-flush rollback deletes an already-finalized message when the underlying turn settles before the RPC failure is observed
+
+- Trigger: user sends prompt A while turn T is streaming. The premature-flush
+  mechanism (accepted out of scope, `context.md` root cause step 1-2) dispatches
+  `chat:continue` for A early — right after T's first streamed message, not at
+  T's real end. T keeps streaming. Two things now race: (a) T reaches its own
+  real terminal event and `finalizeCurrentMessage` runs, splicing A's bubble in
+  as the anchor and calling `applyFinalizedTurn` (`message-finalization.service.ts:242-245`);
+  (b) the `chat:continue` promise for A eventually rejects or throws.
+- Symptom: if (a) happens before (b) resolves back into `runContinueConversation`'s
+  `catch`/rejection branch, `rollBackUnsentPrompt` (`message-sender.service.ts:719-737`)
+  still runs and calls `this.tabManager.setMessages(tabId, tab.messages.filter(m => m.id !== messageId))`
+  against the CURRENT `tab.messages` — which by now is the finalized array
+  containing A's bubble as a real split anchor with assistant content already
+  placed before and after it. The filter removes A's row from that finalized
+  array. The visible result: A's message vanishes from the middle of an
+  otherwise-intact assistant reply, with no error, no notice, and the queued
+  text is silently put back for a later retry that will append a duplicate
+  reply at the END of the transcript, disconnected from where the turn was
+  actually split.
+- Evidence: `message-sender.service.ts:697-712` (the `catch` branch calls
+  `rollBackUnsentPrompt(activeTabId, sentPromptId, dropBubbleOnFailure)`
+  unconditionally, no check against `tab.streamingState` or a "still live"
+  flag), `message-sender.service.ts:719-737` (`rollBackUnsentPrompt` reads
+  `tab.messages` fresh via `findTabByIdAcrossWorkspaces` and filters
+  unconditionally), `message-finalization.service.ts:242-245`
+  (`applyFinalizedTurn` overwrites `tab.messages` with the spliced array,
+  independent of any in-flight `chat:continue`). The developer's own
+  `implementation-notes.md` (S1 section, last paragraph) states: "If the turn
+  finalizes before the RPC fails, the state has already been replaced. The
+  boundary removal is then a no-op. **On the queue path the bubble is still
+  removed.**" — this is exactly the unguarded deletion, acknowledged but not
+  fixed.
+- Current handling: none — the boundary removal correctly no-ops against a
+  replaced state (verified, `streaming-handler.service.spec.ts:624-632`), but
+  the bubble removal in `message-sender.service.ts` has no equivalent guard and
+  operates on `tab.messages` regardless of whether finalization already
+  consumed the message.
+- Recommendation: before deleting on the queue-flush failure path, check
+  whether the bubble is still present in the tab's LIVE (unfinalized) state —
+  e.g. only drop it when `tab.streamingState` is the same object reference
+  captured at send time and still holds the boundary, or when the bubble id is
+  absent from any finalized tree node built from the current `tab.messages`.
+  Otherwise treat the failure as "too late to unwind" and skip the bubble
+  removal (leave both the bubble and the requeued retry — a visible duplicate
+  is a much smaller defect than a silently vanished message).
+
+## Blocking issues
+
+None. S3 requires an async interleaving (a slow/failing `chat:continue` racing
+the interrupted turn's own natural end) rather than firing on the ordinary
+happy or failure path, and it degrades the transcript (a message disappears,
+a duplicate appears later) rather than crashing or corrupting the array
+structurally.
+
+## Serious issues
+
+### S3 — Queue-flush rollback can delete an already-persisted message (see Failure modes above)
+
+- File: `libs/frontend/chat/src/lib/services/message-sender.service.ts:697-712,719-737`
+- Scenario: mid-turn `chat:continue` fails (or times out) after the underlying
+  interrupted turn has already reached its own natural end and finalized
+  around the boundary this call wrote.
+- Impact: the user's own message silently disappears from a transcript that
+  otherwise looks complete and correct; the text is requeued and later
+  reappears out of order as an unexplained duplicate. This undermines the
+  same guarantee S1 was fixed to protect (no orphaned/duplicated mid-turn
+  prompt) — S1 covers the case where the RPC fails before the turn settles;
+  this covers the case where it settles after.
+- Fix: guard the bubble-drop branch of `rollBackUnsentPrompt` against a
+  state that has already been finalized/replaced, per the recommendation
+  above.
+
+## Moderate and minor issues
+
+- **Moderate-1 — Two prompts sent mid-turn (two boundaries in one live state) has no regression spec.**
+  Hand-traced through `placeFinalizedTrees` (`message-finalization.service.ts:48-91`):
+  for `existing = [msg0, promptA, promptB]` and roots
+  `[before, boundaryA, mid, boundaryB, after]`, the result is
+  `[msg0, before, promptA, mid, promptB, after]` — correct, `firstAnchor` stays
+  pinned to the FIRST anchor (`??=`) and the per-message placement loop
+  handles the rest generically. No spec constructs this two-boundary case (only
+  single-boundary and boundary+echo scenarios exist in
+  `message-finalization.service.spec.ts`), so a future change to the anchor
+  loop could regress it silently. Carried over from round 2's "M1-adjacent"
+  note; still open.
+- **Minor — `chat-transcript.component.ts` needed no change and none was made.**
+  Verified: `streamingMessages` (`chat-transcript.component.ts:307-330`) maps
+  `buildTree`'s output directly to `role: 'assistant'` bubbles; since
+  `buildTree` no longer emits user roots at all (S2 fix), this component
+  automatically stopped rendering the ghost bubble with no edit required.
+  `transcriptOrderKey`/`mergeByTime` (`chat-transcript.component.ts:50-87`)
+  key off `streamingState.startTime` for assistant nodes and the bubble's own
+  `timestamp` for user messages — both still monotonic under the boundary
+  mechanism, no reordering found. This is a confirmation, not a defect.
+- **M2 (round 2, rewind while a boundary is live)**: unchanged, still accepted
+  as a note per the existing disposition. Not re-scored.
+
+## Data flow
+
+1. User sends prompt A while turn T streams → `queueOrAppendMessage`, no
+   bubble/boundary yet — OK.
+2. T's root `message_complete` (premature per the accepted out-of-scope
+   trigger) fires the flush → `continueExistingSessionForQueueFlush` →
+   `runContinueConversation`: bubble appended, `recordUserPromptBoundary`
+   called, `sentPromptId` set — OK.
+3a. Happy path: `chat:continue` resolves success before T's real end → nothing
+    rolls back — OK, matches S1 disposition.
+3b. Failure-before-settle path: `chat:continue` rejects/throws while T is
+    still live (`state.currentMessageId` still set to T's message) →
+    `rollBackUnsentPrompt` removes the boundary (real no-op-safe) and the
+    bubble from the still-pre-finalization `tab.messages` — OK, this is what
+    S1's specs pin.
+3c. Failure-after-settle path (NEW): T reaches its own real end before the
+    rejected/thrown `chat:continue` is handled → `finalizeCurrentMessage`
+    splices A's bubble into `tab.messages` as a real anchor and calls
+    `applyFinalizedTurn` → THEN `rollBackUnsentPrompt` runs against the now
+    stale reference and deletes A's row from the persisted array — gap (S3).
+4. `placeFinalizedTrees` walks `state.messageEventIds`, anchors a user root
+   only on an existing user message `id` (R1 fix) — OK, verified against
+   single-boundary, boundary+echo, echo-only, and the R1 stale-stamp
+   scenarios; not verified for concurrent multi-boundary (Moderate-1).
+5. `ExecutionTreeBuilderService.buildTreeWithIndexes` omits every user root
+   from `nodeByRoot`/`ownerByRootIndex`/`reusedRoots` but keeps them in
+   `rootOrder`/`digestByRoot`, so inserting/removing a boundary still forces a
+   rebuild via the whole-tree reuse check — OK, verified by code read.
+6. `chat-transcript.component.ts` renders `buildTree`'s (now user-root-free)
+   output as assistant bubbles and merges by time with the finalized array —
+   OK, no regression found.
+
+## Requirements fulfilment
+
+| Requirement | Status | Gap |
+| ----------- | ------ | --- |
+| Live bubble splits at the user's message while streaming | COMPLETE (happy path) | S3 only affects the specific RPC-failure-after-settle race, not the ordinary split. |
+| A failed mid-turn send does not corrupt the transcript | PARTIAL | Fixed for failure-before-settle (S1); not fixed for failure-after-settle (S3). |
+| A normal (non-mid-turn) send after an earlier failed send is not misplaced | COMPLETE | R1 fix verified, regression spec passes. |
+| Multiple mid-turn prompts split correctly | COMPLETE (by inspection) | No regression spec (Moderate-1). |
+
+Implicit requirements not addressed: a queue-flush failure that arrives after
+its interrupted turn has already finalized must not delete an already-persisted
+message (S3).
+
+## Edge cases
+
+| Case | Handled | How | Concern |
+| ---- | ------- | --- | ------- |
+| Queue-flush RPC fails while the turn is still live | YES | boundary + bubble both rolled back, pinned by 4 specs | none |
+| Queue-flush RPC fails AFTER the turn has already finalized | NO | bubble deleted from the now-persisted array unconditionally | S3 |
+| Direct-send RPC fails | YES | boundary rolled back, bubble intentionally kept (`dropBubbleOnFailure=false`) | none |
+| Failed direct send, then a normal retry succeeds (R1) | YES | anchor by `id` only; echo never anchors via stale `nativeUuid` | none, regression spec passes |
+| Boundary + real SDK echo in one state | YES | echo skipped at placement (not an anchor); tree never builds a node for either | none |
+| Two boundaries (two mid-turn prompts) in one state | YES (by inspection) | generic per-root placement loop | no spec (Moderate-1) |
+| Compaction/cap eviction drops the boundary | ACCEPTED (pre-existing) | documented | out of scope, unchanged |
+| Rewind while a boundary is live (M2) | UNKNOWN | unchanged from round 2 | out of scope for this pass |
+
+## Verdict
+
+- Recommendation: REVISE
+- Confidence: MEDIUM — S3 is traced through concrete code paths
+  (`message-sender.service.ts`, `message-finalization.service.ts`) and is
+  explicitly acknowledged (not contradicted) by the implementer's own notes,
+  but it depends on an async interleaving that was not reproduced against a
+  running app and has no counterexample test either way.
+- Top risk: the fix that closed S1 (drop the bubble on queue-flush failure so a
+  retry doesn't duplicate) reaches back into `tab.messages` without checking
+  whether that array has moved on since the bubble was written — the same
+  category of bug S1 fixed (an unconditional mutation with no regard for
+  concurrent state changes), recurring one step later in the same code path.
+- What a robust implementation would add: (1) a liveness/ownership check in
+  `rollBackUnsentPrompt` before deleting the bubble on the queue-flush path,
+  so a late failure cannot unwind a message finalization already committed;
+  (2) a regression spec reproducing S3 (turn finalizes, THEN the flush's RPC
+  rejects) asserting the persisted message survives; (3) a two-boundary
+  regression spec for `placeFinalizedTrees` (Moderate-1).

--- a/.ptah/specs/TASK_2026_420_84d9/context.md
+++ b/.ptah/specs/TASK_2026_420_84d9/context.md
@@ -1,0 +1,151 @@
+# TASK_2026_420 — Context
+
+## User intent
+
+"When sending a message while the agent is working, it doesn't split the agent
+bubble while streaming, it only shows when the agent completes the whole round."
+The user wants the live transcript to split at their message: output before it
+stays above, output after it renders below — while the turn still streams.
+
+Follow-up request: confirm the cause with an external stress review before
+committing, then orchestrate the fix in a worktree off latest `main` using CLI
+tools and subagents.
+
+## Workspace
+
+- Worktree: `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split`
+- Branch: `fix/task-420-mid-turn-bubble-split` (from `origin/main` @ f7b2c1670)
+- The fix was first written uncommitted on `fix/task-419-session-worktree-resume`
+  in the main checkout and carried over as a patch (applied cleanly, staged).
+
+## Strategy
+
+- Type: BUGFIX, Partial workflow (fix exists and has one external review).
+- CLI delegation: enabled (user: "use cli tools and subagents as you see fit").
+  Available: `codex`, `antigravity` (cli), `ollama cloud` and `claude cli` (ptah-cli).
+- Sequence: code-logic-reviewer + codex review (parallel) → senior-tester
+  (full lib suites, gaps) → fix round if needed → team-leader verify + commit.
+
+## Root cause (confirmed by Ollama Cloud review)
+
+1. Mid-turn sends are queued and flushed in
+   `StreamingHandlerService.processEventForTab` on any root `message_complete`
+   with `stopReason !== 'tool_use'`.
+2. The stream path `StreamEventTransformer.onMessageStop`
+   (`libs/backend/agent-sdk/src/lib/message-transform/stream-event.transformer.ts`)
+   emits `message_complete` with NO `stopReason` for every streamed message, and
+   partial messages are on by default — so the flush fires after the first
+   streamed message of a turn.
+3. `MessageSenderService.runContinueConversation` appends the optimistic user
+   bubble to `tab.messages`; the backend `SessionStreamPump` holds the prompt
+   until the turn ends, so the SDK's user `message_start` echo only arrives then.
+4. `ExecutionTreeBuilderService.buildTree` merges consecutive root assistant
+   messages; only a user root breaks the merge. Live state has none, so later
+   output merges into the bubble above the prompt.
+5. `MessageFinalizationService.finalizeCurrentMessage` appended every new tree
+   after existing messages, i.e. after the prompt.
+
+## Fix (staged in the worktree)
+
+- `StreamingAccumulatorCore.recordUserPromptBoundary(state, event)` — stores a
+  user `message_start` (id = messageId = optimistic bubble id) without moving
+  `currentMessageId` or touching dedup.
+- `StreamingHandlerService.recordUserPromptBoundary(tabId, message)` — only for
+  a live tree (`currentMessageId != null`); resolves the tab across workspaces;
+  active tab → `scheduleUpdate`, background tab → `updateBackgroundTab`.
+- `MessageSenderService.runContinueConversation` calls it after `setMessages`.
+- `finalizeCurrentMessage`: stats on the last NEW tree; `placeFinalizedTrees`
+  splices new messages in root order around the first existing USER anchor.
+
+## Ollama Cloud review (verdict: ACCEPT WITH CHANGES)
+
+- Cause: PARTIAL → mechanism wording corrected (stream path, see step 2).
+- F1 stats fold with boundary-only tree: checked — NOT a regression (the fold
+  requires the last message to be an assistant; the prompt is last). Pinned by
+  a parity spec.
+- F2 background-workspace tab got no boundary: FIXED + 3 specs.
+- F3 compaction replacement state / F4 event-cap eviction drop the boundary:
+  accepted, documented on `recordUserPromptBoundary`.
+- Flush-trigger regression test: declined — it would pin the premature flush.
+- F5 SDK echo user root may render as an assistant bubble: pre-existing, out
+  of scope, needs its own investigation.
+
+## Round 2 reviews (worktree, staged diff)
+
+- `code-logic-review.md` (subagent): NEEDS_REVISION, 5/10 — S1, S2, M1, M2.
+- codex (CLI): cause CONFIRMED; ACCEPT WITH CHANGES — rejected `chat:continue`
+  leaves a false boundary (same as S1).
+
+Dispositions (orchestrator, checked against code):
+
+- S1 FIX — `runContinueConversation` writes bubble + boundary before the RPC;
+  neither failure exit removes them. Roll the boundary back on every failed or
+  thrown continue. On a failed QUEUE FLUSH also remove the optimistic bubble,
+  because `restoreFailedQueue` returns the text to the queue (retry would
+  otherwise show it twice).
+- S2 FIX — confirmed: `handleDuplicateMessageStart` matches by messageId only;
+  the SDK echo (commit ebbcaa16f, forwarded by `stream-transformer.ts:533`)
+  enters `streamingState` as a user root, and the transcript maps every root
+  to `role: 'assistant'`. Pre-existing (Ollama F5) but the boundary adds user
+  roots too, so handle both: user roots break the assistant merge but are NOT
+  emitted by `buildTree`; finalization derives anchors from
+  `messageEventIds` order, matching a user root to an existing message by
+  `id` OR `nativeUuid`.
+- M1 ADD SPEC — boundary + real echo in one state: one split, no extra root,
+  no minted message.
+- M2 — note only (rewind is UI-gated while streaming).
+- codex note: the echo's own `message_complete` (no stopReason) can flush a
+  second queued prompt — pre-existing trigger, out of scope.
+- Alternative "flush only at real turn end" — rejected: user asked for the
+  split while streaming.
+
+## Round 3 — team-leader verify (BATCH REJECTED, see batches.md)
+
+- R1: anchoring on `nativeUuid` misplaces a reply after a failed direct send,
+  because `TabManagerService.reconcileUserMessageNativeUuid` stamps the OLDEST
+  unstamped optimistic bubble (the failed one). Regression vs round 1.
+- Disposition (orchestrator): anchor by `id` ONLY. The `nativeUuid` anchor
+  adds nothing — without a boundary it reproduces the plain append; with a
+  boundary the boundary already anchors by id; a mid-turn prompt's echo
+  normally lands in the next turn's state. The echo stays hidden (S2) and still
+  breaks the merge; a non-anchor user root is skipped during placement.
+  Remove/replace the nativeUuid-anchor specs and add an R1 regression spec.
+- Follow-up (separate task, not this batch): the oldest-first stamping in
+  `reconcileUserMessageNativeUuid` also mis-anchors fork/rewind after a failed
+  send.
+- Separate bug found meanwhile: Codex CLI agents never reach `completed` —
+  `CodexCliAdapter.runTurn` waits for the SDK event iterator to end, which only
+  happens when `codex.exe` exits; it stays alive with a long-lived PowerShell
+  AST-parser child. Fix: return on `turn.completed` / `turn.failed`.
+- Contract change (buildTree no longer returns user roots): settled —
+  harness-builder and setup-wizard run through `InternalQueryService`, which
+  never enables `replay-user-messages`.
+
+## Round 4 — code-logic re-review (NEEDS_REVISION)
+
+- S1, S2, M1, R1: confirmed fixed.
+- S3 (queue-flush `chat:continue` fails AFTER the turn finalized → rollback
+  drops the prompt bubble from the finalized array): race is real, but the
+  current behaviour is ACCEPTED as correct. The prompt was never delivered, so
+  it must not sit between reply parts the model produced without it; the user
+  sees `showSendFailure` and the text back in the queue chip; the assistant
+  messages stay intact and in order. The reviewer's proposed guard (keep the
+  bubble AND requeue) reintroduces the duplicate S1 removed. Pin the behaviour
+  with a spec.
+- Moderate-1 (two mid-turn prompts, two boundaries in one state): code correct
+  by trace; ADD a regression spec.
+
+## Open design note
+
+Split-at-send (this fix) vs holding the queue until the real turn end (matches
+JSONL reload, delays the bubble). User asked for split-while-streaming; this
+task implements that.
+
+## Verification so far (main checkout)
+
+- chat-streaming focused specs: 141 passed
+- chat focused specs: 101 passed
+- typecheck chat-streaming + chat: passed
+- FULL suites via `nx run-many -t test` (main checkout, identical 9-file diff):
+  chat-streaming 22 suites / 468 passed, 1 skipped; chat 69 suites / 1051
+  passed, 2 skipped. Final re-run belongs in the worktree before commit.

--- a/.ptah/specs/TASK_2026_420_84d9/implementation-notes.md
+++ b/.ptah/specs/TASK_2026_420_84d9/implementation-notes.md
@@ -1,0 +1,261 @@
+# TASK_2026_420 — Implementation notes (revision for S1, S2, M1)
+
+Worktree: `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split`
+(branch `fix/task-420-mid-turn-bubble-split`). All changes staged, not committed.
+
+Note: `implementation-notes.md` is not in the set of documents the Tasks board reads
+from a task folder. It was written because the orchestrator asked for it.
+
+## S1: a failed send left a false boundary
+
+- `StreamingAccumulatorCore.removeUserPromptBoundary(state, messageId): boolean`
+  (`libs/frontend/chat-streaming/src/lib/accumulator-core.service.ts`).
+  - It removes the event from `events`, the bucket from `eventsByMessage`, the id from
+    `messageEventIds` and the entry from `messageRevisions`, then calls
+    `markStructuralChange`.
+  - It removes only the boundary's own shape: a user `message_start` whose event id is
+    its messageId. An SDK message with that id is never touched.
+  - It bumps only `structuralRevision`. The boundary insert already defined that counter,
+    so the builder's index memo keys on it. The root order change forces the tree rebuild.
+- `StreamingHandlerService.removeUserPromptBoundary(tabId, messageId)`
+  (`streaming-handler.service.ts`).
+  - Tab resolution is workspace-aware, the same as `recordUserPromptBoundary`.
+  - Active tab: `scheduleUpdate`. Background tab: `updateBackgroundTab`. Nothing is
+    published when there was no boundary to remove.
+  - Both methods now share two private helpers: `findTabStreamingState` and
+    `publishBoundaryChange`.
+- `MessageSenderService.runContinueConversation` (`message-sender.service.ts`).
+  - New parameter `dropBubbleOnFailure = false`.
+  - `sentPromptId` is set right after the bubble and boundary are written.
+  - Both failure exits after that point call `rollBackUnsentPrompt`: the structural
+    `chat:continue` failure branch, and the `catch`.
+  - `rollBackUnsentPrompt` always removes the boundary. It removes the optimistic bubble
+    only when `dropBubble` is true.
+  - `continueExistingSessionForQueueFlush` passes `true`. The queue caller re-queues the
+    text through `restoreFailedQueue`, so a retry now shows it once.
+  - The direct send (`continueConversation`) passes nothing, so its bubble stays as before.
+- If the turn finalizes before the RPC fails, the state has already been replaced. The
+  boundary removal is then a no-op. On the queue path the bubble is still removed.
+
+## S2: user roots are no longer tree output
+
+- `ExecutionTreeBuilderService.buildTreeWithIndexes`
+  (`execution-tree-builder.service.ts`).
+  - A root whose `message_start.role === 'user'` sets `lastAssistantNode = null` and
+    `continue`s. It is never built and never pushed.
+  - Memo and identity reuse stay correct:
+    - User ids stay in `rootOrder` and `digestByRoot`, so inserting or removing a
+      boundary or echo still breaks the whole-tree reuse and re-runs the merge.
+    - `nodeByRoot`, `ownerByRootIndex` and `reusedRoots` only ever see built,
+      non-user nodes.
+- `MessageFinalizationService.placeFinalizedTrees(existing, stateCopy, newMessages)`
+  (`message-finalization.service.ts`).
+  - Placement order walks `stateCopy.messageEventIds` over root messages
+    (`findMessageStartEvent`, skipping `parentToolUseId`).
+  - A user root is an anchor when its messageId is an existing user message's `id` or
+    `nativeUuid`. The boundary and the SDK echo therefore land on the same bubble,
+    deduplicated.
+  - An assistant root maps to the message whose id is its `message_start` event id. A
+    message merged into an earlier node has no slot of its own.
+  - Unchanged:
+    - Plain append when there is no anchor.
+    - Stats go on the last new message.
+    - Existing assistant ids are not anchors.
+    - Existing messages after the first anchor that were not placed keep their order at
+      the end.
+  - Addition not asked for: a new message whose node matches no root is appended after
+    the placed root order instead of being dropped. This cannot happen today, because
+    every tree node comes from a root; it guards against silent loss.
+- The `recordUserPromptBoundary` doc comment is updated. The boundary renders nothing
+  itself; its id is what finalization anchors on.
+
+### `buildTree` consumers checked
+
+| Consumer | Result |
+| --- | --- |
+| `ChatTranscriptComponent.streamingMessages` / `_executionTrees` (chat; canvas tiles use the same component with the `tile-` key) | Fixed by this change. Every root is mapped to `role: 'assistant'`, so the SDK echo no longer renders as an empty assistant bubble. |
+| `ChatStore.currentExecutionTrees` / `currentExecutionTree` (deprecated) | No consumers outside `chat.store.ts`. `[0]` is now the first assistant root instead of a possible user root. |
+| `MessageFinalizationService.finalizeCurrentMessage` | Adjusted, see above. |
+| `MessageFinalizationService.finalizeSessionHistory` | Unaffected. User messages are built from state events; assistant messages look up the tree node by `message_start.id`. |
+| `harness-builder-view.component.ts`, `setup-wizard` `analysis-transcript.component.ts` | Unaffected as far as the frontend shows: neither source handles a user `message_start`. The backend streams were not traced. If one does emit a user root, it used to render as a message node and is now omitted. |
+| `AgentMonitorTreeBuilderService` / `ptah-cli-output.component.ts` | Different builder. Unaffected. |
+| chat-routing `StreamRouter` | Does not call `buildTree`. Unaffected. |
+| `session-loader.service.spec.ts`, `chat-transcript.component.spec.ts` | Mock `buildTree`. Unaffected. |
+
+### Existing specs moved to the new contract
+
+All in `execution-tree-builder.service.spec.ts`:
+
+- The 1 000-delta test now uses an assistant, user, assistant sequence. It still asserts
+  only the changed message is rebuilt and the other root keeps its identity.
+- The mid-turn boundary split test expects 2 roots, not 3.
+- The prune identity test now feeds assistant roots separated by user turns. 400 user-only
+  messages would build an empty tree.
+- The resumed-history test expects 1 root, not 2.
+
+In `message-finalization.service.spec.ts`, the three staged boundary tests are rewritten to
+use a real root-order state (`makeRootsState`). The mocked tree no longer contains user
+nodes.
+
+## M1: new specs
+
+- (a) `execution-tree-builder.service.spec.ts`, real accumulator and builder:
+  - `splits once when the SDK echo of the prompt joins the boundary`: boundary, then the
+    echo under the SDK uuid with its text, then a later assistant message. The tree has
+    exactly the two assistant roots, split at the prompt.
+  - `merges the turn back together once the boundary is removed`: checks the
+    structural revision bump and that `messageEventIds`, `events` and `eventsByMessage`
+    are cleared.
+  - `never removes an SDK message through removeUserPromptBoundary`.
+- (b) `message-finalization.service.spec.ts`. The tree builder is mocked, as in the rest
+  of the file; the state carries real root starts.
+  - `places the turn once around a prompt the boundary AND the SDK echo both mark`: the
+    bubble has `nativeUuid` set to the SDK uuid. Result is before, prompt, after, with no
+    extra message.
+  - `anchors on the SDK echo alone through the stamped nativeUuid`.
+  - `gives a message merged into an earlier node no slot of its own`.
+- (c) S1:
+  - `message-sender.service.spec.ts`, describe `a continue whose prompt never reaches
+    the backend`:
+    - Rejected direct send removes the boundary and keeps the bubble.
+    - Thrown direct send does the same.
+    - Rejected queue flush (`data.success === false`) removes the boundary and the bubble.
+    - Thrown queue flush does the same.
+    - A delivered continue rolls nothing back.
+  - `streaming-handler.service.spec.ts`: removal on the active tab (scheduled update),
+    removal through the background partition, and nothing published when no boundary
+    exists.
+  - `message-sender.session-identity.spec.ts`: the stub gains `removeUserPromptBoundary`.
+
+## Files (staged)
+
+- `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split/libs/frontend/chat-streaming/src/lib/accumulator-core.service.ts`
+- `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split/libs/frontend/chat-streaming/src/lib/execution-tree-builder.service.ts`
+- `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split/libs/frontend/chat-streaming/src/lib/execution-tree-builder.service.spec.ts`
+- `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split/libs/frontend/chat-streaming/src/lib/message-finalization.service.ts`
+- `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split/libs/frontend/chat-streaming/src/lib/message-finalization.service.spec.ts`
+- `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split/libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts`
+- `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split/libs/frontend/chat-streaming/src/lib/streaming-handler.service.spec.ts`
+- `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split/libs/frontend/chat/src/lib/services/message-sender.service.ts`
+- `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split/libs/frontend/chat/src/lib/services/message-sender.service.spec.ts`
+- `D:/projects/ptah-extension/.claude-worktrees/task-420-mid-turn-bubble-split/libs/frontend/chat/src/lib/services/message-sender.session-identity.spec.ts`
+
+## Verification (worktree root)
+
+- `npx nx run-many -t test -p @ptah-extension/chat-streaming @ptah-extension/chat @ptah-extension/chat-execution-tree --skip-nx-cache`
+  - Header: `Running target test for 3 projects`. Final run: `Successfully ran target test
+    for 3 projects`, exit 0.
+  - chat-execution-tree: 2 suites passed; 22 tests passed.
+  - chat-streaming: 22 suites passed; 477 tests passed, 1 skipped (478 total).
+  - chat: 69 suites passed; 1056 tests passed, 2 skipped (1058 total).
+- Earlier runs during the revision, recorded for honesty:
+  - Run 1: 4 failures in `message-finalization.service.spec.ts`. The spec's node ids did
+    not match its root start ids. The spec was fixed; production code was unchanged apart
+    from the fallback append described under S2.
+  - Run 2, after prettier: 1 failure in the timing guard `builds ~5 000 deltas across 50
+    tool calls well under a second` (871 ms against a 528 ms budget; that suite took
+    180 s). That test streams a single assistant message and never reaches the user-root
+    branch. The spec alone passed (23/23), and so did the final full run above. This is
+    load-sensitive flakiness, not a regression.
+- `npx nx run-many -t typecheck -p @ptah-extension/chat-streaming @ptah-extension/chat --skip-nx-cache`:
+  2 projects passed.
+- `npx prettier --check` on the 10 changed files flagged 3 spec files. They were formatted
+  with `--write` before the final run.
+- `npx nx reset` was not run.
+
+## Observations (not changed)
+
+- Stamping quirk in `TabManagerService.reconcileUserMessageNativeUuid` (chat-state,
+  outside this batch). It stamps the FIRST user bubble that has an optimistic id and no
+  `nativeUuid`. If an older bubble was never stamped, the echo's uuid lands on that older
+  bubble instead.
+  - With a boundary present, placement is still correct: the older bubble is already in
+    the preserved prefix, so it is skipped.
+  - Without a boundary (no live tree at send), the echo would anchor on the older bubble
+    and move the messages after it to the end.
+  - This is worth its own follow-up.
+- M2 (rewind while a boundary is live) is untouched, as the disposition says.
+- Out of scope, per the brief: the premature queue flush trigger (including the echo's
+  own `message_complete`), and compaction or the event cap dropping the boundary.
+
+## R1 revision (team-leader rejection): anchor by `id` only
+
+This section replaces the `nativeUuid` anchor described under S2 above.
+
+### Change
+
+`placeFinalizedTrees` in `libs/frontend/chat-streaming/src/lib/message-finalization.service.ts`:
+
+- A user root is an anchor ONLY when its messageId equals an existing USER message's `id`.
+  The `nativeUuid` match is gone.
+- A user root that is not an anchor, such as the SDK echo, is skipped during placement.
+- The doc comment explains why. `reconcileUserMessageNativeUuid` stamps the OLDEST
+  unstamped bubble, so after a failed direct send the echo's uuid lands on the failed bubble
+  and the reply was placed above its own prompt.
+- Unchanged from round 2:
+  - `buildTree` does not emit user roots, and they still break the merge.
+  - Placement walks `messageEventIds`.
+  - Stats go on the last new message.
+  - Existing assistant ids are not anchors.
+  - The plain append applies when there is no anchor.
+  - The fallback append for a new message whose node matches no root stays.
+- `reconcileUserMessageNativeUuid` (chat-state) is untouched. It is a follow-up.
+
+### Spec changes (`message-finalization.service.spec.ts`)
+
+- `places the turn once around a prompt the boundary AND the SDK echo both mark`: kept.
+  Its comment now says the boundary anchors by id and the echo root is skipped. The
+  expected order is still [before, prompt, after], with no extra message.
+- `anchors on the SDK echo alone through the stamped nativeUuid` is inverted and renamed
+  `never anchors on the SDK echo through a stamped nativeUuid`. With no boundary, the
+  result is the plain append: [earlier, user-bubble, before, after].
+- New R1 regression: `appends the reply after its own prompt when the echo uuid was
+  stamped on an older failed bubble (R1)`.
+  - Existing messages: earlier assistant, failed prompt (`msg_1_failed`, with
+    `nativeUuid` = SDK uuid), failure notice, retry prompt (no `nativeUuid`).
+  - State roots: echo(SDK uuid), then the reply assistant root. No boundary.
+  - Expected: [earlier, msg_1_failed, notice, msg_2_retry, reply], with the stats on the
+    reply.
+
+### Verification (worktree root)
+
+- `npx nx run-many -t test -p @ptah-extension/chat-streaming @ptah-extension/chat @ptah-extension/chat-execution-tree --skip-nx-cache`
+  - Header: `Running target test for 3 projects`. Exit 0.
+  - chat-execution-tree: 2 suites passed; 22 tests passed.
+  - chat-streaming: 22 suites passed; 478 tests passed, 1 skipped (479 total).
+  - chat: 69 suites passed; 1056 tests passed, 2 skipped (1058 total).
+- `npx nx run-many -t typecheck -p @ptah-extension/chat-streaming @ptah-extension/chat --skip-nx-cache`:
+  2 projects passed.
+- `npx prettier --check` on `message-finalization.service.ts` and
+  `message-finalization.service.spec.ts`: clean.
+- Staged: those 2 files. The other 8 staged files from round 2 are unchanged. `npx nx reset`
+  was not run.
+
+## Round 4 specs (spec-only; no production code changed)
+
+- Moderate-1: `message-finalization.service.spec.ts` gains `splits one turn around two
+  prompts sent mid-turn, in root order`.
+  - Existing messages: [msg0, prompt-a, prompt-b].
+  - State roots, in order: [before, boundary prompt-a, mid, boundary prompt-b, after].
+  - Expected: [msg0, before, prompt-a, mid, prompt-b, after]. Stats land only on `after`;
+    `before` and `mid` have none.
+- S3 behavior pin (the current behavior is accepted as correct): `message-sender.service.spec.ts`,
+  inside `a continue whose prompt never reaches the backend`, gains `drops the undelivered
+  prompt from a turn that finalized before the flush failed`.
+  - A deferred `chat:continue` promise holds the RPC open after the queue flush writes the
+    bubble and the boundary.
+  - While the RPC is pending, the tab is replaced with a finalized
+    [before, bubble, after] and `streamingState: null`.
+  - The RPC then rejects.
+  - Expected: the outcome resolves with `success: false` and nothing throws. The boundary
+    removal is called. The messages are exactly [before, after], the same objects in order.
+
+### Verification (worktree root)
+
+- `npx nx run-many -t test -p @ptah-extension/chat-streaming @ptah-extension/chat --skip-nx-cache`
+  - Header: `Running target test for 2 projects`. Exit 0.
+  - chat-streaming: 22 suites passed; 479 tests passed, 1 skipped (480 total).
+  - chat: 69 suites passed; 1057 tests passed, 2 skipped (1059 total).
+- `npx prettier --write` then `--check` on the two spec files: clean. Prettier reformatted
+  only `message-sender.service.spec.ts`.
+- Staged: the two spec files. Not committed. `npx nx reset` was not run.

--- a/.ptah/specs/TASK_2026_420_84d9/task.md
+++ b/.ptah/specs/TASK_2026_420_84d9/task.md
@@ -1,0 +1,13 @@
+---
+id: TASK_2026_420_84d9
+status: in_review
+type: BUGFIX
+title: Split the live assistant bubble at a mid-turn user prompt
+description: >-
+  A message sent while the agent is working renders below the live assistant
+  bubble, but later agent output keeps streaming into that bubble above it.
+  The split only appears once the whole round completes.
+---
+
+Live transcript does not split the assistant bubble at a user prompt sent mid-turn.
+See `context.md` for cause, fix and review history.

--- a/.ptah/specs/TASK_2026_422_dee6/context.md
+++ b/.ptah/specs/TASK_2026_422_dee6/context.md
@@ -1,0 +1,31 @@
+# TASK_2026_422 — Context
+
+## Origin
+
+Found while verifying TASK_2026_420 (team-leader rejection R1, see
+`TASK_2026_420_84d9/batches.md`). TASK_2026_420 removed its own dependency on
+`nativeUuid` anchoring, so this bug no longer reorders the transcript; it
+still affects fork and rewind.
+
+## Defect
+
+`TabManagerService.reconcileUserMessageNativeUuid`
+(`libs/frontend/chat-state/src/lib/tab-manager.service.ts` ~1541) targets the
+first user message with a non-UUID id and no `nativeUuid`.
+
+Scenario:
+
+1. A direct send fails. The optimistic bubble stays (non-UUID id, no
+   `nativeUuid`) and a "Message delivery failed" message is appended.
+2. The next send succeeds. The SDK's user `message_start` echo carries the real
+   transcript uuid; `StreamingHandlerService.processEventForTab` calls
+   `reconcileUserMessageNativeUuid`, which stamps the FAILED bubble.
+3. The new bubble stays unstamped. Fork / rewind (`nativeUuid ?? id`, commit
+   ebbcaa16f) on the new message anchors on its optimistic id, and on the
+   failed message anchors on a uuid that belongs to a different prompt.
+
+## Fix direction (to validate)
+
+Stamp the most recent unstamped optimistic user bubble, or skip bubbles that
+are followed by a delivery-failure message. Add a spec with the failed-send
+sequence.

--- a/.ptah/specs/TASK_2026_422_dee6/task.md
+++ b/.ptah/specs/TASK_2026_422_dee6/task.md
@@ -1,0 +1,13 @@
+---
+id: TASK_2026_422_dee6
+status: backlog
+type: BUGFIX
+title: Native uuid stamping picks the oldest unstamped user bubble
+description: >-
+  TabManagerService.reconcileUserMessageNativeUuid stamps the SDK transcript
+  uuid onto the FIRST user bubble with an optimistic id and no nativeUuid.
+  After a failed direct send, the next prompt's uuid lands on the failed
+  bubble, so fork and rewind anchor on the wrong message.
+---
+
+Follow-up from TASK_2026_420 (team-leader R1). See `context.md`.

--- a/.ptah/specs/TASK_2026_425_b4f3/context.md
+++ b/.ptah/specs/TASK_2026_425_b4f3/context.md
@@ -1,0 +1,26 @@
+# TASK_2026_425 — Context
+
+## Origin
+
+Code-logic review M2 on TASK_2026_420 (`TASK_2026_420_84d9/code-logic-review.md`),
+carried as a follow-up in `batches.md`.
+
+## Gap
+
+- `StreamingHandlerService.recordUserPromptBoundary` stores a user
+  `message_start` whose id is the optimistic bubble id.
+- At turn end, `MessageFinalizationService.placeFinalizedTrees` anchors on an
+  existing USER message with that `id`; with no match it falls back to the
+  plain append.
+- Rewind / fork mutators in `chat-state` can remove or replace user messages.
+  Rewind appears UI-gated while a turn streams, but the gate was not traced
+  end-to-end, and no spec covers a boundary whose bubble disappeared.
+
+## To do
+
+1. Trace the rewind / fork entry points and confirm whether they can run while
+   `streamingState` holds a boundary.
+2. Add specs: boundary live → user message removed → finalization gives a
+   sane order (no lost assistant content, no ghost anchor); and the
+   UI gate, if that is the guarantee.
+3. Fix only if a spec exposes a real misplacement.

--- a/.ptah/specs/TASK_2026_425_b4f3/task.md
+++ b/.ptah/specs/TASK_2026_425_b4f3/task.md
@@ -1,0 +1,12 @@
+---
+id: TASK_2026_425_b4f3
+status: backlog
+type: BUGFIX
+title: No regression guard for rewind while a prompt boundary is live
+description: >-
+  TASK_2026_420 anchors a mid-turn prompt through a user message_start
+  boundary in the live streaming state. Nothing tests a rewind or fork that
+  removes or replaces that user message while the boundary is still live.
+---
+
+Follow-up from TASK_2026_420 (code-logic review M2). See `context.md`.

--- a/libs/frontend/chat-streaming/src/lib/accumulator-core.service.ts
+++ b/libs/frontend/chat-streaming/src/lib/accumulator-core.service.ts
@@ -37,6 +37,7 @@ import { Injectable, inject } from '@angular/core';
 import {
   ExecutionNode,
   FlatStreamEventUnion,
+  MessageStartEvent,
   assertNever,
 } from '@ptah-extension/shared';
 import {
@@ -614,6 +615,53 @@ export class StreamingAccumulatorCore {
   clearPendingClears(): void {
     this.pendingTextClear.clear();
     this.pendingThinkingClear.clear();
+  }
+
+  /**
+   * Store a user `message_start` that marks where a prompt sent mid-turn sits
+   * among the root messages, so `ExecutionTreeBuilderService.buildTree` stops
+   * merging assistant messages at it.
+   *
+   * Deliberately NOT routed through `process`: a boundary is not an SDK event.
+   * It must not move `currentMessageId` (finalization reads the in-flight
+   * message's `message_complete` through it) and must not enter the dedup
+   * sets, which only track messages the backend actually sent.
+   */
+  recordUserPromptBoundary(
+    state: StreamingState,
+    event: MessageStartEvent,
+  ): void {
+    if (state.eventsByMessage.has(event.messageId)) return;
+    state.messageEventIds.push(event.messageId);
+    setStreamingEventCapped(state, event);
+    this.indexEventByMessage(state, event);
+  }
+
+  /**
+   * Remove a boundary {@link recordUserPromptBoundary} stored, returning
+   * whether one was there. Only the boundary's own shape is removed — a user
+   * `message_start` whose event id IS its messageId — so an SDK message that
+   * happens to share the id is never touched.
+   *
+   * Bumps the structural revision: a root leaving `messageEventIds` changes the
+   * merge, and the tree builder's index memo keys on that counter.
+   */
+  removeUserPromptBoundary(state: StreamingState, messageId: string): boolean {
+    const boundary = state.events.get(messageId);
+    if (
+      boundary?.eventType !== 'message_start' ||
+      boundary.messageId !== messageId ||
+      boundary.role !== 'user'
+    ) {
+      return false;
+    }
+    state.events.delete(messageId);
+    state.eventsByMessage.delete(messageId);
+    state.messageRevisions?.delete(messageId);
+    const rootIndex = state.messageEventIds.indexOf(messageId);
+    if (rootIndex !== -1) state.messageEventIds.splice(rootIndex, 1);
+    markStructuralChange(state);
+    return true;
   }
 
   /**

--- a/libs/frontend/chat-streaming/src/lib/execution-tree-builder.service.spec.ts
+++ b/libs/frontend/chat-streaming/src/lib/execution-tree-builder.service.spec.ts
@@ -248,6 +248,8 @@ describe('ExecutionTreeBuilderService — incremental rebuild', () => {
   });
 
   it('rebuilds ONLY the message that received deltas — 1 000 of them', () => {
+    feed(messageStart('msg-first', 'assistant'));
+    feed(textDelta('msg-first', 0, 'earlier answer'));
     feed(messageStart('msg-user', 'user'));
     feed(textDelta('msg-user', 0, 'question'));
     feed(messageStart('msg-assistant', 'assistant'));
@@ -263,10 +265,97 @@ describe('ExecutionTreeBuilderService — incremental rebuild', () => {
     const after = builder.buildTree(state, 'k');
 
     expect(spy.mock.calls.map((call) => call[0])).toEqual(['msg-assistant']);
-    // The untouched user message keeps its exact node object, so OnPush skips it.
+    // The untouched earlier answer keeps its exact node object, so OnPush skips it.
     expect(after[0]).toBe(before[0]);
     expect(after[1]).not.toBe(before[1]);
     expect(after[1].children[0].content).toHaveLength(1001);
+  });
+
+  it('splits the merged assistant root at a mid-turn prompt boundary', () => {
+    feed(messageStart('msg-a1', 'assistant'));
+    feed(textDelta('msg-a1', 0, 'before'));
+    feed(messageStart('msg-a2', 'assistant'));
+    feed(textDelta('msg-a2', 0, 'still before'));
+    expect(builder.buildTree(state, 'k')).toHaveLength(1);
+
+    accumulator.recordUserPromptBoundary(state, {
+      ...messageStart('user-bubble', 'user'),
+      id: 'user-bubble',
+    });
+    expect(state.currentMessageId).toBe('msg-a2');
+
+    feed(messageStart('msg-a3', 'assistant'));
+    feed(textDelta('msg-a3', 0, 'after'));
+    const tree = builder.buildTree(state, 'k');
+
+    // The boundary ends the merge but is not itself a root: the prompt renders
+    // from `messages`, never as a (mislabelled) assistant bubble.
+    expect(tree.map((node) => node.id)).toEqual([
+      'evt-start-msg-a1',
+      'evt-start-msg-a3',
+    ]);
+    expect(tree[0].children.map((c) => c.content)).toEqual([
+      'before',
+      'still before',
+    ]);
+    expect(tree[1].children.map((c) => c.content)).toEqual(['after']);
+  });
+
+  it('splits once when the SDK echo of the prompt joins the boundary', () => {
+    feed(messageStart('msg-a1', 'assistant'));
+    feed(textDelta('msg-a1', 0, 'before'));
+    accumulator.recordUserPromptBoundary(state, {
+      ...messageStart('user-bubble', 'user'),
+      id: 'user-bubble',
+    });
+    // The SDK replays the prompt under its OWN uuid, with its text.
+    feed(messageStart('sdk-user-uuid', 'user'));
+    feed(textDelta('sdk-user-uuid', 0, 'follow-up'));
+    feed(messageStart('msg-a2', 'assistant'));
+    feed(textDelta('msg-a2', 0, 'after'));
+
+    const tree = builder.buildTree(state, 'k');
+
+    expect(tree.map((node) => node.id)).toEqual([
+      'evt-start-msg-a1',
+      'evt-start-msg-a2',
+    ]);
+    expect(tree[0].children.map((c) => c.content)).toEqual(['before']);
+    expect(tree[1].children.map((c) => c.content)).toEqual(['after']);
+  });
+
+  it('merges the turn back together once the boundary is removed', () => {
+    feed(messageStart('msg-a1', 'assistant'));
+    feed(textDelta('msg-a1', 0, 'before'));
+    accumulator.recordUserPromptBoundary(state, {
+      ...messageStart('user-bubble', 'user'),
+      id: 'user-bubble',
+    });
+    feed(messageStart('msg-a2', 'assistant'));
+    feed(textDelta('msg-a2', 0, 'after'));
+    expect(builder.buildTree(state, 'k')).toHaveLength(2);
+    const revision = state.structuralRevision;
+
+    expect(accumulator.removeUserPromptBoundary(state, 'user-bubble')).toBe(
+      true,
+    );
+
+    expect(state.structuralRevision).toBe((revision ?? 0) + 1);
+    expect(state.messageEventIds).not.toContain('user-bubble');
+    expect(state.events.has('user-bubble')).toBe(false);
+    expect(state.eventsByMessage.has('user-bubble')).toBe(false);
+    const tree = builder.buildTree(state, 'k');
+    expect(tree).toHaveLength(1);
+    expect(tree[0].children.map((c) => c.content)).toEqual(['before', 'after']);
+  });
+
+  it('never removes an SDK message through removeUserPromptBoundary', () => {
+    feed(messageStart('sdk-user-uuid', 'user'));
+
+    expect(accumulator.removeUserPromptBoundary(state, 'sdk-user-uuid')).toBe(
+      false,
+    );
+    expect(state.messageEventIds).toContain('sdk-user-uuid');
   });
 
   it('keeps completed tool nodes identical while sibling text streams', () => {
@@ -415,11 +504,13 @@ describe('ExecutionTreeBuilderService — incremental rebuild', () => {
       .spyOn(console, 'warn')
       .mockImplementation(() => undefined);
     try {
-      // Enough messages to push the maps past the prune floor.
+      // Enough messages to push the maps past the prune floor. Each answer is
+      // followed by a user turn so it stays its own root instead of merging.
       for (let i = 0; i < 400; i++) {
         const messageId = `msg-${i}`;
-        feed(messageStart(messageId, 'user'));
-        feed(textDelta(messageId, 0, `q${i}`));
+        feed(messageStart(messageId, 'assistant'));
+        feed(textDelta(messageId, 0, `a${i}`));
+        feed(messageStart(`user-${i}`, 'user'));
       }
       builder.buildTree(state, 'k');
       const pruned = builder.buildTree(state, 'k');
@@ -831,12 +922,13 @@ describe('ExecutionTreeBuilderService — incremental rebuild', () => {
       feed(textDelta('msg-live', 0, 'and now'));
       const resumed = expectEquivalent();
 
-      // Two roots, not three: the live assistant message merges into the
-      // replayed assistant turn, which is the same merge the live path does.
-      expect(resumed).toHaveLength(2);
+      // One root: the replayed user prompt is not tree output, and the live
+      // assistant message merges into the replayed assistant turn, which is
+      // the same merge the live path does.
+      expect(resumed).toHaveLength(1);
       expect(countByType(resumed, 'tool')).toBe(1);
       expect(findByType(resumed, 'tool')?.status).toBe('complete');
-      expect(resumed[1].children.map((c) => c.content)).toContain('and now');
+      expect(resumed[0].children.map((c) => c.content)).toContain('and now');
     });
 
     it('agrees with a full rebuild when a resumed tab swaps in a fresh StreamingState under the same cache key', () => {

--- a/libs/frontend/chat-streaming/src/lib/execution-tree-builder.service.ts
+++ b/libs/frontend/chat-streaming/src/lib/execution-tree-builder.service.ts
@@ -241,7 +241,8 @@ export class ExecutionTreeBuilderService {
    * 3. Return the previous tree untouched when nothing moved
    * 4. Rebuild ONLY the root messages whose digest moved; reuse the rest
    * 5. Merge consecutive assistant messages into a single root node
-   *    (SDK sends multiple assistant messages per turn)
+   *    (SDK sends multiple assistant messages per turn). A user root ends the
+   *    merge and is not emitted — the tree holds assistant output only
    * 6. Stabilise object identity inside rebuilt subtrees via cheap fingerprints
    *
    * @param streamingState - Flat event storage
@@ -335,6 +336,16 @@ export class ExecutionTreeBuilderService {
     let lastAssistantNode: ExecutionNode | null = null;
 
     for (const messageId of rootOrder) {
+      const role = startByRoot.get(messageId)?.role;
+      // A user root — a mid-turn prompt boundary, or the SDK's echo of a
+      // prompt — ends the assistant merge but is never a node. The prompt
+      // renders from `messages`, and every consumer of this tree turns a root
+      // into an ASSISTANT bubble.
+      if (role === 'user') {
+        lastAssistantNode = null;
+        continue;
+      }
+
       const reusable =
         cached && epochUnchanged
           ? this.reusableRootNode(cached, digestByRoot, messageId)
@@ -346,7 +357,7 @@ export class ExecutionTreeBuilderService {
       nodeByRoot.set(messageId, messageNode);
       if (reusable) reusedRoots.add(reusable);
 
-      const isAssistant = startByRoot.get(messageId)?.role === 'assistant';
+      const isAssistant = role === 'assistant';
 
       if (isAssistant && lastAssistantNode) {
         if (messageNode.children && messageNode.children.length > 0) {

--- a/libs/frontend/chat-streaming/src/lib/message-finalization.service.spec.ts
+++ b/libs/frontend/chat-streaming/src/lib/message-finalization.service.spec.ts
@@ -76,6 +76,48 @@ function makeNode(overrides: Partial<ExecutionNode> = {}): ExecutionNode {
   } as ExecutionNode;
 }
 
+/** A root `message_start`; `id` is the tree node id a root message builds. */
+type RootStart = { id: string; messageId: string; role: 'user' | 'assistant' };
+
+/** An SDK assistant message; its tree node id is `start-${messageId}`. */
+const assistantRoot = (messageId: string): RootStart => ({
+  id: `start-${messageId}`,
+  messageId,
+  role: 'assistant',
+});
+
+/** `recordUserPromptBoundary`'s shape: event id = messageId = bubble id. */
+const promptBoundary = (bubbleId: string): RootStart => ({
+  id: bubbleId,
+  messageId: bubbleId,
+  role: 'user',
+});
+
+/** The SDK's replay of the prompt, under the SDK's own uuid. */
+const sdkUserEcho = (uuid: string): RootStart => ({
+  id: `start-${uuid}`,
+  messageId: uuid,
+  role: 'user',
+});
+
+/** A state whose root messages are `roots`, in order. */
+function makeRootsState(
+  roots: readonly RootStart[],
+  overrides: Partial<StreamingState> = {},
+): StreamingState {
+  const eventsByMessage = new Map(
+    roots.map((root, index) => [
+      root.messageId,
+      [{ ...root, eventType: 'message_start', timestamp: index } as never],
+    ]),
+  );
+  return makeStreamingState({
+    eventsByMessage,
+    messageEventIds: roots.map((root) => root.messageId),
+    ...overrides,
+  });
+}
+
 describe('MessageFinalizationService', () => {
   let service: MessageFinalizationService;
   let tabsSignal: ReturnType<typeof signal<TabState[]>>;
@@ -282,6 +324,363 @@ describe('MessageFinalizationService', () => {
       expect(msgs[0].cost).toBe(0.12);
 
       expect(sessionManager.setStatus).toHaveBeenCalledWith('loaded');
+    });
+
+    /**
+     * Finalized ids for the turn — the anchors only exist in the state's root
+     * messages, since user roots are not tree output.
+     */
+    const finalizedIds = (): string[] => {
+      const [, msgs] = tabManager.applyFinalizedTurn.mock.calls[0] as [
+        string,
+        ExecutionChatMessage[],
+      ];
+      return msgs.map((m) => m.id);
+    };
+
+    it('keeps the part of a turn that ran before a mid-turn prompt above it', () => {
+      const prompt = {
+        id: 'user-mid-turn',
+        role: 'user',
+        rawContent: 'follow-up',
+      } as ExecutionChatMessage;
+      treeBuilder.buildTree.mockReturnValue([
+        makeNode({ id: 'start-msg-before', type: 'message' }),
+        makeNode({ id: 'start-msg-after', type: 'message' }),
+      ]);
+      tabsSignal.set([
+        makeTab({
+          id: 'tab-1',
+          messages: [prompt],
+          streamingState: makeRootsState(
+            [
+              assistantRoot('msg-before'),
+              promptBoundary('user-mid-turn'),
+              assistantRoot('msg-after'),
+            ],
+            {
+              currentMessageId: 'msg-after',
+              pendingStats: {
+                tokens: { input: 1, output: 2 },
+                cost: 0.01,
+                duration: 10,
+              },
+            },
+          ),
+        }),
+      ]);
+      activeTabIdSignal.set('tab-1');
+
+      service.finalizeCurrentMessage();
+
+      const [, msgs] = tabManager.applyFinalizedTurn.mock.calls[0] as [
+        string,
+        ExecutionChatMessage[],
+      ];
+      expect(msgs.map((m) => m.id)).toEqual([
+        'start-msg-before',
+        'user-mid-turn',
+        'start-msg-after',
+      ]);
+      expect(msgs[1]).toBe(prompt);
+      expect(msgs[0].tokens).toBeUndefined();
+      expect(msgs[2].tokens).toEqual({ input: 1, output: 2 });
+    });
+
+    it('places the turn once around a prompt the boundary AND the SDK echo both mark', () => {
+      // The boundary anchors by the bubble's id. The echo root carries the
+      // SDK's own uuid — stamped onto the bubble as `nativeUuid` — and is
+      // skipped: it is neither an anchor nor a second copy of the prompt.
+      const prompt = {
+        id: 'user-bubble',
+        role: 'user',
+        nativeUuid: 'sdk-user-uuid',
+      } as ExecutionChatMessage;
+      treeBuilder.buildTree.mockReturnValue([
+        makeNode({ id: 'start-msg-before', type: 'message' }),
+        makeNode({ id: 'start-msg-after', type: 'message' }),
+      ]);
+      tabsSignal.set([
+        makeTab({
+          id: 'tab-1',
+          messages: [prompt],
+          streamingState: makeRootsState(
+            [
+              assistantRoot('msg-before'),
+              promptBoundary('user-bubble'),
+              sdkUserEcho('sdk-user-uuid'),
+              assistantRoot('msg-after'),
+            ],
+            { currentMessageId: 'msg-after' },
+          ),
+        }),
+      ]);
+      activeTabIdSignal.set('tab-1');
+
+      service.finalizeCurrentMessage();
+
+      expect(finalizedIds()).toEqual([
+        'start-msg-before',
+        'user-bubble',
+        'start-msg-after',
+      ]);
+    });
+
+    it('never anchors on the SDK echo through a stamped nativeUuid', () => {
+      // No boundary: the echo root matches the bubble only by `nativeUuid`,
+      // which is not an anchor, so the turn is the plain append.
+      const earlier = {
+        id: 'earlier',
+        role: 'assistant',
+      } as ExecutionChatMessage;
+      const prompt = {
+        id: 'user-bubble',
+        role: 'user',
+        nativeUuid: 'sdk-user-uuid',
+      } as ExecutionChatMessage;
+      treeBuilder.buildTree.mockReturnValue([
+        makeNode({ id: 'start-msg-before', type: 'message' }),
+        makeNode({ id: 'start-msg-after', type: 'message' }),
+      ]);
+      tabsSignal.set([
+        makeTab({
+          id: 'tab-1',
+          messages: [earlier, prompt],
+          streamingState: makeRootsState(
+            [
+              assistantRoot('msg-before'),
+              sdkUserEcho('sdk-user-uuid'),
+              assistantRoot('msg-after'),
+            ],
+            { currentMessageId: 'msg-after' },
+          ),
+        }),
+      ]);
+      activeTabIdSignal.set('tab-1');
+
+      service.finalizeCurrentMessage();
+
+      expect(finalizedIds()).toEqual([
+        'earlier',
+        'user-bubble',
+        'start-msg-before',
+        'start-msg-after',
+      ]);
+    });
+
+    it('appends the reply after its own prompt when the echo uuid was stamped on an older failed bubble (R1)', () => {
+      // A failed direct send keeps its bubble and appends a failure notice.
+      // The retry's SDK echo is then stamped onto the OLDEST unstamped bubble —
+      // the failed one — by `reconcileUserMessageNativeUuid`.
+      const earlier = {
+        id: 'earlier',
+        role: 'assistant',
+      } as ExecutionChatMessage;
+      const failedPrompt = {
+        id: 'msg_1_failed',
+        role: 'user',
+        nativeUuid: 'sdk-user-uuid',
+      } as ExecutionChatMessage;
+      const failureNotice = {
+        id: 'notice',
+        role: 'assistant',
+      } as ExecutionChatMessage;
+      const retryPrompt = {
+        id: 'msg_2_retry',
+        role: 'user',
+      } as ExecutionChatMessage;
+      treeBuilder.buildTree.mockReturnValue([
+        makeNode({ id: 'start-msg-reply', type: 'message' }),
+      ]);
+      tabsSignal.set([
+        makeTab({
+          id: 'tab-1',
+          messages: [earlier, failedPrompt, failureNotice, retryPrompt],
+          streamingState: makeRootsState(
+            [sdkUserEcho('sdk-user-uuid'), assistantRoot('msg-reply')],
+            {
+              currentMessageId: 'msg-reply',
+              pendingStats: {
+                tokens: { input: 5, output: 8 },
+                cost: 0.04,
+                duration: 40,
+              },
+            },
+          ),
+        }),
+      ]);
+      activeTabIdSignal.set('tab-1');
+
+      service.finalizeCurrentMessage();
+
+      const [, msgs] = tabManager.applyFinalizedTurn.mock.calls[0] as [
+        string,
+        ExecutionChatMessage[],
+      ];
+      expect(msgs.map((m) => m.id)).toEqual([
+        'earlier',
+        'msg_1_failed',
+        'notice',
+        'msg_2_retry',
+        'start-msg-reply',
+      ]);
+      expect(msgs[4].tokens).toEqual({ input: 5, output: 8 });
+    });
+
+    it('splits one turn around two prompts sent mid-turn, in root order', () => {
+      const msg0 = { id: 'msg0', role: 'assistant' } as ExecutionChatMessage;
+      const promptA = { id: 'prompt-a', role: 'user' } as ExecutionChatMessage;
+      const promptB = { id: 'prompt-b', role: 'user' } as ExecutionChatMessage;
+      treeBuilder.buildTree.mockReturnValue([
+        makeNode({ id: 'start-msg-before', type: 'message' }),
+        makeNode({ id: 'start-msg-mid', type: 'message' }),
+        makeNode({ id: 'start-msg-after', type: 'message' }),
+      ]);
+      tabsSignal.set([
+        makeTab({
+          id: 'tab-1',
+          messages: [msg0, promptA, promptB],
+          streamingState: makeRootsState(
+            [
+              assistantRoot('msg-before'),
+              promptBoundary('prompt-a'),
+              assistantRoot('msg-mid'),
+              promptBoundary('prompt-b'),
+              assistantRoot('msg-after'),
+            ],
+            {
+              currentMessageId: 'msg-after',
+              pendingStats: {
+                tokens: { input: 6, output: 9 },
+                cost: 0.05,
+                duration: 50,
+              },
+            },
+          ),
+        }),
+      ]);
+      activeTabIdSignal.set('tab-1');
+
+      service.finalizeCurrentMessage();
+
+      const [, msgs] = tabManager.applyFinalizedTurn.mock.calls[0] as [
+        string,
+        ExecutionChatMessage[],
+      ];
+      expect(msgs.map((m) => m.id)).toEqual([
+        'msg0',
+        'start-msg-before',
+        'prompt-a',
+        'start-msg-mid',
+        'prompt-b',
+        'start-msg-after',
+      ]);
+      expect(msgs[1].tokens).toBeUndefined();
+      expect(msgs[3].tokens).toBeUndefined();
+      expect(msgs[5].tokens).toEqual({ input: 6, output: 9 });
+    });
+
+    it('gives a message merged into an earlier node no slot of its own', () => {
+      const prompt = {
+        id: 'user-bubble',
+        role: 'user',
+      } as ExecutionChatMessage;
+      // `msg-a2` merged into `msg-a1`'s node, so the tree has no node for it.
+      treeBuilder.buildTree.mockReturnValue([
+        makeNode({ id: 'start-msg-a1', type: 'message' }),
+        makeNode({ id: 'start-msg-a3', type: 'message' }),
+      ]);
+      tabsSignal.set([
+        makeTab({
+          id: 'tab-1',
+          messages: [prompt],
+          streamingState: makeRootsState(
+            [
+              assistantRoot('msg-a1'),
+              assistantRoot('msg-a2'),
+              promptBoundary('user-bubble'),
+              assistantRoot('msg-a3'),
+            ],
+            { currentMessageId: 'msg-a3' },
+          ),
+        }),
+      ]);
+      activeTabIdSignal.set('tab-1');
+
+      service.finalizeCurrentMessage();
+
+      expect(finalizedIds()).toEqual([
+        'start-msg-a1',
+        'user-bubble',
+        'start-msg-a3',
+      ]);
+    });
+
+    it('puts the stats on the last new message when the turn ends on the prompt', () => {
+      const prompt = { id: 'user-last', role: 'user' } as ExecutionChatMessage;
+      treeBuilder.buildTree.mockReturnValue([
+        makeNode({ id: 'start-msg-answer', type: 'message' }),
+      ]);
+      tabsSignal.set([
+        makeTab({
+          id: 'tab-1',
+          messages: [prompt],
+          streamingState: makeRootsState(
+            [assistantRoot('msg-answer'), promptBoundary('user-last')],
+            {
+              currentMessageId: 'msg-answer',
+              pendingStats: {
+                tokens: { input: 4, output: 6 },
+                cost: 0.02,
+                duration: 20,
+              },
+            },
+          ),
+        }),
+      ]);
+      activeTabIdSignal.set('tab-1');
+
+      service.finalizeCurrentMessage();
+
+      const [, msgs] = tabManager.applyFinalizedTurn.mock.calls[0] as [
+        string,
+        ExecutionChatMessage[],
+      ];
+      expect(msgs.map((m) => m.id)).toEqual(['start-msg-answer', 'user-last']);
+      expect(msgs[0].tokens).toEqual({ input: 4, output: 6 });
+    });
+
+    it('settles a tree holding only a prompt boundary like an empty tree', () => {
+      // The prompt is the last message, so the empty-tree stats fold (last
+      // message must be an assistant) never applied here either: no message
+      // is minted and the streaming state is cleared.
+      const answer = {
+        id: 'answer',
+        role: 'assistant',
+      } as ExecutionChatMessage;
+      const prompt = { id: 'user-bg', role: 'user' } as ExecutionChatMessage;
+      // A user root is not tree output, so a boundary-only state builds [].
+      treeBuilder.buildTree.mockReturnValue([]);
+      tabsSignal.set([
+        makeTab({
+          id: 'tab-1',
+          messages: [answer, prompt],
+          streamingState: makeRootsState([promptBoundary('user-bg')], {
+            currentMessageId: 'msg-subagent',
+            pendingStats: {
+              tokens: { input: 7, output: 9 },
+              cost: 0.03,
+              duration: 30,
+            },
+          }),
+        }),
+      ]);
+      activeTabIdSignal.set('tab-1');
+
+      service.finalizeCurrentMessage();
+
+      expect(tabManager.applyFinalizedTurn).not.toHaveBeenCalled();
+      expect(tabManager.clearStreamingForLoaded).toHaveBeenCalledWith('tab-1');
     });
 
     it('does not mint an empty assistant message when the tree has no root', () => {

--- a/libs/frontend/chat-streaming/src/lib/message-finalization.service.ts
+++ b/libs/frontend/chat-streaming/src/lib/message-finalization.service.ts
@@ -20,11 +20,77 @@ import {
   SubagentRecord,
 } from '@ptah-extension/shared';
 import { TabManagerService } from '@ptah-extension/chat-state';
+import { findMessageStartEvent } from '@ptah-extension/chat-execution-tree';
 import { SessionManager } from './session-manager.service';
 import { ExecutionTreeBuilderService } from './execution-tree-builder.service';
 import { BatchedUpdateService } from './batched-update.service';
 import { capFinalizedTree } from './execution-tree-retention';
 import type { StreamingState } from '@ptah-extension/chat-types';
+
+/**
+ * Splice a turn's new messages into the transcript in ROOT order.
+ *
+ * The order is read from the state's root messages, not from the tree: user
+ * roots are not tree output (`ExecutionTreeBuilderService.buildTree`). A user
+ * root whose messageId is an existing user message's `id` is an anchor — the
+ * boundary `StreamingHandlerService.recordUserPromptBoundary` records for a
+ * prompt sent while the turn was streaming. Any other user root, such as the
+ * SDK's echo of a prompt, is skipped. An assistant root places the message
+ * minted from its node; a message merged into an earlier node has none.
+ *
+ * The echo never anchors through `nativeUuid`:
+ * `TabManagerService.reconcileUserMessageNativeUuid` stamps the OLDEST
+ * unstamped bubble, so after a failed send the uuid lands on the failed bubble
+ * and the reply would be placed above its own prompt. With a boundary the id
+ * already anchors; without one the plain append is right.
+ *
+ * Appending every new message after the existing ones moved the part of the
+ * turn that ran BEFORE the prompt below it the moment the turn settled.
+ * Without an anchor this is the plain append. Existing assistant ids are not
+ * anchors: a reused state can still hold an earlier turn's root, and anchoring
+ * on it would pull a later idle-sent prompt below this turn.
+ */
+function placeFinalizedTrees(
+  existing: readonly ExecutionChatMessage[],
+  state: StreamingState,
+  newMessages: readonly ExecutionChatMessage[],
+): ExecutionChatMessage[] {
+  const promptById = new Map(
+    existing.filter((m) => m.role === 'user').map((m) => [m.id, m]),
+  );
+  const messageById = new Map(existing.map((m) => [m.id, m]));
+  for (const message of newMessages) messageById.set(message.id, message);
+
+  const rootOrder: ExecutionChatMessage[] = [];
+  let firstAnchor: ExecutionChatMessage | undefined;
+  for (const messageId of state.messageEventIds) {
+    const start = findMessageStartEvent(state, messageId);
+    if (!start || start.parentToolUseId) continue;
+    const isPrompt = start.role === 'user';
+    const message = isPrompt
+      ? promptById.get(messageId)
+      : messageById.get(start.id);
+    if (!message) continue;
+    if (isPrompt) firstAnchor ??= message;
+    rootOrder.push(message);
+  }
+  if (!firstAnchor) return [...existing, ...newMessages];
+
+  const anchorIndex = existing.indexOf(firstAnchor);
+  const placed = existing.slice(0, anchorIndex);
+  const placedIds = new Set(placed.map((m) => m.id));
+  // A new message whose node matched no root still belongs to this turn;
+  // appending it is better than losing it.
+  for (const message of [...rootOrder, ...newMessages]) {
+    if (placedIds.has(message.id)) continue;
+    placed.push(message);
+    placedIds.add(message.id);
+  }
+  for (const message of existing.slice(anchorIndex)) {
+    if (!placedIds.has(message.id)) placed.push(message);
+  }
+  return placed;
+}
 
 @Injectable({ providedIn: 'root' })
 export class MessageFinalizationService {
@@ -142,7 +208,12 @@ export class MessageFinalizationService {
       this.tabManager.clearStreamingForLoaded(targetTabId);
       return;
     } else {
-      const lastIdx = finalTree.length - 1;
+      // The turn's stats belong on its last NEW message. The last root can be
+      // an already-finalized message from a reused state, which is skipped.
+      let lastIdx = finalTree.length - 1;
+      while (lastIdx >= 0 && existingIds.has(finalTree[lastIdx].id)) {
+        lastIdx--;
+      }
       for (let i = 0; i < finalTree.length; i++) {
         const tree = finalTree[i];
         if (existingIds.has(tree.id)) {
@@ -171,10 +242,10 @@ export class MessageFinalizationService {
       this.tabManager.clearStreamingForLoaded(targetTabId);
       return;
     }
-    this.tabManager.applyFinalizedTurn(targetTabId, [
-      ...existingMessages,
-      ...newMessages,
-    ]);
+    this.tabManager.applyFinalizedTurn(
+      targetTabId,
+      placeFinalizedTrees(existingMessages, stateCopy, newMessages),
+    );
     // The turn is committed, so the builder's memo for this tab now holds only
     // the PRE-CAP nodes — the uncapped payloads this pass just bounded, kept
     // alive by the identity maps. The next turn starts a fresh `streamingState`

--- a/libs/frontend/chat-streaming/src/lib/streaming-handler.service.spec.ts
+++ b/libs/frontend/chat-streaming/src/lib/streaming-handler.service.spec.ts
@@ -283,6 +283,10 @@ describe('StreamingHandlerService', () => {
       markTabStreaming: jest.fn(),
       isTabStreaming: jest.fn().mockReturnValue(false),
       findTabBySessionIdAcrossWorkspaces: jest.fn(() => null),
+      findTabByIdAcrossWorkspaces: jest.fn((tabId: string) => {
+        const tab = tabsSignal().find((t) => t.id === tabId);
+        return tab ? { tab, workspacePath: 'D:/repo' } : null;
+      }),
       updateBackgroundTab: jest.fn(() => false),
     } as unknown as jest.Mocked<
       Pick<
@@ -523,6 +527,108 @@ describe('StreamingHandlerService', () => {
         tabId: TAB_ID,
         queuedContent: 'follow up question',
       });
+    });
+  });
+
+  describe('recordUserPromptBoundary', () => {
+    const prompt = {
+      id: 'msg_prompt',
+      role: 'user',
+      timestamp: 50,
+    } as ExecutionChatMessage;
+
+    it('adds a user root to the live tree of an active tab', () => {
+      service.processStreamEvent(msgStart(), TAB_ID);
+      batchedUpdate.scheduleUpdate.mockClear();
+
+      service.recordUserPromptBoundary(TAB_ID, prompt);
+
+      const state = currentState();
+      expect(state.messageEventIds).toContain('msg_prompt');
+      expect(state.currentMessageId).toBe(MESSAGE_ID);
+      expect(batchedUpdate.scheduleUpdate).toHaveBeenCalledWith(TAB_ID, state);
+    });
+
+    it('writes a background-workspace tab through its partition', () => {
+      service.processStreamEvent(msgStart(), TAB_ID);
+      const backgroundTab = tabsSignal()[0];
+      tabsSignal.set([]);
+      (
+        tabManager as unknown as { findTabByIdAcrossWorkspaces: jest.Mock }
+      ).findTabByIdAcrossWorkspaces.mockReturnValue({
+        tab: backgroundTab,
+        workspacePath: 'D:/other',
+      });
+      batchedUpdate.scheduleUpdate.mockClear();
+
+      service.recordUserPromptBoundary(TAB_ID, prompt);
+
+      const update = (
+        tabManager as unknown as { updateBackgroundTab: jest.Mock }
+      ).updateBackgroundTab;
+      expect(update).toHaveBeenCalledWith(TAB_ID, {
+        streamingState: expect.objectContaining({
+          messageEventIds: expect.arrayContaining(['msg_prompt']),
+        }),
+      });
+      expect(batchedUpdate.scheduleUpdate).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the tab has no live tree', () => {
+      service.recordUserPromptBoundary(TAB_ID, prompt);
+
+      // `makeTab` holds an empty state: no `message_start`, so no live turn.
+      expect(currentState().messageEventIds).toEqual([]);
+      expect(batchedUpdate.scheduleUpdate).not.toHaveBeenCalled();
+    });
+
+    it('removes the boundary of a prompt that was never delivered', () => {
+      service.processStreamEvent(msgStart(), TAB_ID);
+      service.recordUserPromptBoundary(TAB_ID, prompt);
+      batchedUpdate.scheduleUpdate.mockClear();
+
+      service.removeUserPromptBoundary(TAB_ID, 'msg_prompt');
+
+      const state = currentState();
+      expect(state.messageEventIds).toEqual([MESSAGE_ID]);
+      expect(state.eventsByMessage.has('msg_prompt')).toBe(false);
+      expect(batchedUpdate.scheduleUpdate).toHaveBeenCalledWith(TAB_ID, state);
+    });
+
+    it('removes a background-workspace boundary through its partition', () => {
+      service.processStreamEvent(msgStart(), TAB_ID);
+      service.recordUserPromptBoundary(TAB_ID, prompt);
+      const backgroundTab = tabsSignal()[0];
+      tabsSignal.set([]);
+      (
+        tabManager as unknown as { findTabByIdAcrossWorkspaces: jest.Mock }
+      ).findTabByIdAcrossWorkspaces.mockReturnValue({
+        tab: backgroundTab,
+        workspacePath: 'D:/other',
+      });
+      batchedUpdate.scheduleUpdate.mockClear();
+
+      service.removeUserPromptBoundary(TAB_ID, 'msg_prompt');
+
+      const update = (
+        tabManager as unknown as { updateBackgroundTab: jest.Mock }
+      ).updateBackgroundTab;
+      expect(update).toHaveBeenCalledWith(TAB_ID, {
+        streamingState: expect.objectContaining({
+          messageEventIds: [MESSAGE_ID],
+        }),
+      });
+      expect(batchedUpdate.scheduleUpdate).not.toHaveBeenCalled();
+    });
+
+    it('publishes nothing when there is no boundary to remove', () => {
+      service.processStreamEvent(msgStart(), TAB_ID);
+      batchedUpdate.scheduleUpdate.mockClear();
+
+      service.removeUserPromptBoundary(TAB_ID, 'msg_prompt');
+
+      expect(currentState().messageEventIds).toEqual([MESSAGE_ID]);
+      expect(batchedUpdate.scheduleUpdate).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts
+++ b/libs/frontend/chat-streaming/src/lib/streaming-handler.service.ts
@@ -97,6 +97,72 @@ export class StreamingHandlerService {
   }
 
   /**
+   * Split the live bubble at a user prompt sent while a turn is streaming.
+   *
+   * `buildTree` merges consecutive root assistant messages into one bubble,
+   * and only a user `message_start` stops the merge. The optimistic user
+   * bubble lands in `messages` at once, but the SDK echoes its own user
+   * `message_start` only when it consumes the prompt at turn end — so every
+   * later assistant message of the running turn merged into the bubble ABOVE
+   * the prompt until the turn settled.
+   *
+   * A user root is never tree output, so the boundary renders nothing of its
+   * own. It carries the bubble's own id, which is how
+   * `finalizeCurrentMessage` places the settled turn around the prompt. A tab
+   * with no live tree needs no boundary: the next turn starts its own state.
+   *
+   * Known limit: a `compaction_complete` replacement state and the
+   * `STREAMING_EVENT_CAP` eviction can both drop the boundary. The turn then
+   * renders and finalizes as it did before the boundary existed.
+   */
+  recordUserPromptBoundary(tabId: string, message: ExecutionChatMessage): void {
+    const state = this.findTabStreamingState(tabId);
+    if (!state || state.currentMessageId == null) return;
+    this.accumulatorCore.recordUserPromptBoundary(state, {
+      id: message.id,
+      eventType: 'message_start',
+      timestamp: message.timestamp,
+      source: 'complete',
+      messageId: message.id,
+      role: 'user',
+    });
+    this.publishBoundaryChange(tabId, state);
+  }
+
+  /**
+   * Undo {@link recordUserPromptBoundary} for a prompt that never reached the
+   * backend (`chat:continue` rejected or threw). Left in place, the live turn
+   * stays split — and later settles — around a prompt the agent never saw.
+   */
+  removeUserPromptBoundary(tabId: string, messageId: string): void {
+    const state = this.findTabStreamingState(tabId);
+    if (!state) return;
+    if (!this.accumulatorCore.removeUserPromptBoundary(state, messageId)) {
+      return;
+    }
+    this.publishBoundaryChange(tabId, state);
+  }
+
+  /** Workspace-aware, like the send path that appended the bubble. */
+  private findTabStreamingState(tabId: string): StreamingState | null {
+    return (
+      this.tabManager.findTabByIdAcrossWorkspaces(tabId)?.tab.streamingState ??
+      null
+    );
+  }
+
+  /** Active tab → the batched frame; background tab → its partition. */
+  private publishBoundaryChange(tabId: string, state: StreamingState): void {
+    if (this.tabManager.tabs().some((t) => t.id === tabId)) {
+      this.batchedUpdate.scheduleUpdate(tabId, state);
+    } else {
+      this.tabManager.updateBackgroundTab(tabId, {
+        streamingState: { ...state },
+      });
+    }
+  }
+
+  /**
    * Process flat streaming event from SDK
    *
    * Stores events in flat Maps instead of building ExecutionNode trees.

--- a/libs/frontend/chat/src/lib/services/message-sender.service.spec.ts
+++ b/libs/frontend/chat/src/lib/services/message-sender.service.spec.ts
@@ -34,7 +34,10 @@ import {
 import { MessageSenderService } from './message-sender.service';
 import { UltracodeStateService } from './ultracode-state.service';
 import { TabManagerService } from '@ptah-extension/chat-state';
-import { SessionManager } from '@ptah-extension/chat-streaming';
+import {
+  SessionManager,
+  StreamingHandlerService,
+} from '@ptah-extension/chat-streaming';
 import { MessageValidationService } from './message-validation.service';
 import type { TabState } from '@ptah-extension/chat-types';
 import type { ExecutionChatMessage } from '@ptah-extension/shared';
@@ -100,6 +103,8 @@ describe('MessageSenderService', () => {
     Pick<MessageValidationService, 'validate' | 'sanitize'>
   >;
   let rpcCall: jest.Mock;
+  let recordBoundary: jest.Mock;
+  let removeBoundary: jest.Mock;
   let flagAuthRequired: jest.Mock;
   let vscodeConfig: jest.Mock;
   let consoleWarn: jest.SpyInstance;
@@ -205,6 +210,8 @@ describe('MessageSenderService', () => {
     >;
 
     rpcCall = jest.fn();
+    recordBoundary = jest.fn();
+    removeBoundary = jest.fn();
     flagAuthRequired = jest.fn();
     vscodeConfig = jest.fn(() => ({ workspaceRoot: 'D:/repo' }));
 
@@ -216,6 +223,13 @@ describe('MessageSenderService', () => {
         MessageSenderService,
         { provide: TabManagerService, useValue: tabManager },
         { provide: SessionManager, useValue: sessionManager },
+        {
+          provide: StreamingHandlerService,
+          useValue: {
+            recordUserPromptBoundary: recordBoundary,
+            removeUserPromptBoundary: removeBoundary,
+          },
+        },
         { provide: MessageValidationService, useValue: validator },
         { provide: ClaudeRpcService, useValue: { call: rpcCall } },
         {
@@ -298,6 +312,181 @@ describe('MessageSenderService', () => {
       );
       expect(startCalled).toBe(false);
       expect(continueCalled).toBe(true);
+    });
+
+    it('records the continued prompt as a boundary in the live tree', async () => {
+      tabsSignal.set([makeTab({ id: 'tab-1', claudeSessionId: 'sess-X' })]);
+      rpcCall.mockImplementation(
+        (method: string): Promise<{ success: boolean; data?: unknown }> =>
+          Promise.resolve(
+            method === 'session:validate'
+              ? { success: true, data: { exists: true } }
+              : { success: true },
+          ),
+      );
+
+      await service.send('sent mid-turn');
+
+      const userMessage = tabsSignal()[0].messages.at(-1);
+      expect(userMessage?.role).toBe('user');
+      expect(recordBoundary).toHaveBeenCalledWith('tab-1', userMessage);
+    });
+
+    describe('a continue whose prompt never reaches the backend', () => {
+      /** `chat:continue` resolves to `continueResult`, or rejects with it. */
+      const failContinue = (continueResult: unknown, reject = false): void => {
+        rpcCall.mockImplementation((method: string): Promise<unknown> => {
+          if (method === 'session:validate') {
+            return Promise.resolve({ success: true, data: { exists: true } });
+          }
+          if (method === 'chat:continue') {
+            return reject
+              ? Promise.reject(continueResult)
+              : Promise.resolve(continueResult);
+          }
+          return Promise.resolve({ success: true });
+        });
+      };
+
+      /** The bubble the send recorded as a boundary. */
+      const recordedBubbleId = (): string =>
+        (recordBoundary.mock.calls[0][1] as ExecutionChatMessage).id;
+
+      beforeEach(() => {
+        tabsSignal.set([makeTab({ id: 'tab-1', claudeSessionId: 'sess-X' })]);
+      });
+
+      it('removes the boundary but keeps the bubble when chat:continue is rejected', async () => {
+        failContinue({ success: false, error: 'turn rejected' });
+
+        const outcome = await service.send('follow up', { tabId: 'tab-1' });
+
+        expect(outcome).toEqual(expect.objectContaining({ success: false }));
+        expect(removeBoundary).toHaveBeenCalledWith(
+          'tab-1',
+          recordedBubbleId(),
+        );
+        expect(tabsSignal()[0].messages.map((m) => m.id)).toEqual([
+          recordedBubbleId(),
+        ]);
+      });
+
+      it('removes the boundary but keeps the bubble when chat:continue throws', async () => {
+        failContinue(new Error('socket closed'), true);
+
+        await service.send('follow up', { tabId: 'tab-1' });
+
+        expect(removeBoundary).toHaveBeenCalledWith(
+          'tab-1',
+          recordedBubbleId(),
+        );
+        expect(tabsSignal()[0].messages.map((m) => m.id)).toEqual([
+          recordedBubbleId(),
+        ]);
+      });
+
+      it('also removes the bubble when a rejected queue flush re-queues the text', async () => {
+        failContinue({ success: true, data: { success: false, error: 'no' } });
+
+        await service.continueExistingSessionForQueueFlush('queued', 'sess-X', {
+          tabId: 'tab-1',
+        });
+
+        expect(removeBoundary).toHaveBeenCalledWith(
+          'tab-1',
+          recordedBubbleId(),
+        );
+        expect(tabsSignal()[0].messages).toEqual([]);
+      });
+
+      it('also removes the bubble when a queue flush throws', async () => {
+        failContinue(new Error('socket closed'), true);
+
+        await service.continueExistingSessionForQueueFlush('queued', 'sess-X', {
+          tabId: 'tab-1',
+        });
+
+        expect(removeBoundary).toHaveBeenCalledWith(
+          'tab-1',
+          recordedBubbleId(),
+        );
+        expect(tabsSignal()[0].messages).toEqual([]);
+      });
+
+      it('rolls nothing back when the continue is delivered', async () => {
+        failContinue({ success: true });
+
+        await service.continueExistingSessionForQueueFlush('queued', 'sess-X', {
+          tabId: 'tab-1',
+        });
+
+        expect(removeBoundary).not.toHaveBeenCalled();
+        expect(tabsSignal()[0].messages).toHaveLength(1);
+      });
+
+      it('drops the undelivered prompt from a turn that finalized before the flush failed', async () => {
+        // Accepted behaviour (TASK_2026_420 round 4, S3): the prompt never
+        // reached the backend, so it must not sit between reply parts the
+        // model produced without it. The text goes back to the queue.
+        let reachContinue!: () => void;
+        const continueReached = new Promise<void>((resolve) => {
+          reachContinue = resolve;
+        });
+        let rejectContinue!: (reason: unknown) => void;
+        rpcCall.mockImplementation((method: string): Promise<unknown> => {
+          if (method === 'session:validate') {
+            return Promise.resolve({ success: true, data: { exists: true } });
+          }
+          if (method === 'chat:continue') {
+            reachContinue();
+            return new Promise((_resolve, reject) => {
+              rejectContinue = reject;
+            });
+          }
+          return Promise.resolve({ success: true });
+        });
+
+        const pending = service.continueExistingSessionForQueueFlush(
+          'queued',
+          'sess-X',
+          { tabId: 'tab-1' },
+        );
+        await continueReached;
+
+        // The interrupted turn finalizes while `chat:continue` is in flight.
+        const bubble = tabsSignal()[0].messages[0];
+        expect(bubble.id).toBe(recordedBubbleId());
+        const before = {
+          id: 'before',
+          role: 'assistant',
+        } as ExecutionChatMessage;
+        const after = {
+          id: 'after',
+          role: 'assistant',
+        } as ExecutionChatMessage;
+        tabsSignal.update((tabs) =>
+          tabs.map((t) =>
+            t.id === 'tab-1'
+              ? ({
+                  ...t,
+                  messages: [before, bubble, after],
+                  streamingState: null,
+                } as TabState)
+              : t,
+          ),
+        );
+
+        rejectContinue(new Error('socket closed'));
+
+        await expect(pending).resolves.toEqual(
+          expect.objectContaining({ success: false }),
+        );
+        expect(removeBoundary).toHaveBeenCalledWith('tab-1', bubble.id);
+        const messages = tabsSignal()[0].messages;
+        expect(messages.map((m) => m.id)).toEqual(['before', 'after']);
+        expect(messages[0]).toBe(before);
+        expect(messages[1]).toBe(after);
+      });
     });
 
     it('uses the options.tabId to target a non-active tab (canvas tile isolation)', async () => {

--- a/libs/frontend/chat/src/lib/services/message-sender.service.ts
+++ b/libs/frontend/chat/src/lib/services/message-sender.service.ts
@@ -40,7 +40,10 @@ import {
   TabManagerService,
   TabSessionBinding,
 } from '@ptah-extension/chat-state';
-import { SessionManager } from '@ptah-extension/chat-streaming';
+import {
+  SessionManager,
+  StreamingHandlerService,
+} from '@ptah-extension/chat-streaming';
 import { MessageValidationService } from './message-validation.service';
 import { UltracodeStateService } from './ultracode-state.service';
 import type { SendMessageOptions } from '@ptah-extension/chat-types';
@@ -73,6 +76,7 @@ export class MessageSenderService {
   private readonly vscodeService = inject(VSCodeService);
   private readonly tabManager = inject(TabManagerService);
   private readonly sessionManager = inject(SessionManager);
+  private readonly streamingHandler = inject(StreamingHandlerService);
   private readonly validator = inject(MessageValidationService);
   private readonly modelState = inject(ModelStateService);
   private readonly effortState = inject(EffortStateService);
@@ -508,6 +512,10 @@ export class MessageSenderService {
    * `TabManagerService`, so stop-button / tab-close keep working) or sends
    * with no signal when the controller was already cleared by finalization.
    *
+   * A failed flush also removes the optimistic bubble: the caller
+   * (`MessageDispatchService.sendQueuedMessage`) puts the text back in the
+   * queue, so a retry would otherwise show the same prompt twice.
+   *
    * @param content - Message content
    * @param sessionId - Existing session ID
    * @param options - Optional send options (files, images, effort, tabId)
@@ -526,6 +534,7 @@ export class MessageSenderService {
       sessionId,
       options,
       abortSignal,
+      true,
     );
   }
 
@@ -542,11 +551,14 @@ export class MessageSenderService {
     sessionId: SessionId,
     options: SendMessageOptions | undefined,
     abortSignal: AbortSignal | undefined,
+    dropBubbleOnFailure = false,
   ): Promise<SendOutcome> {
     const files = options?.files;
     const images = options?.images;
     const effort = options?.effort;
     const activeTabId = options?.tabId ?? this.tabManager.activeTabId();
+    /** Set once the bubble + boundary are written, so every failure exit after it rolls back. */
+    let sentPromptId: string | null = null;
     try {
       const ready = await this.waitForServices(5000);
       if (!ready) {
@@ -631,6 +643,8 @@ export class MessageSenderService {
         ...(activeTab?.messages ?? []),
         userMessage,
       ]);
+      this.streamingHandler.recordUserPromptBoundary(activeTabId, userMessage);
+      sentPromptId = userMessage.id;
       const effectiveModel = this.resolveValidModel(
         activeTab?.overrideModel ?? this.modelState.currentModel(),
       );
@@ -662,6 +676,11 @@ export class MessageSenderService {
           '[MessageSender] Failed to continue chat:',
           result.data?.error ?? result.error,
         );
+        this.rollBackUnsentPrompt(
+          activeTabId,
+          userMessage.id,
+          dropBubbleOnFailure,
+        );
         this.tabManager.markLoaded(activeTabId);
         this.tabManager.markTabIdle(activeTabId);
         this.sessionManager.setStatus('loaded');
@@ -678,6 +697,13 @@ export class MessageSenderService {
     } catch (error) {
       console.error('[MessageSender] Failed to continue conversation:', error);
       if (activeTabId) {
+        if (sentPromptId) {
+          this.rollBackUnsentPrompt(
+            activeTabId,
+            sentPromptId,
+            dropBubbleOnFailure,
+          );
+        }
         this.tabManager.markLoaded(activeTabId);
         this.tabManager.markTabIdle(activeTabId);
       }
@@ -687,5 +713,26 @@ export class MessageSenderService {
         error: error instanceof Error ? error.message : String(error),
       };
     }
+  }
+
+  /**
+   * Undo what a continue wrote before `chat:continue` failed. The boundary
+   * always goes: the backend never received the prompt, so the live turn must
+   * not split at it. The optimistic bubble goes only when the caller puts the
+   * text back in the queue, where a retry would otherwise show it twice.
+   */
+  private rollBackUnsentPrompt(
+    tabId: string,
+    messageId: string,
+    dropBubble: boolean,
+  ): void {
+    this.streamingHandler.removeUserPromptBoundary(tabId, messageId);
+    if (!dropBubble) return;
+    const tab = this.tabManager.findTabByIdAcrossWorkspaces(tabId)?.tab;
+    if (!tab) return;
+    this.tabManager.setMessages(
+      tabId,
+      tab.messages.filter((m) => m.id !== messageId),
+    );
   }
 }

--- a/libs/frontend/chat/src/lib/services/message-sender.session-identity.spec.ts
+++ b/libs/frontend/chat/src/lib/services/message-sender.session-identity.spec.ts
@@ -16,7 +16,10 @@ import {
   TabWorkspacePartitionService,
   type ModelRefreshControl,
 } from '@ptah-extension/chat-state';
-import { SessionManager } from '@ptah-extension/chat-streaming';
+import {
+  SessionManager,
+  StreamingHandlerService,
+} from '@ptah-extension/chat-streaming';
 import type { TabState } from '@ptah-extension/chat-types';
 import { MessageSenderService } from './message-sender.service';
 import { MessageValidationService } from './message-validation.service';
@@ -68,6 +71,13 @@ describe('MessageSenderService session identity integration', () => {
         ConfirmationDialogService,
         { provide: MODEL_REFRESH_CONTROL, useValue: modelRefresh },
         { provide: SessionManager, useValue: sessionManager },
+        {
+          provide: StreamingHandlerService,
+          useValue: {
+            recordUserPromptBoundary: jest.fn(),
+            removeUserPromptBoundary: jest.fn(),
+          },
+        },
         {
           provide: MessageValidationService,
           useValue: {


### PR DESCRIPTION
﻿## Summary

When the user sends a message while the agent is still working, the user bubble appears, but later agent output kept streaming into the assistant bubble ABOVE it. The split only appeared after the whole round completed.

**Cause**
1. A mid-turn message is queued and flushed on a root `message_complete` whose `stopReason` is not `tool_use`. The stream path emits `message_complete` without a `stopReason`, so the flush happens after the first streamed message of a turn.
2. The optimistic user bubble goes into `tab.messages`. The backend holds the prompt until the turn ends.
3. `ExecutionTreeBuilderService.buildTree` merges consecutive root assistant messages, and only a user root stops that merge. The live state had no user root.
4. `finalizeCurrentMessage` appended every new tree after existing messages, which also moved the pre-prompt part below the prompt.

**Fix**
- **Boundary.** When a prompt is sent while a live tree exists, `recordUserPromptBoundary` stores a user `message_start` whose id is the bubble id. It does not move `currentMessageId` or touch dedup. Tab resolution is workspace-aware, so a background-workspace tab writes through its partition.
- **Tree output.** `buildTree` lets user roots break the assistant merge, but no longer emits them. This also stops the SDK's own user echo from rendering as a phantom assistant bubble.
- **Finalization.** It walks `messageEventIds` in root order and anchors on an existing USER message `id`. It does not match on `nativeUuid`, because stamping can target an older failed bubble; see TASK_2026_422.
- **Failed sends.** A failed or thrown `chat:continue` removes the boundary. A failed queue flush also removes the optimistic bubble, because the text returns to the queue.

**Review history.** Ollama Cloud stress review, codex review, two code-logic-reviewer rounds, and two team-leader passes (one rejection, fixed). The dispositions are in `.ptah/specs/TASK_2026_420_84d9/context.md`.

**Also in this PR.** The task spec, and two follow-ups:
- `TASK_2026_422`: oldest-first native uuid stamping breaks fork and rewind after a failed send.
- `TASK_2026_425`: no test covers a rewind while a boundary is live.

**Known limits (documented).**
- A compaction replacement state or the event cap can drop a boundary. The turn then renders as it did before.
- After a JSONL reload, the prompt appears where the SDK consumed it, at turn end.

## Test plan

- [x] Tree split at a boundary.
- [x] Boundary plus SDK echo gives one split and no extra root.
- [x] Boundary removal.
- [x] Finalization order is [before, prompt, after], with stats on the last new message.
- [x] Two prompts in one turn.
- [x] A failed send followed by a successful one falls back to a plain append (R1).
- [x] Rollback on a rejected or thrown direct send and queue flush.
- [x] A failure after finalization drops only the prompt bubble (S3).
- [x] Boundary writes on a background tab.
- [x] `nx run-many -t test`: chat-execution-tree 22 passed; chat-streaming 479 passed, 1 skipped; chat 1057 passed, 2 skipped.
- [x] Typecheck, lint (0 errors), and prettier are clean.
- [ ] Manual: while the agent runs tools, send a message. The output after the send renders below your bubble while streaming, and stays there after the turn completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
