### PR TITLE
docs: file TASK_2026_427 and TASK_2026_429 — worktree test chain, and agent lifecycle reporting

### DIFF
--- a/.ptah/specs/TASK_2026_427_f669/context.md
+++ b/.ptah/specs/TASK_2026_427_f669/context.md
@@ -1,0 +1,160 @@
+# Context — TASK_2026_427_f669
+
+## How this was found
+
+On 2026-09-12 a `backend-developer` subagent implementing Batch 5 of
+TASK_2026_402_a5c7 appeared to go stale for about twenty minutes. It had not.
+
+The measurement that settled it: `jest` PID 21320 sampled twice, twelve seconds
+apart, reported `CPU 275.09375` both times. Zero CPU delta, 1.2 GB resident, 13
+threads, **no child processes**. Alive, blocked, computing nothing.
+
+Its own output showed the run had already finished:
+
+```
+Test Suites: 1 failed, 1 skipped, 65 passed, 66 of 67 total
+Tests:       4 failed, 3 skipped, 981 passed, 988 total
+Ran all test suites.
+Jest did not exit one second after the test run has completed.
+```
+
+The process was terminated by hand to unblock the agent. Nothing else recovered
+it, and nothing reported it.
+
+**The watchdog was ruled out, not assumed innocent.** Today's Electron log
+(`%APPDATA%\Ptah\logs\Ptah Electron-2026-09-12.log`) was searched for
+`NoActivityWatchdog`, `no activity`, `forceIdle`, `Aborting session` and
+`SessionNotActive`. Zero matches. `NoActivityWatchdog` governs Ptah SDK sessions
+and had no part in this.
+
+---
+
+## Defect 1 — `copy-wasm` resolves `node_modules` against the worktree root
+
+**This is the root cause and the cheapest fix. Do it first.**
+
+`scripts/copy-wasm.js:22` computes its own root:
+
+```js
+const workspaceRoot = path.resolve(__dirname, '..');
+```
+
+In a worktree that resolves to the worktree, and a worktree created under the
+main checkout has **no `node_modules` of its own** — Node's own resolution walks
+UP to the parent checkout, but this script does not. Reproduced directly:
+
+```
+$ cd .claude-worktrees/agent-messaging && node scripts/copy-wasm.js dist/apps/ptah-cli
+WASM file not found: D:\projects\ptah-extension\.claude-worktrees\agent-messaging\node_modules\web-tree-sitter\web-tree-sitter.wasm
+```
+
+`apps/ptah-cli/project.json` chains `test` → `build-esbuild`,
+`build-embedder-worker`, `build-integrity-worker`, and `copy-wasm` →
+`build-esbuild`. One failure takes the chain down:
+
+```
+NX  Running target test for project ptah-cli and 31 tasks it depends on failed
+```
+
+So **`nx test ptah-cli` cannot run in any worktree.** This is not specific to one
+task. It affects every agent this repository runs in a worktree, which is the
+normal operating mode here.
+
+### Acceptance criteria
+
+1. `npx nx test ptah-cli` completes in a worktree that has no `node_modules`.
+2. The resolution walks up to the checkout that actually holds the package,
+   rather than assuming a sibling layout. `require.resolve` answers this question
+   correctly and a hand-built path does not.
+3. A genuinely missing package still fails loudly. The fix must not turn a real
+   absence into a silent skip.
+
+---
+
+## Defect 2 — the `ptah-cli` suite leaks handles, and `--runInBand` makes that fatal
+
+With Defect 1 blocking the proper path, the agent fell back to running the jest
+config directly. That path hangs.
+
+Jest's own message names the class:
+
+> This usually means that there are asynchronous operations that weren't stopped
+> in your tests. Consider running Jest with `--detectOpenHandles`.
+
+and elsewhere:
+
+> Active timers can also cause this, ensure that `.unref()` was called on them.
+
+**Why `--runInBand` is the difference.** In worker mode Jest force-exits the
+leaking worker, and the run survives with a warning — observed in this same
+session: _"A worker process has failed to exit gracefully and has been force
+exited."_ In band mode there is no worker to kill, so the main process waits
+forever. Same leak, two outcomes: a warning nobody reads, or a silent permanent
+hang.
+
+### Acceptance criteria
+
+1. The leaking handle is NAMED, from a `--detectOpenHandles` run, not guessed.
+2. It is released in teardown, and a test proves the process exits.
+3. `jest --config apps/ptah-cli/jest.config.cjs --runInBand` exits on its own.
+4. Whatever the cause, a hang is made diagnosable: a run that cannot exit must
+   say what is holding it open rather than sitting at zero CPU in silence.
+
+---
+
+## Defect 3 — `withEngine` swallows three DI failures and keeps running
+
+Printed on every `ptah-cli` test run, immediately before the hang:
+
+```
+[ptah] withEngine: Thoth activation failed (non-fatal): unexpected token: Symbol(Logger)
+[ptah] withEngine: file-settings migration failed (non-fatal): unexpected token: Symbol(MigrationRunner)
+[ptah] withEngine: failed to resolve SdkPermissionHandler for auto-approve: permissionHandler.setPermissionLevel is not a function
+```
+
+Three separate DI resolutions fail and the engine proceeds anyway. The first two
+are `unexpected token: Symbol(...)`, which is tsyringe reporting an unregistered
+token. The third resolves an object that is not the service it claims to be.
+
+Two distinct problems live here, and they must not be conflated:
+
+- **The registrations are wrong or missing** in whatever container the CLI test
+  path builds.
+- **`non-fatal` is a claim nobody checked.** Thoth activation and the migration
+  runner both start work. An engine that failed to register them, then ran
+  anyway, is the most likely owner of the handle in Defect 2 — `thoth-runtime`
+  boots a cron loop and `cron-scheduler` is a SQLite-backed timer loop.
+
+**That last sentence is a hypothesis, not a finding.** It is written down so the
+investigation starts somewhere, and it must be proven or discarded against a
+`--detectOpenHandles` run before any code changes.
+
+### Acceptance criteria
+
+1. Each of the three failures is either fixed at its registration, or shown to be
+   genuinely harmless with the evidence recorded beside the `non-fatal` label.
+2. `non-fatal` stops being a bare assertion. Where a failure really is tolerable,
+   the log says what is lost by tolerating it.
+3. Whether Defect 3 causes Defect 2 is answered, either way.
+
+---
+
+## Not a defect: the four failing `esm-bundle-gate` specs
+
+For the next reader, so nobody re-investigates them.
+
+The four failures in `apps/ptah-cli/src/test-utils/esm-bundle-gate.spec.ts` all
+read `requires a build -- run nx run ptah-cli:build-embedder-worker`. They are
+the build gate working correctly. They fire only because the raw-jest fallback
+skips the `dependsOn` builds. Fix Defect 1 and they go away on their own.
+
+---
+
+## Why this is worth a task rather than a note
+
+Three defects compose into one failure mode with no symptom. A worktree agent
+cannot use the sanctioned command, falls back to one that hangs, and produces
+nothing — no error, no timeout, no log line. The only way to see it is to sample
+the process CPU by hand and find it flat.
+
+Every agent this repository runs in a worktree is exposed to it.

--- a/.ptah/specs/TASK_2026_427_f669/task.md
+++ b/.ptah/specs/TASK_2026_427_f669/task.md
@@ -1,0 +1,21 @@
+---
+status: backlog
+type: BUGFIX
+title: The ptah-cli test chain is unrunnable in a worktree and hangs on exit
+description: >-
+  Three defects that together make an agent working in a git worktree hang
+  forever with no diagnostic. copy-wasm resolves node_modules against the
+  worktree root, which has none, so the whole ptah-cli build chain fails. The
+  fallback to raw jest then leaks async handles and never exits under
+  --runInBand. Underneath both, withEngine swallows three DI failures as
+  non-fatal and leaves a half-booted engine running.
+---
+
+Found on 2026-09-12 while running Batch 5 of TASK_2026_402_a5c7. A subagent
+appeared to stall for roughly twenty minutes. It had not stalled: it was blocked
+on a `jest` process that had finished its tests and could not exit.
+
+Every claim in `context.md` is reproduced, not inferred. The three defects are
+ranked there by how much time they cost, not by how hard they look.
+
+Evidence and acceptance criteria are in `context.md`.

--- a/.ptah/specs/TASK_2026_429_ba4e/context.md
+++ b/.ptah/specs/TASK_2026_429_ba4e/context.md
@@ -1,0 +1,134 @@
+# Context — TASK_2026_429_ba4e
+
+## How this was found
+
+On 2026-09-12 a single orchestration session spawned six agents: four in-process
+subagents and two CLI agents, plus a third CLI agent for an unrelated CI fix.
+Every one of them completed its work correctly and wrote its report to disk.
+
+The lifecycle reporting was wrong about three of them, in three different ways.
+
+This is not a report about agents failing. It is a report about the system
+lying about agents that succeeded.
+
+---
+
+## Defect 1 — a completed agent vanishes from the registry
+
+**Observed three times**, on two different CLI families.
+
+| Agent        | CLI                     | Task                       | What `ptah_agent_status` returned |
+| ------------ | ----------------------- | -------------------------- | --------------------------------- |
+| `b5b46ca0-…` | antigravity             | Batch 11.1 facade          | `Agent not found`                 |
+| `f3cc215d-…` | ptah-cli (ollama cloud) | Batch 11.2 picker          | `Agent not found`                 |
+| `19f4d943-…` | antigravity             | Batch 11.3 send affordance | `Agent not found`                 |
+
+The exact message:
+
+> Agent not found: `<id>`. This host holds no record under that id — neither a
+> live agent nor one restored from persisted session state. The id is from a run
+> that was never persisted, or from one older than the retention window.
+> Retrying cannot recover it: spawn a new agent if the work still needs doing.
+
+**Every one of those statements was false.** In all three cases the agent had
+finished seconds or minutes earlier, and its output was on disk:
+`peer-session.facade.ts`, `peer-session-picker/`, `peer-session-send/`, and a
+report file each. The id was minutes old, not past any retention window.
+
+A bare `ptah_agent_status` with no id, issued in the same minute, listed a
+different still-running agent correctly. So the registry was alive; these
+records were simply gone from it.
+
+**The cost:** the message ends with explicit advice — _"spawn a new agent if the
+work still needs doing"_. An orchestrator that followed it would re-run finished
+work, and on a shared worktree a second writer would collide with the first
+one's committed output. The only reason that did not happen here is that the
+orchestrator distrusted the tool and checked `git status` instead.
+
+### Acceptance criteria
+
+1. A completed agent remains queryable by id for a stated retention window, and
+   that window is documented where a caller can find it.
+2. If a record genuinely cannot be found, the message stops asserting WHY. It
+   currently offers three confident explanations and picked the wrong one three
+   times out of three.
+3. The "spawn a new agent" advice is removed or made conditional. Advising a
+   re-run of work that may already be complete is the most expensive part of
+   this defect.
+
+---
+
+## Defect 2 — a completed agent never exits
+
+**Observed once.** Agent `06529ee4-…`, codex, on the pull request #494 CI fix.
+
+The agent produced its final report, wrote its changes, and printed a complete
+summary ending in "No commit or push was performed." Then it kept running.
+`ptah_agent_status` reported `running` indefinitely, and the host UI showed
+_"Agent is working — your message queues until it finishes"_, so the caller was
+blocked behind an agent with nothing left to do.
+
+`ptah_agent_stop` terminated it cleanly and returned `Exit Code: N/A`.
+
+This is the mirror image of Defect 1. There, a finished agent disappeared. Here,
+a finished agent never admitted it was finished. Both are the same missing
+signal: **"this agent is done"** is not reliably produced or consumed.
+
+### Acceptance criteria
+
+1. An agent that has produced its final output transitions to `completed`
+   without operator intervention.
+2. If a CLI adapter cannot detect completion for a given vendor, that limit is
+   stated in `ptah_agent_status` output rather than shown as `running`.
+3. A caller is never blocked indefinitely behind an agent that has finished.
+
+---
+
+## Defect 3 — a completed run hangs forever, with no diagnostic
+
+**Observed once**, and it cost about twenty minutes.
+
+A subagent running `jest --runInBand` finished its tests — the output ends with
+`Ran all test suites.` and `Jest did not exit one second after the test run has
+completed.` — and then held the process open on a leaked async handle. Measured:
+`CPU 275.09s` on two samples twelve seconds apart, zero delta, 1.2 GB resident,
+no child processes. Alive, blocked, computing nothing.
+
+Nothing reported this. Not the agent, not the status tool, not a timeout. The
+only way it was found was sampling the process CPU by hand and seeing it flat.
+
+**The underlying handle leak is already filed as `TASK_2026_427_f669`** together
+with its root cause (`copy-wasm` resolving `node_modules` against a worktree
+root that has none, which pushes agents onto the raw-jest path in the first
+place). That part is not duplicated here.
+
+What belongs HERE is the observability half: a spawned agent that is not
+consuming CPU and not producing output is indistinguishable, from the outside,
+from one that is thinking hard.
+
+### Acceptance criteria
+
+1. A spawned agent that produces no output and consumes no CPU for a bounded
+   period is surfaced as such, rather than silently reported as `running`.
+2. Whatever the mechanism, an operator can tell "stuck" from "working" without
+   sampling process CPU by hand.
+
+---
+
+## Why these are one task and not three
+
+They share a root: **the lifecycle signal is unreliable in both directions.**
+A finished agent can vanish, a finished agent can appear to run forever, and a
+stuck agent looks exactly like a working one. Fixing any one of them in
+isolation leaves a caller still unable to answer "is this agent done?" — which
+is the only question the tool exists to answer.
+
+The evidence is six spawns in one session. That is a small sample, but the
+failure rate within it is high enough that the orchestrator abandoned the tool
+mid-session, which is the outcome worth preventing.
+
+## Deliberately not in scope
+
+- The jest handle leak and the `copy-wasm` worktree defect — `TASK_2026_427_f669`.
+- Anything about agent OUTPUT quality. All six agents did their work correctly;
+  every finding here is about reporting, not about results.

--- a/.ptah/specs/TASK_2026_429_ba4e/task.md
+++ b/.ptah/specs/TASK_2026_429_ba4e/task.md
@@ -1,0 +1,26 @@
+---
+status: backlog
+type: BUGFIX
+title: Spawned agents lie about their own lifecycle
+description: >-
+  ptah_agent_status is unreliable enough that an orchestrator has to stop using
+  it. Three distinct defects observed on 2026-09-12 across six spawns. A
+  completed agent vanishes from the registry and reports "Agent not found". A
+  completed agent never exits and blocks the caller. A completed run hangs
+  forever on a leaked handle with no diagnostic at all.
+---
+
+Observed on 2026-09-12 while orchestrating TASK_2026_402_a5c7 and a CI fix on
+pull request #494. Six spawns, six agents that finished their work correctly,
+and three different ways the lifecycle reporting was wrong about it.
+
+None of these defects lost work. Every agent wrote its files and its report to
+disk. What they cost was trust in the tool that reports status, and in one case
+twenty minutes of a blocked caller.
+
+**The orchestrator's workaround is already in place and is the reason this is
+worth fixing: it stopped calling `ptah_agent_status` and started reading the
+worktree instead.** A status tool nobody trusts is worse than no status tool,
+because it still gets called by anything that does not know better.
+
+Evidence and acceptance criteria are in `context.md`.


### PR DESCRIPTION
## Summary

Files `TASK_2026_427_f669`. No code changes — this is a task carrier and its evidence.

Three defects compose into one failure mode with **no symptom**: an agent working in a git worktree cannot use the sanctioned test command, falls back to one that hangs forever, and produces nothing. No error, no timeout, no log line.

It was found when a subagent appeared to stall for twenty minutes. It had not stalled. It was blocked on a `jest` process that had finished its tests and could not exit — sampled twice twelve seconds apart, `CPU 275.09` both times, 1.2 GB resident, no children.

Every claim in `context.md` is reproduced, not inferred.

## The three defects

**1. `copy-wasm` resolves `node_modules` against the worktree root.** `scripts/copy-wasm.js:22` builds `workspaceRoot` from `__dirname`. A worktree created under the main checkout has no `node_modules` of its own — Node's resolution walks up, this script does not. Reproduced directly:

```
WASM file not found: ...\agent-messaging\node_modules\web-tree-sitter\web-tree-sitter.wasm
```

That takes down all 31 tasks `ptah-cli:test` depends on. **`nx test ptah-cli` cannot run in any worktree**, which is the normal operating mode here. This is the root cause and the cheapest fix.

**2. The suite leaks handles, and `--runInBand` makes that fatal.** Under workers, Jest force-exits the leaker with a warning. Under `--runInBand` there is no worker to kill and the main process waits forever. Same leak, one outcome loud and one silent.

**3. `withEngine` swallows three DI failures and keeps running.** Two unregistered tsyringe tokens and an `SdkPermissionHandler` that is not one. Thoth activation and the migration runner both start work, so a half-booted engine is the likely owner of the leaked handle in defect 2 — recorded as a **hypothesis to prove or discard**, not as a finding.

## What was ruled out

The `NoActivityWatchdog` was suspected and cleared by measurement, not assumption. Today's Electron log has zero matches for `NoActivityWatchdog`, `forceIdle`, `Aborting session` or `SessionNotActive`.

The four failing `esm-bundle-gate` specs are documented as **not a defect** — they are the build gate working correctly, firing only because the raw-jest fallback skips the `dependsOn` builds. Recorded so nobody re-investigates them.

## Test plan

No code changes, so nothing to test. The carrier was verified to parse and appear on the Tasks board, and the pre-commit hook ran clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added task documentation covering test execution failures in git worktrees.
  * Documented issues involving WASM dependency resolution, hanging test processes, and hidden dependency-injection failures.
  * Added reproduction evidence, acceptance criteria, and classification of expected build-gate failures.
  * Documented agent lifecycle issues, including disappearing completed agents, incorrect running status, and hangs without diagnostics.
  * Recorded observed impact, preserved work and reports, operational workarounds, and out-of-scope issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->